### PR TITLE
Speed calculation for Tasks and AgentId

### DIFF
--- a/src/app/core/_pipes/agents-speed.pipe.ts
+++ b/src/app/core/_pipes/agents-speed.pipe.ts
@@ -35,8 +35,8 @@ export class AgentsSpeedPipe implements PipeTransform {
 
   transform(id: number, type?:boolean){
 
-      // const maxResults = environment.config.prodApiMaxResults;
-      const maxResults = 60000;
+      const maxResults = environment.config.prodApiMaxResults;
+      // const maxResults = 60000;
       const chunktime = this.uiService.getUIsettings('chunktime').value;
       const cspeed = [];
       let params: any;


### PR DESCRIPTION
Changing MaxResults from 60000 to config value that is a default 3000. I'm not sure what is the sweet spot value for this.