### PR TITLE
New storage service + basic tests for ui-settings

### DIFF
--- a/src/app/account/notifications/notifications.component.spec.ts
+++ b/src/app/account/notifications/notifications.component.spec.ts
@@ -6,7 +6,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { GlobalService } from 'src/app/core/_services/main.service';
 import { Observable, of } from 'rxjs';
 import { SERV } from '../../core/_services/main.config';
-import { NotificationListResponse, Notification } from 'src/app/core/_models/notifications';
+import { Notification } from 'src/app/core/_models/notifications';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import Swal from 'sweetalert2/dist/sweetalert2.js';
@@ -16,6 +16,7 @@ import { RouterModule } from '@angular/router';
 import { ComponentsModule } from 'src/app/shared/components.module';
 import { PipesModule } from 'src/app/shared/pipes.module';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { ResponseWrapper } from 'src/app/core/_models/response-wrapper';
 
 
 describe('NotificationsComponent', () => {
@@ -62,19 +63,17 @@ describe('NotificationsComponent', () => {
   // Mock GlobalService with required methods
   const mockService: Partial<GlobalService> = {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
-    getAll(_methodUrl: string, params: any): Observable<NotificationListResponse> {
+    getAll(_methodUrl: string, params: any): Observable<ResponseWrapper<Notification>> {
       if (_methodUrl === SERV.NOTIFICATIONS) {
-        const response: NotificationListResponse = {
-          _expandable: '',
+        return of({
           startAt: 0,
           maxResults: notifications.length,
           total: notifications.length,
           isLast: true,
           values: notifications,
-        };
-        return of(response);
+        });
       }
-      return of({} as NotificationListResponse);
+      return of({} as ResponseWrapper<Notification>);
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete(_methodUrl: string, id: number): Observable<any> {
@@ -120,6 +119,10 @@ describe('NotificationsComponent', () => {
     fixture.detectChanges();
 
   });
+
+
+  // --- Test Methods ---
+
 
   // Check if the component is created successfully
   it('should create the component', () => {

--- a/src/app/account/notifications/notifications.component.ts
+++ b/src/app/account/notifications/notifications.component.ts
@@ -7,9 +7,9 @@ import { Subject, Subscription } from 'rxjs';
 import { ACTION } from '../../core/_constants/notifications.config';
 import { GlobalService } from 'src/app/core/_services/main.service';
 import { SERV } from '../../core/_services/main.config';
-import { NotificationListResponse } from 'src/app/core/_models/notifications';
 import { Notification } from 'src/app/core/_models/notifications';
 import { AutoTitleService } from 'src/app/core/_services/shared/autotitle.service';
+import { ResponseWrapper } from 'src/app/core/_models/response-wrapper';
 
 
 export interface Filter {
@@ -102,7 +102,7 @@ export class NotificationsComponent implements OnInit, OnDestroy {
   getNotifications(): void {
     const params = { 'maxResults': this.maxResults };
 
-    this.subscriptions.push(this.gs.getAll(SERV.NOTIFICATIONS, params).subscribe((response: NotificationListResponse) => {
+    this.subscriptions.push(this.gs.getAll(SERV.NOTIFICATIONS, params).subscribe((response: ResponseWrapper<Notification>) => {
       this.notifications = response.values;
       this.dtTrigger.next(void 0);
     }));

--- a/src/app/account/settings/ui-settings/ui-settings.component.html
+++ b/src/app/account/settings/ui-settings/ui-settings.component.html
@@ -4,15 +4,10 @@
   <form [formGroup]="uiForm">
     <div class="row">
       <grid-form-input [name]="'Set the time format'">
-        <select
-              type='text'
-              id="localtimefmt"
-              class='form-select'
-              formControlName="localtimefmt"
-              #localtimefmt
-              (change)="setCookieValue('localtimefmt',localtimefmt.value)"
-        >
-        <option *ngFor="let d of dateFormat" [value]="d.format">{{ d.description }}</option>
+        <select id="localtimefmt" class='form-select' formControlName="localtimefmt"
+          (change)="setCookieValue('localtimefmt', uiForm.get('localtimefmt')!.value)"
+          data-testid="select-localtimefmt">
+          <option *ngFor="let d of dateFormat" [value]="d.format">{{ d.description }}</option>
         </select>
       </grid-form-input>
       <button-submit [name]="'Create'"></button-submit>

--- a/src/app/account/settings/ui-settings/ui-settings.component.spec.ts
+++ b/src/app/account/settings/ui-settings/ui-settings.component.spec.ts
@@ -66,6 +66,10 @@ describe('UiSettingsComponent', () => {
     fixture.detectChanges();
   });
 
+
+  // --- Test Methods ---
+
+
   it('should create the component', () => {
     expect(component).toBeTruthy();
   });

--- a/src/app/account/settings/ui-settings/ui-settings.component.spec.ts
+++ b/src/app/account/settings/ui-settings/ui-settings.component.spec.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
+import { UISettings, UiSettingsComponent } from './ui-settings.component';
+import { CookieStorageService } from 'src/app/core/_services/storage/cookie-storage.service';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { ComponentsModule } from 'src/app/shared/components.module';
+import { HttpClientModule } from '@angular/common/http';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { DataTablesModule } from 'angular-datatables';
+import { PipesModule } from 'src/app/shared/pipes.module';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { RouterTestingModule } from '@angular/router/testing';
+import { setFieldValue } from 'src/app/spec-helpers/element.spec-helper';
+import Swal from 'sweetalert2/dist/sweetalert2.js';
+
+class MockCookieStorageService {
+  getItem(key: string): any {
+    return {
+      localtimefmt: 'dd/MM/yyyy'
+    }
+  }
+  setItem(key: string, value: any, expiresInMs: number): void {
+    // Do nothing
+  }
+  removeItem(key: string): void {
+    // Do nothing
+  }
+}
+
+describe('UiSettingsComponent', () => {
+  let component: UiSettingsComponent;
+  let fixture: ComponentFixture<UiSettingsComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        UiSettingsComponent
+      ],
+      imports: [
+        CommonModule,
+        FormsModule,
+        ReactiveFormsModule,
+        HttpClientModule,
+        FontAwesomeModule,
+        ComponentsModule,
+        DataTablesModule,
+        PipesModule,
+        NgbModule,
+        RouterTestingModule,
+      ],
+      providers: [
+        {
+          provide: CookieStorageService,
+          useClass: MockCookieStorageService
+        },
+        Swal
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UiSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize settings from cookies', () => {
+    const mockSettings = { localtimefmt: 'dd/MM/yyyy' };
+
+    component.initSettings();
+    component.initForm();
+
+    expect(component.settings).toEqual(mockSettings);
+  });
+
+  it('should set a new value for a UI setting', () => {
+    const mockName = 'localtimefmt';
+    const mockValue = 'dd/MM/yyyy';
+
+    component.setCookieValue(mockName, mockValue);
+
+    expect(component.settings[mockName]).toBe(mockValue);
+    expect(component.uiForm.get(mockName)?.value).toBe(mockValue);
+  });
+
+  it('should handle select change and call setCookieValue', () => {
+    const mockName = 'localtimefmt';
+    const mockValue = 'dd/MM/yyyy h:mm:ss';
+
+    const setCookieValueSpy = spyOn(component, 'setCookieValue');
+
+    setFieldValue(fixture, 'select-localtimefmt', mockValue);
+
+    fixture.detectChanges();
+
+    expect(setCookieValueSpy).toHaveBeenCalledWith(mockName, mockValue);
+  });
+});

--- a/src/app/account/settings/ui-settings/ui-settings.component.ts
+++ b/src/app/account/settings/ui-settings/ui-settings.component.ts
@@ -1,8 +1,13 @@
-import { CookieService } from '../../../core/_services/shared/cookies.service';
 import { dateFormat } from '../../../core/_constants/settings.config';
 import { FormControl, FormGroup } from '@angular/forms';
 import Swal from 'sweetalert2/dist/sweetalert2.js';
 import { Component, OnInit } from '@angular/core';
+import { CookieStorageService } from 'src/app/core/_services/storage/cookie-storage.service';
+
+
+export interface UISettings {
+  localtimefmt: string
+}
 
 @Component({
   selector: 'app-ui-settings',
@@ -10,45 +15,71 @@ import { Component, OnInit } from '@angular/core';
 })
 export class UiSettingsComponent implements OnInit {
 
+  // Constants
+  static readonly COOKIE_NAME = 'ui-settings';
+  static readonly DEFAULT_LOCALTIMEFMT = 'dd/MM/yyyy h:mm:ss';
+
   dateFormat = dateFormat;
   uiForm: FormGroup;
+  settings!: UISettings
 
-  constructor(
-    private cookieService: CookieService
-  ) { }
+  /**
+   * Creates an instance of UiSettingsComponent.
+   *
+   * @param cookieStorage - Service for managing cookies storing user interface settings.
+   */
+  constructor(private cookieStorage: CookieStorageService<UISettings>) { }
 
-
+  /**
+   * Initializes UI settings, retrieves saved settings from cookies if available, and initializes the UI form.
+   */
   ngOnInit(): void {
-
-    this.uiForm = new FormGroup({
-      'localtimefmt': new FormControl(),
-    });
-
+    this.initSettings();
     this.initForm();
-
   }
 
-  private initForm() {
+  /**
+   * Initializes UI settings, retrieves saved settings from cookies if available.
+   */
+  initSettings(): void {
+    this.settings = this.cookieStorage.getItem(UiSettingsComponent.COOKIE_NAME);
+    // If no settings are found in cookies, use default settings
+    if (!this.settings) {
+      this.settings = {
+        localtimefmt: UiSettingsComponent.DEFAULT_LOCALTIMEFMT
+      }
+    }
+  }
 
-    const localtimefmt = this.getCookieValue('localtimefmt');
-
+  /**
+   * Initializes the Angular form for UI settings.
+   * Sets up form controls and default values based on saved settings.
+   */
+  initForm() {
     this.uiForm = new FormGroup({
-      'localtimefmt': new FormControl(localtimefmt),
+      'localtimefmt': new FormControl(this.settings?.localtimefmt || ''),
     });
-
   }
 
-  setCookieValue(name: string, value: string){
-    this.cookieService.setCookie(name, value, 365);
-    this.savedAlert();
-    this.ngOnInit();
+  /**
+   * Sets a new value for a specific UI setting and updates it in cookies if it has changed.
+   *
+   * @param name - The name of the UI setting to update.
+   * @param value - The new value for the UI setting.
+   */
+  setCookieValue(name: string, value: string) {
+    if (name in this.settings && this.settings[name] !== value) {
+      this.settings[name] = value;
+      this.uiForm.patchValue({ name: value });
+      this.cookieStorage.setItem(UiSettingsComponent.COOKIE_NAME, this.settings, 31557600000);
+      this.savedAlert();
+    }
   }
 
-  getCookieValue(name: string){
-    return this.cookieService.getCookie(name);
-  }
-
-  savedAlert(){
+  /**
+   * Displays a success alert using Swal (SweetAlert2) library.
+   */
+  savedAlert() {
     Swal.fire({
       position: 'top-end',
       backdrop: false,
@@ -58,6 +89,4 @@ export class UiSettingsComponent implements OnInit {
       timer: 1500
     })
   }
-
-
 }

--- a/src/app/config/config-routing.module.ts
+++ b/src/app/config/config-routing.module.ts
@@ -23,184 +23,206 @@ const routes: Routes = [
   {
     path: '',
     children: [
-        {
-          path: 'agent',  component: ServerComponent,
-          data: {
-              kind: 'agent',
-              breadcrumb: 'Agent Settings',
-              permission: 'Config'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'task-chunk',  component: ServerComponent,
-          data: {
-              kind: 'task-chunk',
-              breadcrumb: 'Task Chunk Settings',
-              permission: 'Config'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'hch',  component: ServerComponent,
-          data: {
-              kind: 'hch',
-              breadcrumb: 'Hashes/Cracks/Hashlist Settings',
-              permission: 'Config'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'notifications',  component: ServerComponent,
-          data: {
-              kind: 'notif',
-              breadcrumb: 'Notifications',
-              permission: 'Notif'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'general-settings',  component: ServerComponent,
-          data: {
-              kind: 'gs',
-              breadcrumb: 'General Settings',
-              permission: 'Config'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'hashtypes',  component: HashtypesComponent,
-          data: {
-              kind: 'hashtypes',
-              breadcrumb: 'Hashtypes',
-              permission: 'Hashtype'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'hashtypes/new',  component: HashtypeComponent,
-          data: {
-              kind: 'new-hashtype',
-              breadcrumb: 'New Hashtype',
-              permission: 'Hashtype'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'hashtypes/:id/edit',  component: HashtypeComponent,
-          data: {
-              kind: 'edit-hashtype',
-              breadcrumb: 'Edit Hashtype',
-              permission: 'Hashtype'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'log',  component: LogComponent,
-          data: {
-              kind: 'log',
-              breadcrumb: 'Logs',
-              permission: 'Logs'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'health-checks',  component: HealthChecksComponent,
-          data: {
-              kind: 'health-checks',
-              breadcrumb: 'Health Checks',
-              permission: 'HealthCheck'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'health-checks/new',  component: NewHealthChecksComponent,
-          data: {
-              kind: 'new-health-checks',
-              breadcrumb: 'New Health Checks',
-              permission: 'HealthCheck'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'health-checks/:id/edit',  component: EditHealthChecksComponent,
-          data: {
-              kind: 'edit-health-checks',
-              breadcrumb: 'Edit Health Checks',
-              permission: 'HealthCheck'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'engine/agent-binaries',  component: AgentBinariesComponent,
-          data: {
-              kind: 'agent-binaries',
-              breadcrumb: 'Engine > Agent-binaries',
-              permission: 'AgentBinary'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'engine/agent-binaries/new-agent-binary',  component: NewAgentBinariesComponent,
-          data: {
-              kind: 'new-agent-binary',
-              breadcrumb: 'Engine > New Agent binary',
-              permission: 'AgentBinary'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'engine/agent-binaries/:id/edit',  component: NewAgentBinariesComponent,
-          data: {
-              kind: 'edit-agent-binary',
-              breadcrumb: 'Engine > Edit Agent binary',
-              permission: 'AgentBinary'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'engine/crackers',  component: CrackersComponent,
-          data: {
-              kind: 'crackers',
-              breadcrumb: 'Engine > Crackers',
-              permission: 'CrackerBinary'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'engine/crackers/new',  component: NewCrackerComponent,
-          data: {
-              kind: 'new-cracker',
-              breadcrumb: 'Engine > New Cracker',
-              permission: 'CrackerBinary'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'engine/crackers/:id/new',  component: NewCrackersComponent,
-          data: {
-              kind: 'new-cracker-version',
-              breadcrumb: 'Engine > New Cracker Version/Binary',
-              permission: 'CrackerBinary'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'engine/crackers/:id/edit',  component: EditCrackersComponent,
-          data: {
-              kind: 'edit-cracker-version',
-              breadcrumb: 'Engine > Edit Cracker Version/Binary',
-              permission: 'CrackerBinaryType'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'engine/preprocessors',  component: PreprocessorsComponent,
-          data: {
-              kind: 'preprocessors',
-              breadcrumb: 'Engine > Preprocessors',
-              permission: 'Prepro'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'engine/preprocessors/new-preprocessor',  component: NewPreprocessorComponent,
-          data: {
-              kind: 'new-preprocessor',
-              breadcrumb: 'Engine > New Preprocessor',
-              permission: 'Prepro'
-          },
-          canActivate: [IsAuth,CheckPerm]},
-        {
-          path: 'engine/preprocessors/:id/edit',  component: NewPreprocessorComponent,
-          data: {
-              kind: 'edit-preprocessor',
-              breadcrumb: 'Engine > Edit Preprocessor',
-              permission: 'Prepro'
-          },
-          canActivate: [IsAuth,CheckPerm]},
+      {
+        path: 'agent', component: ServerComponent,
+        data: {
+          kind: 'agent',
+          breadcrumb: 'Agent Settings',
+          permission: 'Config'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'task-chunk', component: ServerComponent,
+        data: {
+          kind: 'task-chunk',
+          breadcrumb: 'Task Chunk Settings',
+          permission: 'Config'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'hch', component: ServerComponent,
+        data: {
+          kind: 'hch',
+          breadcrumb: 'Hashes/Cracks/Hashlist Settings',
+          permission: 'Config'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'notifications', component: ServerComponent,
+        data: {
+          kind: 'notif',
+          breadcrumb: 'Notifications',
+          permission: 'Notif'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'general-settings', component: ServerComponent,
+        data: {
+          kind: 'gs',
+          breadcrumb: 'General Settings',
+          permission: 'Config'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'hashtypes', component: HashtypesComponent,
+        data: {
+          kind: 'hashtypes',
+          breadcrumb: 'Hashtypes',
+          permission: 'Hashtype'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'hashtypes/new', component: HashtypeComponent,
+        data: {
+          kind: 'new-hashtype',
+          breadcrumb: 'New Hashtype',
+          permission: 'Hashtype'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'hashtypes/:id/edit', component: HashtypeComponent,
+        data: {
+          kind: 'edit-hashtype',
+          breadcrumb: 'Edit Hashtype',
+          permission: 'Hashtype'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'log', component: LogComponent,
+        data: {
+          kind: 'log',
+          breadcrumb: 'Logs',
+          permission: 'Logs'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'health-checks', component: HealthChecksComponent,
+        data: {
+          kind: 'health-checks',
+          breadcrumb: 'Health Checks',
+          permission: 'HealthCheck'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'health-checks/new', component: NewHealthChecksComponent,
+        data: {
+          kind: 'new-health-checks',
+          breadcrumb: 'New Health Checks',
+          permission: 'HealthCheck'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'health-checks/:id/edit', component: EditHealthChecksComponent,
+        data: {
+          kind: 'edit-health-checks',
+          breadcrumb: 'Edit Health Checks',
+          permission: 'HealthCheck'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'engine/agent-binaries', component: AgentBinariesComponent,
+        data: {
+          kind: 'agent-binaries',
+          breadcrumb: 'Engine > Agent-binaries',
+          permission: 'AgentBinary'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'engine/agent-binaries/new-agent-binary', component: NewAgentBinariesComponent,
+        data: {
+          kind: 'new-agent-binary',
+          breadcrumb: 'Engine > New Agent binary',
+          permission: 'AgentBinary'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'engine/agent-binaries/:id/edit', component: NewAgentBinariesComponent,
+        data: {
+          kind: 'edit-agent-binary',
+          breadcrumb: 'Engine > Edit Agent binary',
+          permission: 'AgentBinary'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'engine/crackers', component: CrackersComponent,
+        data: {
+          kind: 'crackers',
+          breadcrumb: 'Engine > Crackers',
+          permission: 'CrackerBinary'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'engine/crackers/new', component: NewCrackerComponent,
+        data: {
+          kind: 'new-cracker',
+          breadcrumb: 'Engine > New Cracker',
+          permission: 'CrackerBinary'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'engine/crackers/:id/new', component: NewCrackersComponent,
+        data: {
+          kind: 'new-cracker-version',
+          breadcrumb: 'Engine > New Cracker Version/Binary',
+          permission: 'CrackerBinary'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'engine/crackers/:id/edit', component: EditCrackersComponent,
+        data: {
+          kind: 'edit-cracker-version',
+          breadcrumb: 'Engine > Edit Cracker Version/Binary',
+          permission: 'CrackerBinaryType'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'engine/preprocessors', component: PreprocessorsComponent,
+        data: {
+          kind: 'preprocessors',
+          breadcrumb: 'Engine > Preprocessors',
+          permission: 'Prepro'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'engine/preprocessors/new-preprocessor', component: NewPreprocessorComponent,
+        data: {
+          kind: 'new-preprocessor',
+          breadcrumb: 'Engine > New Preprocessor',
+          permission: 'Prepro'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
+      {
+        path: 'engine/preprocessors/:id/edit', component: NewPreprocessorComponent,
+        data: {
+          kind: 'edit-preprocessor',
+          breadcrumb: 'Engine > Edit Preprocessor',
+          permission: 'Prepro'
+        },
+        canActivate: [IsAuth, CheckPerm]
+      },
     ]
-},
+  },
 ];
 
 @NgModule({
@@ -208,4 +230,4 @@ const routes: Routes = [
   exports: [RouterModule]
 
 })
-export class ConfigRoutingModule {}
+export class ConfigRoutingModule { }

--- a/src/app/config/config.module.ts
+++ b/src/app/config/config.module.ts
@@ -28,7 +28,7 @@ import { PipesModule } from "../shared/pipes.module";
 import { LogComponent } from "./log/log.component";
 
 @NgModule({
-  declarations:[
+  declarations: [
     NewAgentBinariesComponent,
     EditHealthChecksComponent,
     NewPreprocessorComponent,
@@ -47,7 +47,7 @@ import { LogComponent } from "./log/log.component";
     ServerComponent,
     LogComponent
   ],
-  imports:[
+  imports: [
     ReactiveFormsModule,
     ConfigRoutingModule,
     FontAwesomeModule,
@@ -60,4 +60,4 @@ import { LogComponent } from "./log/log.component";
     NgbModule
   ]
 })
-export class ConfigModule {}
+export class ConfigModule { }

--- a/src/app/config/engine/agent-binaries/agent-binaries.component.html
+++ b/src/app/config/engine/agent-binaries/agent-binaries.component.html
@@ -1,39 +1,42 @@
-<app-page-title [title]="'Agent Binaries'" [buttontitle]="'New Binary'" [buttonlink]="'/config/engine/agent-binaries/new-agent-binary'" [subbutton]="true"></app-page-title>
+<app-page-title [title]="'Agent Binaries'" [buttontitle]="'New Binary'"
+  [buttonlink]="'/config/engine/agent-binaries/new-agent-binary'" [subbutton]="true"></app-page-title>
 <!-- <engine-menu [aclass]="'btn-outline-gray-600-select'"></engine-menu> -->
 <!-- Body -->
 <app-table>
-  <table style="width: 100%" class="table table-striped table-hover table-sm" datatable [dtOptions]="dtOptions" [dtTrigger]="dtTrigger">
+  <table style="width: 100%" class="table table-striped table-hover table-sm" datatable [dtOptions]="dtOptions"
+    [dtTrigger]="dtTrigger">
     <thead class="thead-light">
       <tr>
-          <th class="rounded-start">ID</th>
-          <th>Type</th>
-          <th>OS</th>
-          <th>Filename</th>
-          <th>Current Version</th>
-          <th>Update Track</th>
-          <th class="rounded-end">Actions</th>
+        <th class="rounded-start">ID</th>
+        <th>Type</th>
+        <th>OS</th>
+        <th>Filename</th>
+        <th>Current Version</th>
+        <th>Update Track</th>
+        <th class="rounded-end">Actions</th>
       </tr>
-      </thead>
-      <tbody>
+    </thead>
+    <tbody>
       <tr *ngFor="let b of binaries">
-          <td class="text-align:center">{{ b.agentBinaryId }}</td>
-          <td>{{ b.type }}</td>
-          <td>{{ b.operatingSystems }}</td>
-          <td>{{ b.filename }}</td>
-          <td>{{ b.version }}</td>
-          <td>{{ b.updateTrack }}</td>
-          <td class="overflow-hidden">
-            <app-button-actions>
-              <button ngbDropdownItem [routerLink]="[b.agentBinaryId,'edit']" data-placement="top" title="Edit">
-                <fa-icon [icon]="faEdit" aria-hidden="true"></fa-icon> Edit
-              </button>
-              <div class="dropdown-divider"></div>
-              <button ngbDropdownItem data-toggle="tooltip" data-placement="top" title="Delete" (click)="onDelete(b.agentBinaryId,b.filename)">
-                <fa-icon [icon]="faTrash" aria-hidden="true"></fa-icon> Delete
-              </button>
-            </app-button-actions>
-          </td>
+        <td class="text-align:center">{{ b.agentBinaryId }}</td>
+        <td>{{ b.type }}</td>
+        <td>{{ b.operatingSystems }}</td>
+        <td>{{ b.filename }}</td>
+        <td>{{ b.version }}</td>
+        <td>{{ b.updateTrack }}</td>
+        <td class="overflow-hidden">
+          <app-button-actions>
+            <button ngbDropdownItem [routerLink]="[b.agentBinaryId,'edit']" data-placement="top" title="Edit">
+              <fa-icon [icon]="faEdit" aria-hidden="true"></fa-icon> Edit
+            </button>
+            <div class="dropdown-divider"></div>
+            <button ngbDropdownItem data-toggle="tooltip" data-placement="top" title="Delete"
+              (click)="onDelete(b.agentBinaryId,b.filename)">
+              <fa-icon [icon]="faTrash" aria-hidden="true"></fa-icon> Delete
+            </button>
+          </app-button-actions>
+        </td>
       </tr>
-      </tbody>
+    </tbody>
   </table>
 </app-table>

--- a/src/app/config/engine/agent-binaries/agent-binaries.component.spec.ts
+++ b/src/app/config/engine/agent-binaries/agent-binaries.component.spec.ts
@@ -1,0 +1,168 @@
+import { ComponentFixture, TestBed, tick, fakeAsync, flush } from '@angular/core/testing';
+import { AgentBinariesComponent } from './agent-binaries.component';
+import { CommonModule } from '@angular/common';
+import { DataTablesModule } from 'angular-datatables';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { GlobalService } from 'src/app/core/_services/main.service';
+import { Observable, of } from 'rxjs';
+import { SERV } from '../../../core/_services/main.config';
+import { AgentBinary } from 'src/app/core/_models/agent-binary';
+import Swal from 'sweetalert2/dist/sweetalert2.js';
+import { HttpClientModule } from '@angular/common/http';
+import { ComponentsModule } from 'src/app/shared/components.module';
+import { PipesModule } from 'src/app/shared/pipes.module';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { RouterModule } from '@angular/router';
+import { ResponseWrapper } from 'src/app/core/_models/response-wrapper';
+import { AutoTitleService } from 'src/app/core/_services/shared/autotitle.service';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FormsModule } from '@angular/forms';
+
+describe('AgentBinariesComponent', () => {
+  let component: AgentBinariesComponent;
+  let fixture: ComponentFixture<AgentBinariesComponent>;
+
+  // Sample agent binaries data
+  const agentBinaries: AgentBinary[] = [
+    {
+      agentBinaryId: 1,
+      type: 'test-type-1',
+      version: '1.0.0',
+      operatingSystems: 'Linux',
+      filename: 'agent-binary-1.bin',
+      updateTrack: 'stable',
+      updateAvailable: ''
+    },
+    {
+      agentBinaryId: 2,
+      type: 'test-type-2',
+      version: '1.0.0',
+      operatingSystems: 'Linux',
+      filename: 'agent-binary-2.bin',
+      updateTrack: 'stable',
+      updateAvailable: ''
+    },
+    {
+      agentBinaryId: 3,
+      type: 'test-type-3',
+      version: '1.0.0',
+      operatingSystems: 'Linux',
+      filename: 'agent-binary-3.bin',
+      updateTrack: 'stable',
+      updateAvailable: ''
+    },
+  ];
+  // response object
+
+  // Mock GlobalService with required methods
+  const mockService: Partial<GlobalService> = {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+    getAll(_methodUrl: string, params: any): Observable<ResponseWrapper<AgentBinary>> {
+      if (_methodUrl === SERV.AGENT_BINARY) {
+        return of({
+          startAt: 0,
+          maxResults: agentBinaries.length,
+          total: agentBinaries.length,
+          isLast: true,
+          values: agentBinaries
+        });
+      }
+      return of({} as ResponseWrapper<AgentBinary>);
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete(_methodUrl: string, id: number): Observable<any> {
+      if (_methodUrl === SERV.AGENT_BINARY) {
+        const index = agentBinaries.findIndex((ab) => ab.agentBinaryId === id);
+        if (index !== -1) {
+          agentBinaries.splice(index, 1);
+        }
+        return of({});
+      }
+      return of({});
+    },
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        HttpClientModule,
+        FontAwesomeModule,
+        DataTablesModule,
+        ComponentsModule,
+        PipesModule,
+        RouterModule,
+        NgbModule,
+        RouterTestingModule,
+        FormsModule,
+      ],
+      declarations: [
+        AgentBinariesComponent
+      ],
+      providers: [
+        {
+          provide: GlobalService,
+          useValue: mockService,
+        },
+        AutoTitleService,
+        Swal,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AgentBinariesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+
+  // --- Test Methods ---
+
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should fetch agent binaries on initialization', () => {
+    expect(component.binaries).toEqual(agentBinaries);
+  });
+
+  it('should render the table with agent binaries', () => {
+    const tableRows = fixture.nativeElement.querySelectorAll('tbody tr');
+    expect(tableRows.length).toBe(agentBinaries.length);
+  });
+  it('should handle agent binary deletion', fakeAsync(() => {
+    const deleteSpy = spyOn(mockService, 'delete').and.callThrough();
+    const swalFireSpy = spyOn(Swal, 'fire').and.callFake(() => {
+      return Promise.resolve({ isConfirmed: true });
+    });
+
+    const binaryToDelete = agentBinaries[0];
+    component.onDelete(binaryToDelete.agentBinaryId, binaryToDelete.type);
+
+    // Trigger the confirmation and flush any asynchronous tasks
+    Swal.clickConfirm();
+    flush();
+
+    expect(deleteSpy).toHaveBeenCalledWith(SERV.AGENT_BINARY, binaryToDelete.agentBinaryId);
+    expect(swalFireSpy).toHaveBeenCalled();
+    expect(component.binaries).not.toContain(binaryToDelete);
+  }));
+
+  it('should handle agent binary deletion cancellation', fakeAsync(() => {
+    const deleteSpy = spyOn(mockService, 'delete').and.callThrough();
+    const swalFireSpy = spyOn(Swal, 'fire').and.callFake(() => {
+      return Promise.resolve({ isConfirmed: false });
+    });
+
+    const binaryToDelete = agentBinaries[0];
+    component.onDelete(binaryToDelete.agentBinaryId, binaryToDelete.type);
+
+    // Trigger the cancellation and flush any asynchronous tasks
+    Swal.clickCancel();
+    flush();
+
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(swalFireSpy).toHaveBeenCalled();
+    expect(component.binaries).toContain(binaryToDelete);
+  }));
+});

--- a/src/app/core/_constants/settings.config.ts
+++ b/src/app/core/_constants/settings.config.ts
@@ -3,15 +3,15 @@
 **/
 
 export const dateFormat = [
-  {format:'d/M/yy', description:'d/M/yy (ie. 6/7/23 )'},
-  {format:'dd/MM/yyyy h:mm:ss', description:'dd/MM/yyyy h:mm:ss (ie. 06/07/2023, 9:03 AM)'},
-  {format:'d MMM, y h:mm:ss a', description:'dd/MM/yyyy h:mm:ss (ie. 06 Jul, 2023 9:03:01 AM)'},
-  {format:'M/d/yy', description:'M/d/yy (ie. 7/6/23)'},
-  {format:'M/d/yy, h:mm a', description:'M/d/yy, h:mm a (ie. 7/6/23, 9:03 AM)'},
-  {format:'MMM d, y, h:mm:ss a', description:'MMM d, y, h:mm:ss a (ie. Jul 06, 2023, 9:03:01 AM)'},
-  {format:'yy/M/d', description:'yy/M/d (ie. 23/7/6 )'},
-  {format:'yyyy/M/d, h:mm:ss a', description:'yyyy/M/d (ie. 2023/7/6, 9:03:01 AM )'},
-  {format:'yyyy/MM/dd h:mm:ss', description:'yyyy/MM/dd h:mm:ss (ie. 2023/07/06, 9:03 AM)'},
+  { format: 'd/M/yy', description: 'd/M/yy (ie. 6/7/23 )' },
+  { format: 'dd/MM/yyyy h:mm:ss', description: 'dd/MM/yyyy h:mm:ss (ie. 06/07/2023, 9:03 AM)' },
+  { format: 'd MMM, y h:mm:ss a', description: 'dd/MM/yyyy h:mm:ss (ie. 06 Jul, 2023 9:03:01 AM)' },
+  { format: 'M/d/yy', description: 'M/d/yy (ie. 7/6/23)' },
+  { format: 'M/d/yy, h:mm a', description: 'M/d/yy, h:mm a (ie. 7/6/23, 9:03 AM)' },
+  { format: 'MMM d, y, h:mm:ss a', description: 'MMM d, y, h:mm:ss a (ie. Jul 06, 2023, 9:03:01 AM)' },
+  { format: 'yy/M/d', description: 'yy/M/d (ie. 23/7/6 )' },
+  { format: 'yyyy/M/d, h:mm:ss a', description: 'yyyy/M/d (ie. 2023/7/6, 9:03:01 AM )' },
+  { format: 'yyyy/MM/dd h:mm:ss', description: 'yyyy/MM/dd h:mm:ss (ie. 2023/07/06 9:03 AM)' },
 ];
 
 
@@ -20,12 +20,12 @@ export const dateFormat = [
 **/
 
 export const serverlog = [
-  {id:0, value: 'TRACE'},
-  {id:10, value: 'DEBUG'},
-  {id:20, value: 'INFO'},
-  {id:30, value: 'WARNING'},
-  {id:40, value: 'ERROR'},
-  {id:50, value: 'FATAL'}
+  { id: 0, value: 'TRACE' },
+  { id: 10, value: 'DEBUG' },
+  { id: 20, value: 'INFO' },
+  { id: 30, value: 'WARNING' },
+  { id: 40, value: 'ERROR' },
+  { id: 50, value: 'FATAL' }
 ];
 
 /**
@@ -33,10 +33,10 @@ export const serverlog = [
 **/
 
 export const proxytype = [
-  {value:'HTTP'},
-  {value:'HTTPS'},
-  {value:'SOCKS4'},
-  {value:'SOCKS5'}
+  { value: 'HTTP' },
+  { value: 'HTTPS' },
+  { value: 'SOCKS4' },
+  { value: 'SOCKS5' }
 ];
 
 /**

--- a/src/app/core/_models/agent-binary.ts
+++ b/src/app/core/_models/agent-binary.ts
@@ -1,0 +1,9 @@
+export interface AgentBinary {
+    agentBinaryId: number,
+    type: string,
+    version: string,
+    operatingSystems: string,
+    filename: string,
+    updateTrack: string,
+    updateAvailable: string
+}

--- a/src/app/core/_models/notifications.ts
+++ b/src/app/core/_models/notifications.ts
@@ -1,12 +1,3 @@
-export interface NotificationListResponse {
-  _expandable: string,
-  startAt: number,
-  maxResults: number,
-  total: number,
-  isLast: boolean,
-  values: Notification[]
-}
-
 export interface Notification {
   _id: number,
   _self: string,

--- a/src/app/core/_models/response-wrapper.ts
+++ b/src/app/core/_models/response-wrapper.ts
@@ -1,0 +1,8 @@
+export interface ResponseWrapper<T> {
+  _expandable?: string
+  startAt: number
+  maxResults: number
+  total: number
+  isLast: boolean
+  values: T[]
+}

--- a/src/app/core/_pipes/date.pipe.ts
+++ b/src/app/core/_pipes/date.pipe.ts
@@ -1,60 +1,54 @@
-import {
-  Inject,
-  LOCALE_ID,
-  PipeTransform,
-  Pipe
-} from '@angular/core';
-import { CookieService } from '../_services/shared/cookies.service';
-import { dateFormat } from '../../core/_constants/settings.config';
+import { Inject, LOCALE_ID, PipeTransform, Pipe } from '@angular/core';
 import { DatePipe } from '@angular/common';
+import { CookieStorageService } from '../_services/storage/cookie-storage.service';
+import { UISettings, UiSettingsComponent } from 'src/app/account/settings/ui-settings/ui-settings.component';
 
 /**
- * Pipe to format date
- * @param epoch - Epoch date number
+ * Custom Angular pipe for formatting dates based on user settings.
+ *
  * Usage:
  *   value | uiDate
+ *
  * Example:
  *   {{ 1694866300 | uiDate }}
- * @returns 16/09/2023
-**/
-
+ *
+ * @returns Formatted date string, e.g., '16/09/2023'
+ */
 @Pipe({
   name: 'uiDate'
 })
 export class uiDatePipe extends DatePipe implements PipeTransform {
 
-  constructor(
-    private cookieService: CookieService,
-    @Inject(LOCALE_ID) locale: string
-  ) { super(locale); }
+  settings: UISettings
 
-  override transform(epoch: number):any {
-
-    if(epoch === undefined  || epoch === null) return epoch;
-
-    if(!this.cookieService.getCookie('localtimefmt')){
-      this.cookieService.setCookie('localtimefmt', 'dd/MM/yyyy h:mm:ss', 365);
-    }
-
-    const format = this.checkFormat(this.cookieService.getCookie('localtimefmt'));
-
-    return super.transform(epoch*1000, format);
+  /**
+   * Creates an instance of UiDatePipe.
+   *
+   * @param cookieService - The CookieStorageService for retrieving user interface settings.
+   * @param locale - The locale ID used for date formatting.
+   */
+  constructor(cookieService: CookieStorageService<UISettings>, @Inject(LOCALE_ID) locale: string) {
+    super(locale);
+    this.settings = cookieService.getItem(UiSettingsComponent.COOKIE_NAME)
   }
 
-  //Check that format is correct
-  checkFormat(format: any){
-    let res; //Default date format
-    for(let i=0; i < dateFormat.length; i++){
-      if(dateFormat[i]['format']== format){
-        res = format;
-      }
+  /**
+   * Transforms an epoch timestamp into a formatted date string based on user settings.
+   *
+   * @param epoch - The epoch timestamp to be formatted.
+   * @returns The formatted date string.
+   */
+  override transform(epoch: number): any {
+    if (epoch === undefined || epoch === null) {
+      return epoch;
     }
-    if(!res){
-      res = 'dd/MM/yyyy h:mm:ss';
-      this.cookieService.setCookie('localtimefmt', res, 365);
-    }
-    return res;
-  }
 
+    let format: string = UiSettingsComponent.DEFAULT_LOCALTIMEFMT;
+    if (this.settings) {
+      format = this.settings.localtimefmt
+    }
+
+    return super.transform(epoch * 1000, format);
+  }
 }
 

--- a/src/app/core/_services/storage/base-storage.service.spec.ts
+++ b/src/app/core/_services/storage/base-storage.service.spec.ts
@@ -1,0 +1,61 @@
+import { BaseStorageService } from './base-storage.service';
+
+class MockStorageService<T> extends BaseStorageService<T> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getItem(key: string): T | null {
+    return null
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setItem(key: string, value: T, expiresInMs: number): void {
+    // Do nothing
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  removeItem(key: string): void {
+    // Do nothing
+  }
+}
+
+describe('BaseStorageService', () => {
+  let service: MockStorageService<string>;
+
+  beforeEach(() => {
+    service = new MockStorageService();
+  });
+
+  // --- Test Methods ---
+
+  it('should decode a URL-encoded string', () => {
+    const encodedString = 'Hello%20World';
+    const decodedString = service.decode(encodedString);
+
+    expect(decodedString).toBe('Hello World');
+  });
+
+  it('should return the original string if not URL-encoded', () => {
+    const originalString = 'Hello World';
+    const decodedString = service.decode(originalString);
+
+    expect(decodedString).toBe(originalString);
+  });
+
+  it('should return true for an expired storage wrapper', () => {
+    const expiredWrapper = { value: 'expired', expires: Date.now() - 1000 }; // Set expiration in the past
+    const result = service.hasExpired(expiredWrapper);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false for a valid (not expired) storage wrapper', () => {
+    const validWrapper = { value: 'valid', expires: Date.now() + 1000 }; // Set expiration in the future
+    const result = service.hasExpired(validWrapper);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false for a wrapper with no expiration', () => {
+    const noExpirationWrapper = { value: 'no expiration', expires: null };
+    const result = service.hasExpired(noExpirationWrapper);
+
+    expect(result).toBe(false);
+  });
+});

--- a/src/app/core/_services/storage/base-storage.service.ts
+++ b/src/app/core/_services/storage/base-storage.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@angular/core';
+
+export interface StorageWrapper<T> {
+  value: T
+  expires: number
+}
+
+/**
+ * Abstract base service for data storage with expiration.
+ * Implementations of this service should provide methods for storing, retrieving,
+ * and removing data with optional expiration.
+ *
+ * @template T - The type of data to be stored.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export abstract class BaseStorageService<T> {
+
+  /**
+   * Retrieves the stored data associated with the specified key.
+   *
+   * @param key - The key under which the data is stored.
+   * @returns The stored data if found, or `null` if not found or expired.
+   */
+  abstract getItem(key: string): T | null;
+
+  /**
+   * Stores data with an optional expiration time.
+   *
+   * @param key - The key under which to store the data.
+   * @param value - The data to be stored.
+   * @param expiresInMs - The optional expiration time in milliseconds.
+   *                     If provided and greater than 0, the data will expire
+   *                     after the specified time has passed.
+   */
+  abstract setItem(key: string, value: T, expiresInMs: number): void;
+
+  /**
+   * Removes the stored data associated with the specified key.
+   *
+   * @param key - The key under which the data is stored.
+   */
+  abstract removeItem(key: string): void;
+
+  /**
+   * Decodes a string that may be URL-encoded. If the input string is a valid
+   * URL-encoded string, it is decoded; otherwise, it returns the original string.
+   *
+   * @param data - The string to decode, which may be URL-encoded.
+   * @returns The decoded string if it was URL-encoded, or the original string if not.
+   */
+  decode(data: string): string {
+    try {
+      return decodeURIComponent(data);
+    } catch {
+      return data;
+    }
+  }
+
+  /**
+   * Checks if the provided storage wrapper has expired based on its expiration timestamp.
+   *
+   * @param wrapper - The storage wrapper containing data and an optional expiration timestamp.
+   * @returns `true` if the wrapper has expired, or `false` if it is still valid or has no expiration timestamp.
+   */
+  hasExpired(wrapper: StorageWrapper<T>): boolean {
+    return !!(wrapper.expires && wrapper.expires <= Date.now())
+  }
+}

--- a/src/app/core/_services/storage/cookie-storage.service.spec.ts
+++ b/src/app/core/_services/storage/cookie-storage.service.spec.ts
@@ -1,0 +1,98 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { CookieStorageService } from './cookie-storage.service';
+
+
+describe('CookieStorageService', () => {
+  let service: CookieStorageService<object | string>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        CookieStorageService,
+      ]
+    });
+    service = TestBed.inject(CookieStorageService);
+  });
+
+  // --- Test Methods ---
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should store and retrieve data in cookies', () => {
+    const key = 'testKey';
+    const value = 'testValue';
+
+    service.setItem(key, value, 1000); // Set with 1-second expiration
+    const retrievedValue = service.getItem(key);
+
+    expect(retrievedValue).toBe(value);
+  });
+
+  it('should remove data from cookies after expiration', fakeAsync(() => {
+    const key = 'testKey';
+    const value = 'testValue';
+
+    service.setItem(key, value, 1); // Set with 1-millisecond expiration
+
+    tick(2);
+
+    const retrievedValue = service.getItem(key);
+    expect(retrievedValue).toBeNull();
+  }));
+
+  it('should remove data from cookies when explicitly removed', () => {
+    const key = 'testKey';
+    const value = 'testValue';
+
+    service.setItem(key, value, 1000);
+    service.removeItem(key);
+
+    const retrievedValue = service.getItem(key);
+    expect(retrievedValue).toBeNull();
+  });
+
+
+  it('should handle invalid JSON data', () => {
+    const key = 'invalidKey';
+    const invalidValue = 'invalidJSON';
+
+    service.setItem(key, invalidValue, 1000);
+    const retrievedValue = service.getItem(key);
+
+    // The stored value is not valid JSON, so it should be retrieved as-is
+    expect(retrievedValue).toBe(invalidValue);
+  });
+
+  it('should handle null values', () => {
+    const key = 'nullKey';
+
+    // Store a null value
+    service.setItem(key, null, 1000);
+    const retrievedValue = service.getItem(key);
+
+    expect(retrievedValue).toBeNull();
+  });
+
+  it('should handle complex objects', () => {
+    const key = 'objectKey';
+    const complexObject = { name: 'John', age: 30, hobbies: ['reading', 'hiking'] };
+
+    // Store a complex object
+    service.setItem(key, complexObject, 1000);
+    const retrievedValue = service.getItem(key);
+
+    expect(retrievedValue).toEqual(complexObject);
+  });
+
+  it('should handle keys with special characters', () => {
+    const key = 'specialKey@!$%^&*()_+';
+
+    service.setItem(key, 'specialValue', 1000);
+    const retrievedValue = service.getItem(key);
+
+    expect(retrievedValue).toBe('specialValue');
+  });
+
+});

--- a/src/app/core/_services/storage/cookie-storage.service.ts
+++ b/src/app/core/_services/storage/cookie-storage.service.ts
@@ -1,0 +1,97 @@
+import { Injectable } from "@angular/core";
+import { BaseStorageService } from "./base-storage.service";
+
+export type SameSite = 'Lax' | 'None' | 'Strict';
+
+export interface CookieOptions {
+  expires?: number | Date;
+  path?: string;
+  domain?: string;
+  secure?: boolean;
+  sameSite?: SameSite;
+}
+
+/**
+ * A storage service implementation that uses browser cookies to store and retrieve data
+ * with optional expiration.
+ *
+ * @template T - The type of data to be stored.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class CookieStorageService<T> extends BaseStorageService<T> {
+
+  static readonly SAME_SITE: SameSite = 'Lax'
+
+  /**
+   * Retrieves the stored data associated with the specified key from browser cookies.
+   *
+   * @param key - The key under which the data is stored.
+   * @returns The stored data if found, or `null` if not found or expired.
+   */
+  getItem(key: string): T | null {
+    key = this.decode(key);
+    const value = this.getCookie(key);
+
+    try {
+      // Try parsing the value as JSON
+      return JSON.parse(value) as T;
+    } catch (e) {
+      // If parsing fails, return the value as a plain string
+      return value !== null ? value as T : null;
+    }
+  }
+
+  /**
+   * Stores data with an optional expiration time in browser cookies.
+   *
+   * @param key - The key under which to store the data.
+   * @param value - The data to be stored.
+   * @param expiresInMs - The optional expiration time in milliseconds.
+   *                     If provided and greater than 0, the data will expire
+   *                     after the specified time has passed.
+   */
+  setItem(key: string, value: T, expiresInMs: number): void {
+    key = this.decode(key);
+    const serializedValue = typeof value === 'string' ? value : JSON.stringify(value);
+
+    // Construct the cookie string with optional attributes
+    let cookieString = `${key}=${serializedValue};sameSite=${CookieStorageService.SAME_SITE};`
+    if (expiresInMs) {
+      const expires = new Date(Date.now() + expiresInMs).toUTCString();
+      cookieString += `expires=${expires};`;
+    }
+
+    document.cookie = cookieString
+  }
+
+  /**
+   * Removes the stored data associated with the specified key from browser cookies.
+   *
+   * @param key - The key under which the data is stored.
+   */
+  removeItem(key: string): void {
+    key = this.decode(key);
+    document.cookie = `${key}=; expires=Thu, 01 Jan 1970 00:00:00 UTC`;
+  }
+
+  /**
+   * Retrieves the raw cookie value associated with the specified key from browser cookies.
+   *
+   * @param key - The key under which the data is stored.
+   * @returns The raw cookie value if found, or `null` if not found.
+   */
+  private getCookie(key: string): string | null {
+    key = this.decode(key);
+    const cookies = document.cookie.split(';');
+
+    for (const cookie of cookies) {
+      const [cookieKey, cookieValue] = cookie.split('=').map((c) => c.trim());
+      if (cookieKey === key) {
+        return cookieValue;
+      }
+    }
+    return null;
+  }
+}

--- a/src/app/core/_services/storage/cookie-storage.service.ts
+++ b/src/app/core/_services/storage/cookie-storage.service.ts
@@ -3,13 +3,6 @@ import { BaseStorageService } from "./base-storage.service";
 
 export type SameSite = 'Lax' | 'None' | 'Strict';
 
-export interface CookieOptions {
-  expires?: number | Date;
-  path?: string;
-  domain?: string;
-  secure?: boolean;
-  sameSite?: SameSite;
-}
 
 /**
  * A storage service implementation that uses browser cookies to store and retrieve data

--- a/src/app/core/_services/storage/local-storage.service.spec.ts
+++ b/src/app/core/_services/storage/local-storage.service.spec.ts
@@ -1,0 +1,96 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { LocalStorageService } from './local-storage.service';
+
+
+describe('LocalStorageService', () => {
+  let service: LocalStorageService<string | object>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        LocalStorageService,
+      ]
+    });
+    service = TestBed.inject(LocalStorageService);
+  });
+
+  // --- Test Methods ---
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should store and retrieve data in local storage', () => {
+    const key = 'testKey';
+    const value = 'testValue';
+
+    service.setItem(key, value, 1000);
+    const retrievedValue = service.getItem(key);
+
+    expect(retrievedValue).toBe(value);
+  });
+
+  it('should remove data from local storage after expiration', fakeAsync(() => {
+    const key = 'testKey';
+    const value = 'testValue';
+
+    service.setItem(key, value, 1); // Set with 1-millisecond expiration
+
+    tick(2);
+
+    const retrievedValue = service.getItem(key);
+    expect(retrievedValue).toBeNull();
+  }));
+
+  it('should remove data from local storage when explicitly removed', () => {
+    const key = 'testKey';
+    const value = 'testValue';
+
+    service.setItem(key, value, 1000);
+    service.removeItem(key);
+
+    const retrievedValue = service.getItem(key);
+    expect(retrievedValue).toBeNull();
+  });
+
+  it('should handle invalid JSON data', () => {
+    const key = 'invalidKey';
+    const invalidValue = 'invalidJSON';
+
+    service.setItem(key, invalidValue, 1000);
+    const retrievedValue = service.getItem(key);
+
+    // The stored value is not valid JSON, so it should be retrieved as-is
+    expect(retrievedValue).toBe(invalidValue);
+  });
+
+  it('should handle null values', () => {
+    const key = 'nullKey';
+
+    // Store a null value
+    service.setItem(key, null, 1000);
+    const retrievedValue = service.getItem(key);
+
+    expect(retrievedValue).toBeNull();
+  });
+
+  it('should handle complex objects', () => {
+    const key = 'objectKey';
+    const complexObject = { name: 'John', age: 30, hobbies: ['reading', 'hiking'] };
+
+    // Store a complex object
+    service.setItem(key, complexObject, 1000);
+    const retrievedValue = service.getItem(key);
+
+    expect(retrievedValue).toEqual(complexObject);
+  });
+
+  it('should handle keys with special characters', () => {
+    const key = 'specialKey@!$%^&*()_+';
+
+    service.setItem(key, 'specialValue', 1000);
+    const retrievedValue = service.getItem(key);
+
+    expect(retrievedValue).toBe('specialValue');
+  });
+});

--- a/src/app/core/_services/storage/local-storage.service.ts
+++ b/src/app/core/_services/storage/local-storage.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from "@angular/core";
+import { BaseStorageService, StorageWrapper } from "./base-storage.service";
+
+/**
+ * A storage service implementation that uses browser's local storage to store and retrieve data
+ * with optional expiration.
+ *
+ * @template T - The type of data to be stored.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class LocalStorageService<T> extends BaseStorageService<T> {
+
+  /**
+   * Retrieves the stored data associated with the specified key from local storage,
+   * and checks if it has expired. If the data has expired, it is removed from local storage.
+   *
+   * @param key - The key under which the data is stored.
+   * @returns The stored data if found and not expired, or `null` if not found or expired.
+   */
+  getItem(key: string): T | null {
+    key = this.decode(key)
+    const storedValue = localStorage.getItem(key);
+    if (!storedValue) {
+      return null; // Data not found.
+    }
+
+    const storedData: StorageWrapper<T> = JSON.parse(storedValue);
+    if (this.hasExpired(storedData)) {
+      // Data has expired, remove it from local storage.
+      localStorage.removeItem(key);
+      return null;
+    }
+
+    return storedData.value;
+  }
+
+  /**
+   * Stores data with an optional expiration time in local storage.
+   *
+   * @param key - The key under which to store the data.
+   * @param value - The data to be stored.
+   * @param expiresInMs - The optional expiration time in milliseconds.
+   *                     If provided and greater than 0, the data will expire
+   *                     after the specified time has passed.
+   */
+  setItem(key: string, value: T, expiresInMs: number): void {
+    const storedValue: StorageWrapper<T> = {
+      expires: new Date(Date.now() + expiresInMs).getTime(),
+      value: value
+    }
+
+    localStorage.setItem(this.decode(key), JSON.stringify(storedValue));
+  }
+
+  /**
+   * Removes the stored data associated with the specified key from local storage.
+   *
+   * @param key - The key under which the data is stored.
+   */
+  removeItem(key: string): void {
+    key = this.decode(key)
+    localStorage.removeItem(key);
+  }
+}


### PR DESCRIPTION
This PR includes:
- A new service for handling cookies + tests
- A new service for handling localstorage + tests
- basic tests for ui-settings page
- minor refactoring of the ui-settings component.
- updated date pipe

A few notes:
My thought on the new services is to have one place to store cookies and local storage data with a common interface. I have not included the changes to use the new services in this PR other than for ui-settings.
I am not sure how the button on the ui-settings page is supposed to work so I just left it.
I am not sure why the ui-settings cookie was set in the pipe, i changed so it uses the default value instead, hope I don´t break anything.