### PR TITLE
Change to predefined colors

### DIFF
--- a/src/styles/layout/_header.scss
+++ b/src/styles/layout/_header.scss
@@ -33,7 +33,6 @@
 
     &.active {
       background-color: $primary-900;
-      border-radius: 0;
 
       .mdc-button__label {
         font-weight: 400;

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -2,90 +2,21 @@
 @import "@angular/material/theming";
 @include mat.core();
 
-$hashtopolis-primary-palette: (
-  50: #eceff1,
-  100: #cfd8dc,
-  200: #b0bec5,
-  300: #90a4ae,
-  400: #78909c,
-  500: #607d8b,
-  600: #546e7a,
-  700: #455a64,
-  800: #37474f,
-  900: #263238,
-  contrast: (50: rgba(black, 0.87),
-    100: rgba(black, 0.87),
-    200: rgba(black, 0.87),
-    300: rgba(black, 0.87),
-    400: rgba(black, 0.87),
-    500: #ffffff,
-    600: #ffffff,
-    700: #ffffff,
-    800: #ffffff,
-    900: #ffffff)
-);
-
-$hashtopolis-accent-palette: (
-  50: #e0f7fa,
-  100: #b2ebf2,
-  200: #80deea,
-  300: #4dcfe1,
-  400: #26c5da,
-  500: #00bbd4,
-  600: #00abc1,
-  700: #0096a7,
-  800: #00828f,
-  900: #005f64,
-  contrast: (50: rgba(black, 0.87),
-    100: rgba(black, 0.87),
-    200: rgba(black, 0.87),
-    300: rgba(black, 0.87),
-    400: #ffffff,
-    500: #ffffff,
-    600: #ffffff,
-    700: #ffffff,
-    800: #ffffff,
-    900: #ffffff)
-);
-
-$hashtopolis-warn-palette: (
-  50: #f3e4e8,
-  100: #e3bbc8,
-  200: #d191a5,
-  300: #c06c84,
-  400: #b3566d,
-  500: #af4159,
-  600: #9f3e55,
-  700: #8b384e,
-  800: #773348,
-  900: #56283a,
-  contrast: (50: rgba(black, 0.87),
-    100: rgba(black, 0.87),
-    200: rgba(black, 0.87),
-    300: rgba(black, 0.87),
-    400: #ffffff,
-    500: #ffffff,
-    600: #ffffff,
-    700: #ffffff,
-    800: #ffffff,
-    900: #ffffff)
-);
-
-$primary: mat.define-palette($hashtopolis-primary-palette);
-$accent: mat.define-palette($hashtopolis-accent-palette);
-$warn: mat.define-palette($hashtopolis-warn-palette);
+$hashtopolis-primary-palette: mat.define-palette(mat.$blue-grey-palette);
+$hashtopolis-accent-palette: mat.define-palette(mat.$cyan-palette);
+$hashtopolis-warn-palette: mat.define-palette(mat.$red-palette);
 
 // Include custom palettes in the theme
-$hashtopolis-light-theme: mat.define-light-theme((color: (primary: $primary,
-        accent: $accent,
-        warn: $warn ),
+$hashtopolis-light-theme: mat.define-light-theme((color: (primary: $hashtopolis-primary-palette,
+        accent: $hashtopolis-accent-palette,
+        warn: $hashtopolis-warn-palette ),
       typography: mat.define-typography-config(),
       density: 0,
     ));
 
-$hashtopolis-dark-theme: mat.define-dark-theme((color: (primary: $primary,
-        accent: $accent,
-        warn: $warn ),
+$hashtopolis-dark-theme: mat.define-dark-theme((color: (primary: $hashtopolis-primary-palette,
+        accent: $hashtopolis-accent-palette,
+        warn: $hashtopolis-warn-palette ),
       typography: mat.define-typography-config(),
       density: 0,
     ));


### PR DESCRIPTION
This PR includes:
- Removal of custom color schemes
- Included predefined color schemes

I used blue-grey and cyan as primary and accent colors now. [here's](https://m1.material.io/style/color.html#color-color-palette) a list of all available color schemes.