### PR TITLE
refactor: update cache keys in BaseTableComponent for render user link

### DIFF
--- a/src/app/core/_components/tables/base-table/base-table.component.ts
+++ b/src/app/core/_components/tables/base-table/base-table.component.ts
@@ -148,7 +148,7 @@ export class BaseTableComponent {
     ];
   }
 
-  @Cacheable(['userId'])
+  @Cacheable(['_id', 'userId'])
   async renderUserLink(obj: unknown): Promise<HTTableRouterLink[]> {
     return [
       {


### PR DESCRIPTION
Changed the cache keys of renderUserLink to check for both userId and _id. Closes #95 