### PR TITLE
Create Hashlist - URGENT

### DIFF
--- a/src/app/core/_components/forms/simple-forms/formconfig.component.ts
+++ b/src/app/core/_components/forms/simple-forms/formconfig.component.ts
@@ -142,7 +142,7 @@ export class FormConfigComponent implements OnInit, OnDestroy {
           result[item.item] = item._id;
           return result;
         }, {});
-        console.log(result);
+
         this.isloaded = true; // Data is loaded and ready for form rendering
       });
   }

--- a/src/app/core/_components/forms/simple-forms/formconfig.component.ts
+++ b/src/app/core/_components/forms/simple-forms/formconfig.component.ts
@@ -142,7 +142,7 @@ export class FormConfigComponent implements OnInit, OnDestroy {
           result[item.item] = item._id;
           return result;
         }, {});
-
+        console.log(result);
         this.isloaded = true; // Data is loaded and ready for form rendering
       });
   }

--- a/src/app/hashlists/new-hashlist/new-hashlist.component.html
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.html
@@ -38,7 +38,7 @@
 
     <div fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="10px">
       <div fxLayout="column">
-        <input-text title="Separator" formControlName="separator"></input-text>
+        <input-text title="Separator" formControlName="hashlistSeperator"></input-text>
       </div>
       <div fxLayout="column" style="position: relative; top: -10px;">
         <input-check title="Salt is in hex (only salted hashes)" formControlName="isHexSalt"></input-check>

--- a/src/app/hashlists/new-hashlist/new-hashlist.component.ts
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.ts
@@ -125,7 +125,7 @@ export class NewHashlistComponent implements OnInit, OnDestroy {
       name: new FormControl('', [Validators.required]),
       hashTypeId: new FormControl('', [Validators.required]),
       format: new FormControl('' || 0),
-      separator: new FormControl(null || ':'),
+      hashlistSeperator: new FormControl(null || ':'),
       isSalted: new FormControl(false),
       isHexSalt: new FormControl(false),
       accessGroupId: new FormControl(null, [Validators.required]),


### PR DESCRIPTION
This pull request is really important and affects Web UI and API V2 if wrong key is used.

After some tests, we found that when the payload is being sent with the key _**separator**_ it works fine and no error is returned and the response returns with the key separator. However, after checking the database no separator is being saved. 

{
	"0": {
		" #_id": 0,
		"name": "Test2",
		"**separator**": "",
		"useBrain": false,
                 ##.....
	}
}

In order for the separator to work this pull request needs to be merged. Maybe some fix in the API v2 @zyronix ? I saw in the PHP at least 3 names for the separator. 