### PR TITLE
Added login guard to prevent going to login page when already logged in

### DIFF
--- a/src/app/auth/auth-routing.module.ts
+++ b/src/app/auth/auth-routing.module.ts
@@ -1,0 +1,28 @@
+import { MyRoute, RouteData } from '../core/_models/routes.model';
+import { RouterModule, Routes } from '@angular/router';
+import { IsAuth } from '../core/_guards/login.guard';
+import { NgModule } from '@angular/core';
+import { AuthComponent } from './auth.component';
+
+const routes: MyRoute[] = [
+  {
+    path: 'auth',
+    children: [
+    {
+        path: '',
+        component: AuthComponent,
+        data: {
+          kind: 'auth',
+          breadcrumb: ''
+        },
+        canActivate: [IsAuth]
+      },
+    ]
+  }
+]
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class AuthRoutingModule {}

--- a/src/app/auth/auth.module.ts
+++ b/src/app/auth/auth.module.ts
@@ -8,10 +8,12 @@ import { NgModule } from '@angular/core';
 import { ComponentsModule } from '../shared/components.module';
 import { AuthComponent } from './auth.component';
 import { CoreFormsModule } from '../shared/forms.module';
+import { AuthRoutingModule } from './auth-routing.module';
 
 @NgModule({
   declarations: [AuthComponent],
   imports: [
+    AuthRoutingModule,
     RouterModule.forChild([
       { path: 'auth', component: AuthComponent },
       {

--- a/src/app/core/_guards/login.guard.ts
+++ b/src/app/core/_guards/login.guard.ts
@@ -1,0 +1,34 @@
+import { Injectable, inject } from "@angular/core";
+import { ActivatedRouteSnapshot, CanActivateFn, Router, RouterStateSnapshot } from "@angular/router";
+import { AuthService } from "../_services/access/auth.service";
+import { map, take, Observable } from "rxjs";
+
+@Injectable({
+  providedIn: 'root'
+})
+class AuthGuard {
+    isAuthenticated: boolean;
+
+    constructor(
+        private authService: AuthService,
+        private router: Router
+    ) { }
+
+    canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+    return this.authService.user.pipe(
+        take(1),
+        map(user => {
+        const isAuth = !!user;
+        if (isAuth) {
+            this.router.navigate(['/']); // Redirect authenticated users to home
+            return false; // Block access to login page
+        }
+        return true; // Allow access to login page
+        })
+    );
+    };
+}
+
+export const IsAuth: CanActivateFn = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> => {
+  return inject(AuthGuard).canActivate(route, state);
+}


### PR DESCRIPTION
fixes #1208. Because logging in goes wrong when already logged in, I added a route guard for the log in page to prevent going to the logged in page when the user is already logged in.