### PR TITLE
Remove cracked link in agent table

### DIFF
--- a/src/app/core/_components/tables/agents-table/agents-table.component.ts
+++ b/src/app/core/_components/tables/agents-table/agents-table.component.ts
@@ -152,7 +152,7 @@ export class AgentsTableComponent extends BaseTableComponent implements OnInit, 
       {
         id: AgentsTableCol.CRACKED,
         dataKey: 'cracked',
-        routerLink: (agent: JAgent) => this.renderCracked(agent),
+        async: (agent: JAgent) => this.renderCracked(agent),
         isSortable: true,
         export: async (agent: JAgent) => (await this.getCracked(agent)) + ''
       }
@@ -288,17 +288,13 @@ export class AgentsTableComponent extends BaseTableComponent implements OnInit, 
   }
 
   @Cacheable(['id'])
-  async renderCracked(agent: JAgent): Promise<HTTableRouterLink[]> {
-    const links: HTTableRouterLink[] = [];
+  async renderCracked(agent: JAgent): Promise<SafeHtml> {
+    let html = '';
     const cracked = await this.getCracked(agent);
     if (cracked) {
-      links.push({
-        label: cracked + '',
-        routerLink: ['/hashlists', 'hashes', 'tasks', agent.taskId]
-      });
+      html = `<span>${cracked}</span>`;
     }
-
-    return links;
+    return this.sanitize(html);
   }
 
   @Cacheable(['id'])


### PR DESCRIPTION
Removed cracked link from agent table and show only the cracked number. The link lead to a table showing all cracked hashes of task, but if the agent has no task assigned, it makes no sense and lead to an error.

This only could make sense for a currently running task, but the necessary conditional logic seems not worth the effort as the same link can be accessed via the task table.

Another option would be an extra table showing all cracked hashes of the agent, but unsure if this is really required.