### PR TITLE
1334 bug cracks are not displayed in the new dashboard

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -3,7 +3,6 @@ import * as echarts from 'echarts/core';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { CalendarComponent, TitleComponent, TooltipComponent, VisualMapComponent } from 'echarts/components';
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Subscription, interval } from 'rxjs';
 import { formatDate, formatUnixTimestamp, unixTimestampInPast } from '@src/app/shared/utils/datetime';
 
 import { AlertService } from '@services/shared/alert.service';
@@ -18,6 +17,7 @@ import { PageTitle } from '@src/app/core/_decorators/autotitle';
 import { RequestParamBuilder } from '@src/app/core/_services/params/builder-implementation.service';
 import { ResponseWrapper } from '@src/app/core/_models/response.model';
 import { SERV } from '@src/app/core/_services/main.config';
+import { Subscription } from 'rxjs';
 import { UIConfig } from '@src/app/core/_models/config-ui.model';
 import { UISettingsUtilityClass } from '@src/app/shared/utils/config';
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -3,6 +3,7 @@ import * as echarts from 'echarts/core';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { CalendarComponent, TitleComponent, TooltipComponent, VisualMapComponent } from 'echarts/components';
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription, interval } from 'rxjs';
 import { formatDate, formatUnixTimestamp, unixTimestampInPast } from '@src/app/shared/utils/datetime';
 
 import { AlertService } from '@services/shared/alert.service';
@@ -17,7 +18,6 @@ import { PageTitle } from '@src/app/core/_decorators/autotitle';
 import { RequestParamBuilder } from '@src/app/core/_services/params/builder-implementation.service';
 import { ResponseWrapper } from '@src/app/core/_models/response.model';
 import { SERV } from '@src/app/core/_services/main.config';
-import { Subscription } from 'rxjs';
 import { UIConfig } from '@src/app/core/_models/config-ui.model';
 import { UISettingsUtilityClass } from '@src/app/shared/utils/config';
 
@@ -234,7 +234,7 @@ export class HomeComponent implements OnInit, OnDestroy {
           backgroundColor: backgroundColor,
           visualMap: {
             min: 0,
-            max: 300,
+            max: Math.ceil(hashes.length / 10) * 10,
             type: 'piecewise',
             orient: 'horizontal',
             left: 'center',


### PR DESCRIPTION
*The number of cracks shown and filterable in the heat mat are now relative to the total number of cracks instead of a hard max value, for example if we have cracked 301 hashes the max value is rounded to 310 and shown in the heatmap.

*each total value is split in sorting stacks can be modified using "splitNumber: value" 