### PR TITLE
Removed unused hashes from request for report builder

### DIFF
--- a/src/app/core/_models/hashlist.model.ts
+++ b/src/app/core/_models/hashlist.model.ts
@@ -1,5 +1,6 @@
 import { BaseModel } from '@models/base.model';
 import { JHashtype } from '@models/hashtype.model';
+import { JTask } from './task.model';
 
 /**
  * Interface definition for a Hashlist
@@ -26,4 +27,5 @@ export interface JHashlist extends BaseModel {
   sourceType: string;
   sourceData: string;
   hashlists?: JHashlist[];
+  tasks?: JTask[];
 }

--- a/src/app/core/_models/hashlist.model.ts
+++ b/src/app/core/_models/hashlist.model.ts
@@ -1,6 +1,6 @@
 import { BaseModel } from '@models/base.model';
 import { JHashtype } from '@models/hashtype.model';
-import { JTask } from './task.model';
+import { JTask } from '@models/task.model';
 
 /**
  * Interface definition for a Hashlist

--- a/src/app/shared/report-builder/datasources/hashlists.datasource.ts
+++ b/src/app/shared/report-builder/datasources/hashlists.datasource.ts
@@ -1,13 +1,13 @@
 import { catchError, finalize, of } from 'rxjs';
 import { SERV } from 'src/app/core/_services/main.config';
 import { Hashlist } from 'src/app/hashlists/hashlist.model';
+import { ReportBaseDataSource } from 'src/app/shared/report-builder/datasources/base.datasource';
 
 import { JHashlist } from '@models/hashlist.model';
 import { JTask } from '@models/task.model';
 
 import { JsonAPISerializer } from '@services/api/serializer-service';
 
-import { ReportBaseDataSource } from 'src/app/shared/report-builder/datasources/base.datasource';
 
 export class HashlistReportDataSource extends ReportBaseDataSource<Hashlist> {
   private _hashlistId = 0;

--- a/src/app/shared/report-builder/datasources/hashlists.datasource.ts
+++ b/src/app/shared/report-builder/datasources/hashlists.datasource.ts
@@ -8,7 +8,6 @@ import { JTask } from '@models/task.model';
 
 import { JsonAPISerializer } from '@services/api/serializer-service';
 
-
 export class HashlistReportDataSource extends ReportBaseDataSource<Hashlist> {
   private _hashlistId = 0;
 

--- a/src/app/shared/report-builder/datasources/hashlists.datasource.ts
+++ b/src/app/shared/report-builder/datasources/hashlists.datasource.ts
@@ -20,7 +20,7 @@ export class HashlistReportDataSource extends ReportBaseDataSource<Hashlist> {
     this.loading = true;
 
     const hashList$ = this.service.get(SERV.HASHLISTS, this._hashlistId, {
-      include: ['accessGroup', 'tasks', 'hashes', 'hashType', 'hashlists']
+      include: ['accessGroup', 'tasks', 'hashType', 'hashlists']
     });
 
     this.subscriptions.push(

--- a/src/app/shared/report-builder/datasources/hashlists.datasource.ts
+++ b/src/app/shared/report-builder/datasources/hashlists.datasource.ts
@@ -7,7 +7,7 @@ import { JTask } from '@models/task.model';
 
 import { JsonAPISerializer } from '@services/api/serializer-service';
 
-import { ReportBaseDataSource } from '/app/src/app/shared/report-builder/datasources/base.datasource';
+import { ReportBaseDataSource } from 'src/app/shared/report-builder/datasources/base.datasource';
 
 export class HashlistReportDataSource extends ReportBaseDataSource<Hashlist> {
   private _hashlistId = 0;

--- a/src/app/shared/report-builder/datasources/hashlists.datasource.ts
+++ b/src/app/shared/report-builder/datasources/hashlists.datasource.ts
@@ -7,7 +7,7 @@ import { JTask } from '@models/task.model';
 
 import { JsonAPISerializer } from '@services/api/serializer-service';
 
-import { ReportBaseDataSource } from './base.datasource';
+import { ReportBaseDataSource } from '/app/src/app/shared/report-builder/datasources/base.datasource';
 
 export class HashlistReportDataSource extends ReportBaseDataSource<Hashlist> {
   private _hashlistId = 0;
@@ -43,7 +43,7 @@ export class HashlistReportDataSource extends ReportBaseDataSource<Hashlist> {
     this.loadAll();
   }
 
-  getReport(data: any) {
+  getReport(data: JHashlist) {
     let sum = 0;
     const workflow = [];
     let preCommand;


### PR DESCRIPTION
This pull request solves the problem where a network error can happen when you have a hashlist with a lot of hashes where the backend will crash.

The report builder will request all hashes even though it never uses these hashes so i could just safely remove it. If we do want to show the hashes in the report builder in the future we have to think about how to handle it. Because requesting all hashes can result in memory errors plus it will clutter the report anyway. 