### PR TITLE
Add Playwright E2E testing framework and initial tests for login and hashlist workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,16 +35,15 @@ jobs:
             **/*.js
             !**/*.spec.ts
 
-      - name: Run ESLint on changed files
+      - name: Run ESLint and Prettier on changed files
         if: steps.changed-files.outputs.all_changed_files != ''
         run: |
           FILES="${{ steps.changed-files.outputs.all_changed_files }}"
-          echo "Linting files: $FILES"
-          npx eslint $FILES
-
-      - name: Run Prettier check on changed files
-        if: steps.changed-files.outputs.all_changed_files != ''
-        run: echo "${{ steps.changed-files.outputs.all_changed_files }}" | tr ' ' '\n' | xargs npx prettier --check
+          eslint_exit=0
+          prettier_exit=0
+          npx eslint $FILES || eslint_exit=$?
+          echo "$FILES" | tr ' ' '\n' | xargs npx prettier --check || prettier_exit=$?
+          exit $((eslint_exit | prettier_exit))
 
   build:
     name: Run Tests & Build
@@ -69,3 +68,28 @@ jobs:
 
       - name: Build the project
         run: npm run build --if-present
+
+  e2e:
+    name: Playwright E2E Tests
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium webkit
+
+      - name: Run Playwright tests
+        run: npx playwright test
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,8 +87,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium webkit
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium webkit
 
       - name: Run Playwright tests
         run: npx playwright test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,11 +96,11 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium webkit
+        run: npx playwright install --with-deps chromium firefox webkit
 
       - name: Install Playwright system dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium webkit
+        run: npx playwright install-deps chromium firefox webkit
 
       - name: Run Playwright tests
         run: npx playwright test

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,11 @@ git-version.json
 # Config file
 config.json
 .devcontainer/.env
+
+# Playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
+# Claude code
+CLAUDE.md

--- a/angular.json
+++ b/angular.json
@@ -104,12 +104,18 @@
           "builder": "@angular/build:karma",
           "options": {
             "main": "src/test.ts",
-            "polyfills": ["src/polyfills.ts"],
+            "polyfills": [
+              "src/polyfills.ts"
+            ],
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "inlineStyleLanguage": "scss",
             "stylePreprocessorOptions": {
-              "includePaths": ["src/styles", "node_modules", "."]
+              "includePaths": [
+                "src/styles",
+                "node_modules",
+                "."
+              ]
             },
             "assets": [
               "src/styles/styles.scss"
@@ -130,6 +136,17 @@
               "src/**/*.ts",
               "src/**/*.html"
             ]
+          }
+        },
+        "e2e": {
+          "builder": "playwright-ng-schematics:playwright",
+          "options": {
+            "devServerTarget": "hashtopolis:serve"
+          },
+          "configurations": {
+            "production": {
+              "devServerTarget": "hashtopolis:serve:production"
+            }
           }
         }
       }

--- a/e2e/auth/auth-guard.spec.ts
+++ b/e2e/auth/auth-guard.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@playwright/test';
+
+test('redirects unauthenticated users to the login page', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page).toHaveURL(/#\/auth/);
+  await expect(page).toHaveTitle(/Hashtopolis/);
+});

--- a/e2e/auth/login.spec.ts
+++ b/e2e/auth/login.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test';
+
+import { mockLoginFlow } from '@e2e/support/api-mocks';
+
+test.describe('Login', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/#/auth/login');
+  });
+
+  test('shows the login form', async ({ page }) => {
+    await expect(page.getByTestId('username-input')).toBeVisible();
+    await expect(page.getByTestId('password-input')).toBeVisible();
+    await expect(page.getByTestId('submit-button')).toBeVisible();
+  });
+
+  test('shows validation errors when submitting empty form', async ({ page }) => {
+    await page.getByTestId('submit-button').click();
+
+    await expect(page.getByText('Username is required')).toBeVisible();
+    await expect(page.getByText('Password is required')).toBeVisible();
+  });
+
+  test('redirects to dashboard after successful login', async ({ page }) => {
+    await mockLoginFlow(page);
+    await page.goto('/#/auth/login');
+
+    await page.getByTestId('username-input').fill('e2e-test');
+    await page.getByTestId('password-input').fill('anypassword');
+    await page.getByTestId('submit-button').click();
+
+    await expect(page).not.toHaveURL(/#\/auth/);
+  });
+});

--- a/e2e/hashlists/hashlist-list.spec.ts
+++ b/e2e/hashlists/hashlist-list.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+import { mockHashlistsFlow } from '@e2e/support/api-mocks';
+
+test.describe('Hashlist list', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockHashlistsFlow(page);
+    await page.goto('/#/hashlists/hashlist');
+  });
+
+  test('shows the New Hashlist button', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'New Hashlist' })).toBeVisible();
+  });
+
+  test('navigates to the create form', async ({ page }) => {
+    await page.getByRole('button', { name: 'New Hashlist' }).click();
+    await expect(page).toHaveURL(/#\/hashlists\/new-hashlist/);
+  });
+});

--- a/e2e/hashlists/new-hashlist.spec.ts
+++ b/e2e/hashlists/new-hashlist.spec.ts
@@ -27,35 +27,28 @@ test.describe('New Hashlist form', () => {
   });
 
   test('creates a hashlist via paste and redirects to the list', async ({ page }) => {
-    // Wait for form dependencies to finish loading
-    await expect(page.getByPlaceholder('Hashtypes...')).toBeVisible();
+    await expect(page.getByTestId('hashtypes-input')).toBeVisible();
 
-    // Fill in the hashlist name
     await page.getByTestId('name-input').locator('input').fill('Test Hashlist');
 
-    // Select a hash type from the autocomplete
+    // Hashtypes Autocomplete
     await page.getByTestId('hashtypes-input').locator('input').fill('MD5');
     await page.getByRole('option', { name: /1 - MD5/ }).click();
 
-    // Select an access group.
-    // Use keyboard to open: mat-label overlays the select and blocks pointer events.
-    await page.getByTestId('access-group-select').locator('[role="combobox"]').press('Enter');
+    // Access Group Select (using role + force to bypass label overlays)
+    await page.getByTestId('access-group-select').locator('.mat-mdc-select-trigger').click({ force: true });
     await page.getByRole('option', { name: 'Default' }).click();
 
-    // Switch source type to paste — same keyboard pattern.
-    await page.getByTestId('hash-source-select').locator('[role="combobox"]').press('Enter');
+    // Source Type Select — focus the mat-select then open with Space to avoid CDK overlay conflicts.
+    await page.getByTestId('hash-source-select').locator('mat-select').focus();
+    await page.keyboard.press('Space');
     await page.getByRole('option', { name: 'Paste Hash(es)' }).click();
 
-    // Paste some hashes.
-    // Scoped via data-testid so the test does not break on label renames.
-    // force: true is required because cdkTextareaAutosize initialises with zero
-    // computed height in Firefox, making Playwright consider it not visible.
     await page
       .getByTestId('paste-hashes-input')
       .locator('textarea')
       .fill('5d41402abc4b2a76b9719d911017c592', { force: true });
 
-    // Submit and verify redirect
     await page.getByRole('button', { name: 'Create' }).click();
     await expect(page).toHaveURL(/#\/hashlists\/hashlist/, { timeout: 10_000 });
   });

--- a/e2e/hashlists/new-hashlist.spec.ts
+++ b/e2e/hashlists/new-hashlist.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+
+import { mockHashlistsFlow } from '@e2e/support/api-mocks';
+
+test.describe('New Hashlist form', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockHashlistsFlow(page);
+    await page.goto('/#/hashlists/new-hashlist');
+  });
+
+  test('shows the form fields after data loads', async ({ page }) => {
+    // Name is always present
+    await expect(page.getByTestId('name-input')).toBeVisible();
+    // Hashtype multiselect appears once hashtypes have loaded
+    await expect(page.getByTestId('hashtypes-input')).toBeVisible();
+    // Access group select
+    await expect(page.getByTestId('access-group-select')).toBeVisible();
+  });
+
+  test('shows validation errors when submitting empty form', async ({ page }) => {
+    // Default source type is "upload", which shows the testid submit button
+    await page.getByTestId('submit-button').click();
+
+    await expect(page.getByText('Name is required')).toBeVisible();
+    await expect(page.getByText('This field is required.')).toBeVisible();
+    await expect(page.getByText('Access group is required')).toBeVisible();
+  });
+
+  test('creates a hashlist via paste and redirects to the list', async ({ page }) => {
+    // Wait for form dependencies to finish loading
+    await expect(page.getByPlaceholder('Hashtypes...')).toBeVisible();
+
+    // Fill in the hashlist name
+    await page.getByTestId('name-input').locator('input').fill('Test Hashlist');
+
+    // Select a hash type from the autocomplete
+    await page.getByTestId('hashtypes-input').locator('input').fill('MD5');
+    await page.getByRole('option', { name: /1 - MD5/ }).click();
+
+    // Select an access group.
+    // Use keyboard to open: mat-label overlays the select and blocks pointer events.
+    await page.getByTestId('access-group-select').locator('[role="combobox"]').press('Enter');
+    await page.getByRole('option', { name: 'Default' }).click();
+
+    // Switch source type to paste — same keyboard pattern.
+    await page.getByTestId('hash-source-select').locator('[role="combobox"]').press('Enter');
+    await page.getByRole('option', { name: 'Paste Hash(es)' }).click();
+
+    // Paste some hashes.
+    // Scoped via data-testid so the test does not break on label renames.
+    // force: true is required because cdkTextareaAutosize initialises with zero
+    // computed height in Firefox, making Playwright consider it not visible.
+    await page
+      .getByTestId('paste-hashes-input')
+      .locator('textarea')
+      .fill('5d41402abc4b2a76b9719d911017c592', { force: true });
+
+    // Submit and verify redirect
+    await page.getByRole('button', { name: 'Create' }).click();
+    await expect(page).toHaveURL(/#\/hashlists\/hashlist/, { timeout: 10_000 });
+  });
+});

--- a/e2e/support/api-mocks.ts
+++ b/e2e/support/api-mocks.ts
@@ -70,30 +70,27 @@ function buildJsonApiItem(type: string, id: string, attributes: Record<string, u
  * @param permissions - Optional permission flags to seed into the permissions cache
  * @returns Resolves when the init script has been registered
  */
-export async function seedAuthStorage(
-  page: Page,
-  permissions: Record<string, boolean> = {}
-): Promise<void> {
-  await page.addInitScript(({ token, permissions }) => {
-    localStorage.setItem(
-      'userData',
-      JSON.stringify({
-        expires: 0,
-        value: {
-          _token: token,
-          _expires: new Date(9_999_999_999 * 1000).toISOString(),
-          userId: 1,
-          canonicalUsername: 'e2e-test'
-        }
-      })
-    );
-    if (Object.keys(permissions).length > 0) {
+export async function seedAuthStorage(page: Page, permissions: Record<string, boolean> = {}): Promise<void> {
+  await page.addInitScript(
+    ({ token, permissions }) => {
       localStorage.setItem(
-        'user_permissions',
-        JSON.stringify({ expires: 0, value: permissions })
+        'userData',
+        JSON.stringify({
+          expires: 0,
+          value: {
+            _token: token,
+            _expires: new Date(9_999_999_999 * 1000).toISOString(),
+            userId: 1,
+            canonicalUsername: 'e2e-test'
+          }
+        })
       );
-    }
-  }, { token: FAKE_JWT, permissions });
+      if (Object.keys(permissions).length > 0) {
+        localStorage.setItem('user_permissions', JSON.stringify({ expires: 0, value: permissions }));
+      }
+    },
+    { token: FAKE_JWT, permissions }
+  );
 }
 
 /**

--- a/e2e/support/api-mocks.ts
+++ b/e2e/support/api-mocks.ts
@@ -120,7 +120,7 @@ export async function mockLoginFlow(page: Page): Promise<void> {
     })
   );
 
-  // 1. Auth token — the primary login endpoint.
+  // Auth token — the primary login endpoint.
   await page.route('**/auth/token', (route) =>
     route.fulfill({
       status: 200,
@@ -129,7 +129,7 @@ export async function mockLoginFlow(page: Page): Promise<void> {
     })
   );
 
-  // 2. User permissions — loaded by PermissionService immediately after login.
+  // User permissions — loaded by PermissionService immediately after login.
   await page.route('**/helper/getUserPermission', (route) =>
     route.fulfill({
       status: 200,
@@ -166,7 +166,7 @@ export async function mockHashlistsFlow(page: Page): Promise<void> {
     permAccessGroupRead: true
   });
 
-  // Catch-all — lowest priority (registered first).
+  // Catch-all — lowest priority
   await page.route('**/api/v2/**', (route) =>
     route.fulfill({
       status: 200,
@@ -215,8 +215,8 @@ export async function mockHashlistsFlow(page: Page): Promise<void> {
     })
   );
 
-  // Access groups — populates the access group select on the create form.
-  await page.route('**/ui/accessgroups*', (route) =>
+  // Access groups — the create form loads these via the user relationship endpoint.
+  await page.route('**/ui/users/*/accessGroups*', (route) =>
     route.fulfill({
       status: 200,
       contentType: 'application/vnd.api+json',

--- a/e2e/support/api-mocks.ts
+++ b/e2e/support/api-mocks.ts
@@ -1,0 +1,255 @@
+import { Page } from '@playwright/test';
+
+/**
+ * Builds a syntactically valid JWT with a fake signature.
+ *
+ * The payload includes `userId` and `username` so that
+ * `getCanonicalUsernameFromJwt` returns a value and the app skips the
+ * secondary `/ui/users/{id}` fetch. The signature is intentionally fake —
+ * the app never verifies it client-side.
+ *
+ * @param userId - Numeric user ID to embed in the token payload
+ * @param username - Username string to embed in the token payload
+ * @returns A dot-separated JWT string with a fake signature segment
+ */
+function buildFakeJwt(userId = 1, username = 'e2e-test'): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ userId, username, exp: 9_999_999_999 })).toString('base64url');
+  return `${header}.${payload}.fakesig`;
+}
+
+/** Pre-built fake JWT used in E2E tests that require an authenticated session. */
+export const FAKE_JWT = buildFakeJwt();
+
+/**
+ * Builds a JSON:API collection response body.
+ *
+ * @param type - The JSON:API resource type string (e.g. `'HashTypes'`)
+ * @param items - Array of attribute objects; each becomes one resource object
+ * @returns Serialised JSON string ready to pass to `route.fulfill`
+ */
+function buildJsonApiList(type: string, items: Record<string, unknown>[]): string {
+  return JSON.stringify({
+    data: items.map((attributes, index) => ({
+      type,
+      id: String(index + 1),
+      attributes
+    })),
+    included: [],
+    meta: { page: { total_elements: items.length } },
+    links: { next: null, prev: null }
+  });
+}
+
+/**
+ * Builds a JSON:API single-resource response body.
+ *
+ * @param type - The JSON:API resource type string
+ * @param id - The string ID of the resource
+ * @param attributes - The attribute object for the resource
+ * @returns Serialised JSON string ready to pass to `route.fulfill`
+ */
+function buildJsonApiItem(type: string, id: string, attributes: Record<string, unknown>): string {
+  return JSON.stringify({ data: { type, id, attributes }, included: [] });
+}
+
+/**
+ * Injects a fake auth session into `localStorage` before the page loads so that
+ * tests can navigate directly to protected routes without going through the login form.
+ *
+ * @remarks
+ * Must be called before `page.goto()`. Uses `addInitScript` so the data is
+ * present before Angular's `autoLogin()` runs on every navigation.
+ *
+ * When `permissions` is provided it is written to the `user_permissions` cache
+ * key that `PermissionService` reads synchronously on startup. This eliminates
+ * the race condition between `CheckRole` running and the async
+ * `getUserPermission` HTTP call completing.
+ *
+ * @param page - The Playwright `Page` instance to inject the session into
+ * @param permissions - Optional permission flags to seed into the permissions cache
+ * @returns Resolves when the init script has been registered
+ */
+export async function seedAuthStorage(
+  page: Page,
+  permissions: Record<string, boolean> = {}
+): Promise<void> {
+  await page.addInitScript(({ token, permissions }) => {
+    localStorage.setItem(
+      'userData',
+      JSON.stringify({
+        expires: 0,
+        value: {
+          _token: token,
+          _expires: new Date(9_999_999_999 * 1000).toISOString(),
+          userId: 1,
+          canonicalUsername: 'e2e-test'
+        }
+      })
+    );
+    if (Object.keys(permissions).length > 0) {
+      localStorage.setItem(
+        'user_permissions',
+        JSON.stringify({ expires: 0, value: permissions })
+      );
+    }
+  }, { token: FAKE_JWT, permissions });
+}
+
+/**
+ * Registers Playwright route mocks for every API call made during the login flow.
+ *
+ * @remarks
+ * Call this before `page.goto()` in any test that submits the login form.
+ * A wildcard catch-all intercepts secondary API calls after redirect so the
+ * app does not throw on unanswered requests.
+ *
+ * @param page - The Playwright `Page` instance to register routes on
+ * @returns Resolves when all route handlers have been registered
+ */
+export async function mockLoginFlow(page: Page): Promise<void> {
+  // Wildcard catch-all registered first so specific handlers below take priority.
+  // Keeps the app from throwing on any secondary calls made after redirect.
+  await page.route('**/api/v2/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/vnd.api+json',
+      body: JSON.stringify({
+        data: [],
+        included: [],
+        meta: { page: { total_elements: 0 } },
+        links: { next: null, prev: null }
+      })
+    })
+  );
+
+  // 1. Auth token — the primary login endpoint.
+  await page.route('**/auth/token', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ token: FAKE_JWT, expires: 9_999_999_999 })
+    })
+  );
+
+  // 2. User permissions — loaded by PermissionService immediately after login.
+  await page.route('**/helper/getUserPermission', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/vnd.api+json',
+      body: JSON.stringify({
+        data: {
+          type: 'Helper',
+          id: '1',
+          attributes: { permissions: {} }
+        },
+        included: []
+      })
+    })
+  );
+}
+
+/**
+ * Registers route mocks and seeds auth storage for the hashlist section.
+ *
+ * @remarks
+ * Bypasses the login form by pre-populating `localStorage` via `seedAuthStorage`.
+ * Returns appropriate permissions so the `CheckRole` guard allows both the list
+ * and create routes. Also mocks the form dependencies (hashtypes, access groups,
+ * brain config) and the hashlist collection endpoint for GET and POST.
+ *
+ * @param page - The Playwright `Page` instance to configure
+ * @returns Resolves when all route handlers and the init script have been registered
+ */
+export async function mockHashlistsFlow(page: Page): Promise<void> {
+  await seedAuthStorage(page, {
+    permHashlistRead: true,
+    permHashlistCreate: true,
+    permHashTypeRead: true,
+    permAccessGroupRead: true
+  });
+
+  // Catch-all — lowest priority (registered first).
+  await page.route('**/api/v2/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/vnd.api+json',
+      body: JSON.stringify({
+        data: [],
+        included: [],
+        meta: { page: { total_elements: 0 } },
+        links: { next: null, prev: null }
+      })
+    })
+  );
+
+  // Permissions — grants read and create access to hashlists.
+  await page.route('**/helper/getUserPermission', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/vnd.api+json',
+      body: JSON.stringify({
+        data: {
+          type: 'Helper',
+          id: '1',
+          attributes: {
+            permissions: {
+              permHashlistRead: true,
+              permHashlistCreate: true,
+              permHashTypeRead: true,
+              permAccessGroupRead: true
+            }
+          }
+        },
+        included: []
+      })
+    })
+  );
+
+  // Hash types — populates the hashtype multiselect on the create form.
+  await page.route('**/ui/hashtypes*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/vnd.api+json',
+      body: buildJsonApiList('HashTypes', [
+        { description: 'MD5', isSalted: false },
+        { description: 'SHA1', isSalted: false }
+      ])
+    })
+  );
+
+  // Access groups — populates the access group select on the create form.
+  await page.route('**/ui/accessgroups*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/vnd.api+json',
+      body: buildJsonApiList('AccessGroups', [{ groupName: 'Default' }])
+    })
+  );
+
+  // Config 66 — the brain-enabled flag; 0 means disabled.
+  await page.route('**/ui/configs/66*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/vnd.api+json',
+      body: buildJsonApiItem('Configs', '66', { value: '0' })
+    })
+  );
+
+  // Hashlists — GET returns empty list; POST returns the newly created resource.
+  await page.route('**/ui/hashlists*', (route) => {
+    if (route.request().method() === 'POST') {
+      route.fulfill({
+        status: 201,
+        contentType: 'application/vnd.api+json',
+        body: buildJsonApiItem('HashLists', '1', { name: 'test', hashTypeId: 0 })
+      });
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/vnd.api+json',
+        body: buildJsonApiList('HashLists', [])
+      });
+    }
+  });
+}

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*.ts"]
+}

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "..",
+    "paths": {
+      "@e2e/*": ["./e2e/*"]
+    }
+  },
   "include": ["./**/*.ts"]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -127,6 +127,11 @@ export default defineConfig([
               pattern: '@src/**',
               group: 'sibling',
               position: 'after'
+            },
+            {
+              pattern: '@e2e/**',
+              group: 'internal',
+              position: 'after'
             }
           ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@eslint/compat": "^2.0.2",
         "@eslint/eslintrc": "^3.3.4",
         "@eslint/js": "^9.39.3",
+        "@playwright/test": "1.58.2",
         "@trivago/prettier-plugin-sort-imports": "^4.2.1",
         "@types/jasmine": "~4.3.5",
         "@types/node": "^20.5.0",
@@ -79,6 +80,7 @@
         "karma-jasmine-html-reporter": "~2.1.0",
         "karma-spec-reporter": "^0.0.36",
         "nodemon": "^3.0.1",
+        "playwright-ng-schematics": "^20.0.2",
         "prettier": "^3.0.3",
         "puppeteer": "^24.6.1",
         "typescript": "^5.9.3"
@@ -323,13 +325,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2003.18",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.18.tgz",
-      "integrity": "sha512-pPEDby3wQb40YSpH+UrjodJ78Z7q0Qvy3DTkS7mP2EIM4r0WVz8OlxLGS2uAc6tXSbIZe0bPp0B56P6uet3tUw==",
+      "version": "0.2003.22",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.22.tgz",
+      "integrity": "sha512-gxVOslVweD+Co6gpRVlByHus/3HVAnsl99MobS9PBh8vh2g6bJ011PBgl0TKsP/pqBGawZOkJXYrRPeMKnobYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.18",
+        "@angular-devkit/core": "20.3.22",
         "rxjs": "7.8.2"
       },
       "engines": {
@@ -339,16 +341,16 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "20.3.18",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.18.tgz",
-      "integrity": "sha512-zGWMjMqE8qXYr8baYCs43k9HlKz9J4Gh3Yx+7XE0uS0Y1LXzzALevSoUw7GIPdSvOriQJAEgtWE6QKssqSGltQ==",
+      "version": "20.3.22",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.22.tgz",
+      "integrity": "sha512-1vZnZTAjGcCM+86v2al+2eiROiSw0uAWeVllfHSQe0KsKOP1FE8UUUiWChhxVn7vIxypphlfGunkeeIn1C/ZFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
         "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.3",
+        "picomatch": "4.0.4",
         "rxjs": "7.8.2",
         "source-map": "0.7.6"
       },
@@ -367,13 +369,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "20.3.18",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.18.tgz",
-      "integrity": "sha512-GRMEGl3YTL/qhQhaxYXLbSQxUTPTYMQ65IlxLQRq5+UKPomN9KVxxVdADXqs7Ss1uQcetr+jc+taVgxOqsAoxg==",
+      "version": "20.3.22",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.22.tgz",
+      "integrity": "sha512-gN2XSXRn3eErGEJlH0iSfQZZ7NdxVZNdjSxuVEGBEFhe3cVeC21LzM3GTWW6xwtBb4pxHglFyc7BUFiYtZiYtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.18",
+        "@angular-devkit/core": "20.3.22",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "8.2.0",
@@ -583,14 +585,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "20.3.21",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.21.tgz",
-      "integrity": "sha512-jh9QqMPmAO4CLozGena08IPVnK95G7SwWKiVvMXVPQTxvPRfg8o0okmXvO55V2cMx/87H30AWMtRiNdE9Eoqfg==",
+      "version": "20.3.22",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.22.tgz",
+      "integrity": "sha512-sxjVZU6AZHXyKRHJUMawXOj4qMf3vm8XK6wUejr01UKj6BqW2YWaQO26RpRJssXD2ITTqn6+UBwL7pEwe2a4Jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2003.21",
+        "@angular-devkit/architect": "0.2003.22",
         "@babel/core": "7.28.3",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -606,7 +608,7 @@
         "magic-string": "0.30.17",
         "mrmime": "2.0.1",
         "parse5-html-rewriting-stream": "8.0.0",
-        "picomatch": "4.0.3",
+        "picomatch": "4.0.4",
         "piscina": "5.1.3",
         "rollup": "4.59.0",
         "sass": "1.90.0",
@@ -632,7 +634,7 @@
         "@angular/platform-browser": "^20.0.0",
         "@angular/platform-server": "^20.0.0",
         "@angular/service-worker": "^20.0.0",
-        "@angular/ssr": "^20.3.21",
+        "@angular/ssr": "^20.3.22",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^20.0.0",
@@ -681,50 +683,6 @@
         }
       }
     },
-    "node_modules/@angular/build/node_modules/@angular-devkit/architect": {
-      "version": "0.2003.21",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.21.tgz",
-      "integrity": "sha512-cdtiGFRW5Sgd8QkEAGw5daYT3Eh0hQtXFkUtnkU1HASpKrLdNLdfEUWho1y6A9bNlXL7fNVCvHOnK+G6Fd++rw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "20.3.21",
-        "rxjs": "7.8.2"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular/build/node_modules/@angular-devkit/core": {
-      "version": "20.3.21",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.21.tgz",
-      "integrity": "sha512-+flPAkPPn6MLVOa4ereSo6M5QRqxElKvDL6rCJWOJHRzH7K4CcfA269vr5mQSlImI5ZZc/EAPpm9rwEfWZRwew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.18.0",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.3",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@angular/build/node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -755,19 +713,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "20.3.18",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.18.tgz",
-      "integrity": "sha512-I0kanxt3vzedZmLY4FLoxgo3yGG1mWoiGLlzwEslJdLJj5X1zd422WPtTygZgEHFHcGxR9qxdQ+PsPdMRwykQA==",
+      "version": "20.3.22",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.22.tgz",
+      "integrity": "sha512-0uyQPF0gGuzioWJKNyOzWSQrrC5GiidR+8gz1lODoJTnJZZdsP5n3nvccbcRmhy55B1WByHvQBE+6eDBbh06/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2003.18",
-        "@angular-devkit/core": "20.3.18",
-        "@angular-devkit/schematics": "20.3.18",
+        "@angular-devkit/architect": "0.2003.22",
+        "@angular-devkit/core": "20.3.22",
+        "@angular-devkit/schematics": "20.3.22",
         "@inquirer/prompts": "7.8.2",
         "@listr2/prompt-adapter-inquirer": "3.0.1",
         "@modelcontextprotocol/sdk": "1.26.0",
-        "@schematics/angular": "20.3.18",
+        "@schematics/angular": "20.3.22",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.35.0",
         "ini": "5.0.0",
@@ -3488,9 +3446,9 @@
       }
     },
     "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3949,6 +3907,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -4461,14 +4435,14 @@
       "license": "MIT"
     },
     "node_modules/@schematics/angular": {
-      "version": "20.3.18",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.18.tgz",
-      "integrity": "sha512-JZdvBNrWODBTLrmtUF6+UD26z5cENpV0X9liR1jPDT1O7taQqwRePSuCQcjRo1qXCjlNfBW7pGGVxVCRKK8EXw==",
+      "version": "20.3.22",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.22.tgz",
+      "integrity": "sha512-wXTdFaPIBnSSNj/m0kclvPCYQOc2EGTQN1+Q3j9RIghS9gKgPxI1unSfgieJldZWKzcl8+WdB2zUuDzE7tEshQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.18",
-        "@angular-devkit/schematics": "20.3.18",
+        "@angular-devkit/core": "20.3.22",
+        "@angular-devkit/schematics": "20.3.22",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -5042,9 +5016,9 @@
       }
     },
     "node_modules/@tufjs/models/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5414,9 +5388,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5713,9 +5687,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6264,9 +6238,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6469,9 +6443,9 @@
       }
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9541,9 +9515,9 @@
       }
     },
     "node_modules/ignore-walk/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10811,9 +10785,9 @@
       "license": "MIT"
     },
     "node_modules/karma/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11326,7 +11300,6 @@
       "integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^4.0.0",
         "colorette": "^2.0.20",
@@ -12305,9 +12278,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12382,9 +12355,9 @@
       }
     },
     "node_modules/nodemon/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13126,9 +13099,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -13185,9 +13158,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -13217,6 +13190,70 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright-ng-schematics": {
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/playwright-ng-schematics/-/playwright-ng-schematics-20.0.2.tgz",
+      "integrity": "sha512-fiYCVE19REISlaHnl/vPcNDJ3tbpoMpHvA9Q1EPcce0jorFElVYQXK+qX5VavHWCOYQrc4fE4RnOBudMu8nEIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@angular-devkit/architect": ">= 0.2000.0 < 0.2100.0",
+        "@angular-devkit/core": "^20.0.0",
+        "@angular-devkit/schematics": "^20.0.0"
+      },
+      "peerDependencies": {
+        "@angular-devkit/architect": ">= 0.2000.0 < 0.2100.0",
+        "@angular-devkit/core": "^20.0.0",
+        "@angular-devkit/schematics": "^20.0.0"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/png-js": {
@@ -13594,9 +13631,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -15530,7 +15567,6 @@
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:ci": "ng build --configuration production",
     "format": "npx prettier 'src/**/*.{js,jsx,ts,tsx,html,css,scss}' --write",
     "lint": "ng lint",
-    "clean": "rm -rf package-lock.json npm-shrinkwrap.json node_modules;npm cache clean --force;npm cache verify"
+    "clean": "rm -rf package-lock.json npm-shrinkwrap.json node_modules;npm cache clean --force;npm cache verify",
+    "e2e": "ng e2e"
   },
   "private": true,
   "dependencies": {
@@ -71,6 +72,7 @@
     "@eslint/compat": "^2.0.2",
     "@eslint/eslintrc": "^3.3.4",
     "@eslint/js": "^9.39.3",
+    "@playwright/test": "1.58.2",
     "@trivago/prettier-plugin-sort-imports": "^4.2.1",
     "@types/jasmine": "~4.3.5",
     "@types/node": "^20.5.0",
@@ -90,6 +92,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "karma-spec-reporter": "^0.0.36",
     "nodemon": "^3.0.1",
+    "playwright-ng-schematics": "^20.0.2",
     "prettier": "^3.0.3",
     "puppeteer": "^24.6.1",
     "typescript": "^5.9.3"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env['CI'],
+  /* Retry on CI only */
+  retries: process.env['CI'] ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env['CI'] ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: process.env['CI'] ? [['github'], ['list']] : 'list',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env['PLAYWRIGHT_TEST_BASE_URL'] ?? 'http://localhost:4200',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry'
+  },
+
+  /* Start the Angular dev server automatically before running tests. */
+  webServer: {
+    command: 'node git-version.js && ng serve',
+    url: 'http://localhost:4200',
+    /* Reuse an already-running server locally; always start fresh in CI. */
+    reuseExistingServer: !process.env['CI'],
+    timeout: 120_000
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] }
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] }
+    }
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ]
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
   forbidOnly: !!process.env['CI'],
   /* Retry on CI only */
   retries: process.env['CI'] ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env['CI'] ? 1 : undefined,
+  /* Use 4 workers in CI — tests are network-mock-bound, not CPU-bound. */
+  workers: process.env['CI'] ? 8 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env['CI'] ? [['github'], ['list']] : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/src/app/auth/auth.component.html
+++ b/src/app/auth/auth.component.html
@@ -24,6 +24,7 @@
             placeholder="User Name"
             formControlName="username"
             aria-describedby="username-error"
+            data-testid="username-input"
             />
           @if (loginForm.controls['username'].errors?.required) {
             <mat-error>Username is required</mat-error>
@@ -40,6 +41,7 @@
             formControlName="password"
             (keydown.enter)="$event.preventDefault(); onSubmit()"
             aria-describedby="password-error"
+            data-testid="password-input"
             />
           <button
             mat-icon-button

--- a/src/app/hashlists/new-hashlist/new-hashlist.component.html
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.html
@@ -5,7 +5,7 @@
   <form [formGroup]="form" (ngSubmit)="onSubmit()">
 
     <div class="flex flex-wrap items-center gap-2">
-      <input-text title="Name" formControlName="name" [isRequired]="true"></input-text>
+      <input-text title="Name" formControlName="name" [isRequired]="true" data-testid="name-input"></input-text>
     </div>
 
     @if (!isLoadingHashtypes) {
@@ -19,6 +19,7 @@
           formControlName="hashTypeId"
           [multiselectEnabled]="false"
           [mergeIdAndName]="true"
+          data-testid="hashtypes-input"
         ></input-multiselect>
         <button mat-icon-button matTooltip="Help" (click)="openHelpDialog()">
           <mat-icon>help</mat-icon>
@@ -34,7 +35,7 @@
     <input-text-area title="Notes" formControlName="notes"></input-text-area>
 
     <div class="flex flex-wrap items-center gap-2">
-      <input-select title="Access group" formControlName="accessGroupId" [items]="selectAccessgroup" [isRequired]="true"></input-select>
+      <input-select title="Access group" formControlName="accessGroupId" [items]="selectAccessgroup" [isRequired]="true" data-testid="access-group-select"></input-select>
       <input-select title="Hashlist format" formControlName="format" [items]="selectFormat"></input-select>
     </div>
 
@@ -63,7 +64,7 @@
 
     <div class="flex flex-wrap items-center gap-2">
       <div class="flex flex-col">
-        <input-select title="Hash Source" formControlName="sourceType" [items]="selectSource"></input-select>
+        <input-select title="Hash Source" formControlName="sourceType" [items]="selectSource" data-testid="hash-source-select"></input-select>
       </div>
       <div class="flex flex-col" style="position: relative; top: -10px;">
         <input-check title="Secret Data" formControlName="isSecret"></input-check>
@@ -72,7 +73,7 @@
 
     @if (sourceType === 'paste') {
       <div>
-        <input-text-area title="Paste Hash(es)" formControlName="sourceData"></input-text-area>
+        <input-text-area title="Paste Hash(es)" formControlName="sourceData" data-testid="paste-hashes-input"></input-text-area>
         <grid-buttons>
           <button-submit name="Cancel" [disabled]="false" type="cancel"></button-submit>
           <button-submit [name]="'Create'"></button-submit>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,9 @@
       ],
       "@interceptors/*": [
         "./src/app/core/_interceptors/*"
+      ],
+      "@e2e/*": [
+        "./e2e/*"
       ]
     },
     "outDir": "./dist/out-tsc",


### PR DESCRIPTION
- Add Playwright configuration and test infrastructure
- Add initial tests for login and hashlist workflow
- Add data-testid attributes to auth and hashlist components for test targeting
- Update ESLint config to support @e2e path alias
- Update angular.json test configuration
- Add Playwright output directories to .gitignore
- Add CI job for E2E tests
- Change Prettier CI job to run even if ESLint errors out