### PR TITLE
Fix default sort parameter not being sent to backend

### DIFF
--- a/src/app/core/_models/config-ui.model.ts
+++ b/src/app/core/_models/config-ui.model.ts
@@ -113,7 +113,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: NotificationsTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -125,7 +125,7 @@ const _uiConfigDefault = {
       columns: [VouchersTableCol.ID, VouchersTableCol.KEY, VouchersTableCol.CREATED],
       order: {
         id: VouchersTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -136,8 +136,8 @@ const _uiConfigDefault = {
       page: 25,
       columns: [PermissionsTableCol.ID, PermissionsTableCol.NAME, PermissionsTableCol.MEMBERS],
       order: {
-        id: PermissionsTableCol.ID,
-        dataKey: '',
+        id: PermissionsTableCol.NAME,
+        dataKey: 'name',
         isSortable: true,
         direction: 'asc'
       },
@@ -177,7 +177,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: AgentsTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -196,7 +196,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: AgentErrorTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -219,7 +219,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: AgentsStatusTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -241,7 +241,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: TasksAgentsTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -263,7 +263,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: ChunksTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -282,7 +282,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: HashlistsTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -300,7 +300,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: HashlistsTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -318,7 +318,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: SuperHashlistsTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -335,7 +335,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: HashtypesTableCol.HASHTYPE,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -353,7 +353,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: FilesTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -371,7 +371,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: FilesTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -389,7 +389,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: FilesTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -407,7 +407,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: FilesTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -419,7 +419,7 @@ const _uiConfigDefault = {
       columns: [FilesTableCol.ID, FilesTableCol.NAME, FilesTableCol.SIZE, FilesTableCol.LINE_COUNT],
       order: {
         id: FilesTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -431,7 +431,7 @@ const _uiConfigDefault = {
       columns: [FilesAttackTableCol.ID, FilesAttackTableCol.NAME, FilesAttackTableCol.SIZE],
       order: {
         id: FilesAttackTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -443,7 +443,7 @@ const _uiConfigDefault = {
       columns: [CrackersTableCol.ID, CrackersTableCol.TYPE, CrackersTableCol.VERSIONS],
       order: {
         id: CrackersTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -455,7 +455,7 @@ const _uiConfigDefault = {
       columns: [PreprocessorsTableCol.ID, PreprocessorsTableCol.NAME],
       order: {
         id: PreprocessorsTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -474,7 +474,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: AgentBinariesTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -491,7 +491,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: HealthChecksTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -510,7 +510,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: HealthCheckAgentsTableCol.AGENT_ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -530,7 +530,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: PretasksTableCol.PRIORITY,
-        dataKey: '',
+        dataKey: 'priority',
         isSortable: true,
         direction: 'asc'
       },
@@ -575,7 +575,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: TasksChunksTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -595,7 +595,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: TasksSupertasksDataSourceTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -607,7 +607,7 @@ const _uiConfigDefault = {
       columns: [SupertasksTableCol.ID, SupertasksTableCol.NAME, SupertasksTableCol.PRETASKS],
       order: {
         id: SupertasksTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -624,7 +624,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: SupertasksPretasksTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -645,7 +645,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: PretasksTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -657,7 +657,7 @@ const _uiConfigDefault = {
       columns: [TaskTableCol.ID, TaskTableCol.NAME, TaskTableCol.DISPATCHED_SEARCHED, TaskTableCol.CRACKED],
       order: {
         id: TaskTableCol.ID,
-        dataKey: '',
+        dataKey: 'taskWrapperId',
         isSortable: true,
         direction: 'asc'
       },
@@ -676,7 +676,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: HashesTableCol.TIMECRACKED,
-        dataKey: '',
+        dataKey: 'timeCracked',
         isSortable: true,
         direction: 'asc'
       },
@@ -693,7 +693,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: SearchHashTableCol.HASH,
-        dataKey: '',
+        dataKey: 'hash',
         isSortable: true,
         direction: 'asc'
       },
@@ -714,7 +714,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: UsersTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -726,7 +726,7 @@ const _uiConfigDefault = {
       columns: [LogsTableCol.ID, LogsTableCol.ISSUER, LogsTableCol.LEVEL, LogsTableCol.MESSAGE, LogsTableCol.TIME],
       order: {
         id: LogsTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -743,7 +743,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: AccessGroupsTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -755,7 +755,7 @@ const _uiConfigDefault = {
       columns: [AccessGroupsUsersTableCol.ID, AccessGroupsUsersTableCol.NAME, AccessGroupsUsersTableCol.STATUS],
       order: {
         id: AccessGroupsUsersTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -773,7 +773,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: AccessPermissionGroupsUserTableCol.NAME,
-        dataKey: '',
+        dataKey: 'name',
         isSortable: true,
         direction: 'asc'
       },
@@ -790,7 +790,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: AccessPermissionGroupsUsersTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },
@@ -802,7 +802,7 @@ const _uiConfigDefault = {
       columns: [AccessGroupsAgentsTableCol.ID, AccessGroupsAgentsTableCol.NAME],
       order: {
         id: AccessGroupsAgentsTableCol.ID,
-        dataKey: '',
+        dataKey: 'id',
         isSortable: true,
         direction: 'asc'
       },

--- a/src/app/core/_models/config-ui.model.ts
+++ b/src/app/core/_models/config-ui.model.ts
@@ -554,7 +554,7 @@ const _uiConfigDefault = {
       ],
       order: {
         id: TaskTableCol.PRIORITY,
-        dataKey: '',
+        dataKey: 'priority',
         isSortable: true,
         direction: 'desc'
       },

--- a/src/app/core/_services/params/builder-implementation.service.spec.ts
+++ b/src/app/core/_services/params/builder-implementation.service.spec.ts
@@ -1,0 +1,128 @@
+import { RequestParamBuilder } from './builder-implementation.service';
+import { setParameter } from '@src/app/core/_services/buildparams';
+import { uiConfigDefault, TableConfig } from '@models/config-ui.model';
+import { SortingColumn } from '@components/tables/ht-table/ht-table.models';
+
+function isTableConfig(value: number[] | TableConfig): value is TableConfig {
+  return !Array.isArray(value) && typeof value === 'object' && 'order' in value;
+}
+
+/**
+ * Collects all tables from uiConfigDefault that have a single sort `order`
+ * object (not an array). This covers the standard case used by most tables.
+ */
+function getTablesWithSortOrder(): Array<{ name: string; config: TableConfig }> {
+  return Object.entries(uiConfigDefault.tableSettings)
+    .filter(([, cfg]) => isTableConfig(cfg) && !Array.isArray(cfg.order))
+    .map(([name, cfg]) => ({ name, config: cfg as TableConfig }));
+}
+
+describe('RequestParamBuilder – default sort serialization', () => {
+  // ── 1. Sanity checks on uiConfigDefault ─────────────────────────────
+
+  describe('uiConfigDefault table orders', () => {
+    const tables = getTablesWithSortOrder();
+
+    tables.forEach(({ name, config }) => {
+      it(`${name}: dataKey should be non-empty`, () => {
+        const order = config.order as SortingColumn;
+        expect(order.dataKey).toBeTruthy();
+      });
+
+      it(`${name}: isSortable should be true`, () => {
+        const order = config.order as SortingColumn;
+        expect(order.isSortable).toBe(true);
+      });
+    });
+  });
+
+  // ── 2. Builder output (addSorting → create → params.sort) ──────────
+
+  describe('addSorting + create', () => {
+    const tables = getTablesWithSortOrder();
+
+    tables.forEach(({ name, config }) => {
+      it(`${name}: produces correct sort string`, () => {
+        const order = config.order as SortingColumn;
+        const params = new RequestParamBuilder().addSorting(order).create();
+
+        const prefix = order.direction === 'asc' ? '' : '-';
+        expect(params.sort).toEqual([`${prefix}${order.dataKey}`]);
+      });
+    });
+
+    it('tasksTable: sorts by -priority (descending)', () => {
+      const order = (uiConfigDefault.tableSettings.tasksTable as TableConfig).order as SortingColumn;
+      const params = new RequestParamBuilder().addSorting(order).create();
+      expect(params.sort).toEqual(['-priority']);
+    });
+
+    it('cracksTable: sorts by -timeCracked (descending)', () => {
+      const order = (uiConfigDefault.tableSettings.cracksTable as TableConfig).order as SortingColumn;
+      const params = new RequestParamBuilder().addSorting(order).create();
+      expect(params.sort).toEqual(['-timeCracked']);
+    });
+  });
+
+  // ── 3. End-to-end through setParameter → HttpParams ────────────────
+
+  describe('setParameter produces correct HttpParams', () => {
+    const tables = getTablesWithSortOrder();
+
+    tables.forEach(({ name, config }) => {
+      it(`${name}: httpParams.get('sort') matches expected value`, () => {
+        const order = config.order as SortingColumn;
+        const params = new RequestParamBuilder().addSorting(order).create();
+        const httpParams = setParameter(params);
+
+        const prefix = order.direction === 'asc' ? '' : '-';
+        expect(httpParams.get('sort')).toBe(`${prefix}${order.dataKey}`);
+      });
+    });
+  });
+
+  // ── 4. Regression guards ───────────────────────────────────────────
+
+  describe('regression: empty dataKey or isSortable=false skips sorting', () => {
+    it('empty dataKey produces no sort param', () => {
+      const column: SortingColumn = {
+        dataKey: '',
+        isSortable: true,
+        direction: 'asc'
+      };
+      const params = new RequestParamBuilder().addSorting(column).create();
+      expect(params.sort).toBeUndefined();
+    });
+
+    it('isSortable=false produces no sort param', () => {
+      const column: SortingColumn = {
+        dataKey: 'id',
+        isSortable: false,
+        direction: 'asc'
+      };
+      const params = new RequestParamBuilder().addSorting(column).create();
+      expect(params.sort).toBeUndefined();
+    });
+
+    it('empty dataKey + isSortable=false produces no sort param', () => {
+      const column: SortingColumn = {
+        dataKey: '',
+        isSortable: false,
+        direction: 'asc'
+      };
+      const params = new RequestParamBuilder().addSorting(column).create();
+      expect(params.sort).toBeUndefined();
+    });
+
+    it('empty dataKey produces no sort in HttpParams', () => {
+      const column: SortingColumn = {
+        dataKey: '',
+        isSortable: true,
+        direction: 'asc'
+      };
+      const params = new RequestParamBuilder().addSorting(column).create();
+      const httpParams = setParameter(params);
+      expect(httpParams.has('sort')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
https://github.com/hashtopolis/server/issues/2010

This does not seem like a regression but has probably been present for quite some time.
With empty local storage in most tables nothing regarding sort parameter is sent to the backend.
I tried adding most defaults but certain pages do not seem to allow sorting by some of the parameters (for example global permissions somehow do not allow id as sort parameter even though they are sorted by default by id).

This requires a bit larger rework, created an issue for that:  https://github.com/hashtopolis/server/issues/2013

Also introduced that the defaults are sent for every other table. Switched global permissions default filtering in global permissions from id to name as ordering by id does not seem to work. 