### PR TITLE
Add stale-while-revalidate HTTP cache with auto-refresh fixes and quota handling

### DIFF
--- a/src/app/core/_components/tables/ht-table/ht-table.component.ts
+++ b/src/app/core/_components/tables/ht-table/ht-table.component.ts
@@ -602,7 +602,7 @@ export class HTTableComponent implements OnInit, AfterViewInit, OnDestroy {
     this.dataSource.pageBefore = tableSettings['before'];
     this.dataSource.index = tableSettings['index'];
     // Note: totalItems is NOT restored from localStorage as it should always come from the API response
-    this.dataSource.reload();
+    this.dataSource.forceReload();
     if (this.bulkMenu) {
       this.bulkMenu.reload();
     }

--- a/src/app/core/_datasources/base.datasource.ts
+++ b/src/app/core/_datasources/base.datasource.ts
@@ -14,6 +14,7 @@ import { JsonAPISerializer } from '@services/api/serializer-service';
 import { GlobalService } from '@services/main.service';
 import { IParamBuilder } from '@services/params/builder-types.service';
 import { PermissionService } from '@services/permission/permission.service';
+import { HttpCacheService } from '@services/shared/http-cache.service';
 import { AutoRefreshService } from '@services/shared/refresh/auto-refresh.service';
 import { UIConfigService } from '@services/shared/storage.service';
 import { LocalStorageService } from '@services/storage/local-storage.service';
@@ -97,7 +98,11 @@ export abstract class BaseDataSource<T, P extends MatPaginator = MatPaginator> i
   protected permissionService: PermissionService;
   public util: UISettingsUtilityClass;
   autoRefreshService: AutoRefreshService;
+  private cacheService: HttpCacheService;
   private autoRefreshSubscription: Subscription;
+  /** Cursor that was used to load the currently displayed page, restored before each auto-refresh reload. */
+  private _refreshPageAfter: number | string | null | undefined = undefined;
+  private _refreshPageBefore: number | string | null | undefined = undefined;
 
   // eslint-disable-next-line @angular-eslint/prefer-inject
   constructor(protected injector: Injector) {
@@ -107,6 +112,7 @@ export abstract class BaseDataSource<T, P extends MatPaginator = MatPaginator> i
     this.permissionService = injector.get(PermissionService);
     this.serializer = new JsonAPISerializer();
     this.autoRefreshService = injector.get(AutoRefreshService);
+    this.cacheService = injector.get(HttpCacheService);
 
     const chunktime = this.uiService.getUISettings()?.chunktime;
     if (chunktime !== undefined) {
@@ -356,6 +362,10 @@ export abstract class BaseDataSource<T, P extends MatPaginator = MatPaginator> i
     pageBefore: number | string | null,
     index: number
   ): void {
+    // Capture the cursors that were actually used to load this page before overwriting with the
+    // next/prev page cursors returned by the API. Auto-refresh uses these to reload the same page.
+    this._refreshPageAfter = this.pageAfter;
+    this._refreshPageBefore = this.pageBefore;
     this.pageSize = pageSize;
     this.totalItems = totalItems;
     this.pageAfter = pageAfter;
@@ -389,6 +399,16 @@ export abstract class BaseDataSource<T, P extends MatPaginator = MatPaginator> i
   }
 
   abstract reload(): void;
+
+  /**
+   * Invalidates the HTTP cache and reloads the current page.
+   * Use this for explicit user-initiated reloads (e.g. the reload button) so the
+   * response is always fetched from the network rather than served from cache.
+   */
+  forceReload(): void {
+    this.cacheService.invalidate();
+    this.reload();
+  }
 
   /**
    * Convert all JChunk objects related to a task or agent to a ChunkData object
@@ -460,6 +480,9 @@ export abstract class BaseDataSource<T, P extends MatPaginator = MatPaginator> i
     this.autoRefreshEnabled = flag; // Keep the flag in sync
     this.autoRefreshService.toggleAutoRefresh(flag, { immediate: true });
     this.autoRefreshSubscription = this.autoRefreshService.refresh$.subscribe(() => {
+      this.cacheService.invalidate();
+      this.pageAfter = this._refreshPageAfter;
+      this.pageBefore = this._refreshPageBefore;
       this.reload();
     });
   }
@@ -486,6 +509,9 @@ export abstract class BaseDataSource<T, P extends MatPaginator = MatPaginator> i
     this.autoRefreshEnabled = true; // Keep the flag in sync
     this.autoRefreshService.startAutoRefresh({ immediate: false });
     this.autoRefreshSubscription = this.autoRefreshService.refresh$.subscribe(() => {
+      this.cacheService.invalidate();
+      this.pageAfter = this._refreshPageAfter;
+      this.pageBefore = this._refreshPageBefore;
       this.reload();
     });
   }

--- a/src/app/core/_interceptors/http-cache.interceptor.spec.ts
+++ b/src/app/core/_interceptors/http-cache.interceptor.spec.ts
@@ -7,7 +7,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { CacheGetResult, HttpCacheService } from '@services/shared/http-cache.service';
 import { SessionStorageService } from '@services/storage/session-storage.service';
-import { DEFAULT_STALE_TIME_MS } from './http-cache.interceptor';
+import { DEFAULT_STALE_TIME_MS, DEFAULT_TTL_MS } from './http-cache.interceptor';
 
 describe('HttpCacheInterceptor', () => {
   let httpClient: HttpClient;
@@ -207,7 +207,7 @@ describe('HttpCacheInterceptor', () => {
       const req = httpMock.expectOne(testUrl);
       req.flush({ ok: true });
 
-      expect(setSpy).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), 30_000, DEFAULT_);
+      expect(setSpy).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), DEFAULT_TTL_MS, DEFAULT_STALE_TIME_MS);
     });
 
     it('should not cache when Cache-Control: no-store is present', () => {

--- a/src/app/core/_interceptors/http-cache.interceptor.spec.ts
+++ b/src/app/core/_interceptors/http-cache.interceptor.spec.ts
@@ -178,6 +178,86 @@ describe('HttpCacheInterceptor', () => {
     firstReq.flush(testData);
   });
 
+  describe('Cache-Control header (RFC 5861)', () => {
+    let cacheService: HttpCacheService;
+
+    beforeEach(() => {
+      cacheService = TestBed.inject(HttpCacheService);
+    });
+
+    it('should use max-age and stale-while-revalidate from response headers', () => {
+      const testUrl = 'https://api.test.com/data';
+      const setSpy = spyOn(cacheService, 'set').and.callThrough();
+
+      httpClient.get(testUrl).subscribe();
+
+      const req = httpMock.expectOne(testUrl);
+      req.flush({ ok: true }, { headers: { 'Cache-Control': 'max-age=10, stale-while-revalidate=20' } });
+
+      expect(setSpy).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), 10_000, 20_000);
+    });
+
+    it('should fall back to defaults when Cache-Control header is absent', () => {
+      const testUrl = 'https://api.test.com/data';
+      const setSpy = spyOn(cacheService, 'set').and.callThrough();
+
+      httpClient.get(testUrl).subscribe();
+
+      const req = httpMock.expectOne(testUrl);
+      req.flush({ ok: true });
+
+      expect(setSpy).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), 30_000, 60_000);
+    });
+
+    it('should not cache when Cache-Control: no-store is present', () => {
+      const testUrl = 'https://api.test.com/data';
+      const setSpy = spyOn(cacheService, 'set');
+
+      httpClient.get(testUrl).subscribe();
+
+      const req = httpMock.expectOne(testUrl);
+      req.flush({ ok: true }, { headers: { 'Cache-Control': 'no-store' } });
+
+      expect(setSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not cache when Cache-Control: no-cache is present', () => {
+      const testUrl = 'https://api.test.com/data';
+      const setSpy = spyOn(cacheService, 'set');
+
+      httpClient.get(testUrl).subscribe();
+
+      const req = httpMock.expectOne(testUrl);
+      req.flush({ ok: true }, { headers: { 'Cache-Control': 'no-cache' } });
+
+      expect(setSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not cache when Cache-Control: private is present', () => {
+      const testUrl = 'https://api.test.com/data';
+      const setSpy = spyOn(cacheService, 'set');
+
+      httpClient.get(testUrl).subscribe();
+
+      const req = httpMock.expectOne(testUrl);
+      req.flush({ ok: true }, { headers: { 'Cache-Control': 'private' } });
+
+      expect(setSpy).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to default stale window when only max-age is present', () => {
+      const testUrl = 'https://api.test.com/data';
+      const setSpy = spyOn(cacheService, 'set').and.callThrough();
+
+      httpClient.get(testUrl).subscribe();
+
+      const req = httpMock.expectOne(testUrl);
+      req.flush({ ok: true }, { headers: { 'Cache-Control': 'max-age=5' } });
+
+      expect(setSpy).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), 5_000, 60_000);
+    });
+  });
+
   describe('stale-while-revalidate', () => {
     let cacheService: HttpCacheService;
 

--- a/src/app/core/_interceptors/http-cache.interceptor.spec.ts
+++ b/src/app/core/_interceptors/http-cache.interceptor.spec.ts
@@ -1,11 +1,11 @@
 import { HttpCacheInterceptor } from '@interceptors/http-cache.interceptor';
 
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpResponse } from '@angular/common/http';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { HttpCacheService } from '@services/shared/http-cache.service';
+import { CacheGetResult, HttpCacheService } from '@services/shared/http-cache.service';
 import { SessionStorageService } from '@services/storage/session-storage.service';
 
 describe('HttpCacheInterceptor', () => {
@@ -176,5 +176,66 @@ describe('HttpCacheInterceptor', () => {
 
     const firstReq = httpMock.expectOne(testUrl);
     firstReq.flush(testData);
+  });
+
+  describe('stale-while-revalidate', () => {
+    let cacheService: HttpCacheService;
+
+    beforeEach(() => {
+      cacheService = TestBed.inject(HttpCacheService);
+    });
+
+    it('should serve a stale response immediately and trigger a background revalidation', () => {
+      const testUrl = 'https://api.test.com/data';
+      const staleData = { id: 1, name: 'Stale' };
+      const freshData = { id: 1, name: 'Fresh' };
+
+      // Seed the cache with a stale entry by manipulating the service directly
+      const staleResult: CacheGetResult = {
+        response: new HttpResponse({
+          body: staleData,
+          status: 200,
+          statusText: 'OK'
+        }),
+        isStale: true
+      };
+      spyOn(cacheService, 'get').and.returnValue(staleResult);
+      const setSpy = spyOn(cacheService, 'set').and.callThrough();
+
+      let receivedData: unknown;
+      httpClient.get(testUrl).subscribe((data) => {
+        receivedData = data;
+      });
+
+      // The stale response should be returned synchronously without any network request for the caller
+      expect(receivedData).toEqual(staleData);
+
+      // A background revalidation request must have been fired
+      const revalidationReq = httpMock.expectOne(testUrl);
+      revalidationReq.flush(freshData);
+
+      // The background response should update the cache
+      expect(setSpy).toHaveBeenCalled();
+    });
+
+    it('should not trigger a background revalidation for a fresh cache hit', () => {
+      const testUrl = 'https://api.test.com/data';
+      const cachedData = { id: 1, name: 'Fresh' };
+
+      const freshResult: CacheGetResult = {
+        response: new HttpResponse({
+          body: cachedData,
+          status: 200,
+          statusText: 'OK'
+        }),
+        isStale: false
+      };
+      spyOn(cacheService, 'get').and.returnValue(freshResult);
+
+      httpClient.get(testUrl).subscribe();
+
+      // No network request should be made for a fresh hit
+      httpMock.expectNone(testUrl);
+    });
   });
 });

--- a/src/app/core/_interceptors/http-cache.interceptor.spec.ts
+++ b/src/app/core/_interceptors/http-cache.interceptor.spec.ts
@@ -7,6 +7,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { CacheGetResult, HttpCacheService } from '@services/shared/http-cache.service';
 import { SessionStorageService } from '@services/storage/session-storage.service';
+import { DEFAULT_STALE_TIME_MS } from './http-cache.interceptor';
 
 describe('HttpCacheInterceptor', () => {
   let httpClient: HttpClient;
@@ -206,7 +207,7 @@ describe('HttpCacheInterceptor', () => {
       const req = httpMock.expectOne(testUrl);
       req.flush({ ok: true });
 
-      expect(setSpy).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), 30_000, 60_000);
+      expect(setSpy).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), 30_000, DEFAULT_);
     });
 
     it('should not cache when Cache-Control: no-store is present', () => {
@@ -254,7 +255,7 @@ describe('HttpCacheInterceptor', () => {
       const req = httpMock.expectOne(testUrl);
       req.flush({ ok: true }, { headers: { 'Cache-Control': 'max-age=5' } });
 
-      expect(setSpy).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), 5_000, 60_000);
+      expect(setSpy).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), 5_000, DEFAULT_STALE_TIME_MS);
     });
   });
 

--- a/src/app/core/_interceptors/http-cache.interceptor.ts
+++ b/src/app/core/_interceptors/http-cache.interceptor.ts
@@ -9,7 +9,9 @@ import { HttpCacheService } from '@services/shared/http-cache.service';
  * HTTP cache interceptor implementing a stale-while-revalidate strategy.
  *
  * @remarks
- * - GET responses are cached with a short TTL and a longer stale window.
+ * - GET responses are cached using TTL and stale window values sourced from the
+ *   response `Cache-Control` header (`max-age`, `stale-while-revalidate` per RFC 5861).
+ *   When these directives are absent, hardcoded defaults are used.
  * - While the entry is fresh, the cached response is returned immediately.
  * - While the entry is stale (TTL elapsed but within the stale window), the cached
  *   response is returned immediately **and** a background revalidation request is fired
@@ -48,7 +50,8 @@ export class HttpCacheInterceptor implements HttpInterceptor {
     return next.handle(req).pipe(
       tap((event) => {
         if (event instanceof HttpResponse) {
-          this.cache.set(req, event, this.defaultTtlMs, this.defaultStaleWindowMs);
+          const ttl = this.resolveCacheTtl(event);
+          if (ttl) this.cache.set(req, event, ttl.ttlMs, ttl.staleWindowMs);
         }
       })
     );
@@ -66,11 +69,67 @@ export class HttpCacheInterceptor implements HttpInterceptor {
       .pipe(
         tap((event) => {
           if (event instanceof HttpResponse) {
-            this.cache.set(req, event, this.defaultTtlMs, this.defaultStaleWindowMs);
+            const ttl = this.resolveCacheTtl(event);
+            if (ttl) this.cache.set(req, event, ttl.ttlMs, ttl.staleWindowMs);
           }
         })
       )
       .subscribe();
+  }
+
+  /**
+   * Resolves TTL and stale window from the response `Cache-Control` header.
+   * Reads `max-age` and `stale-while-revalidate` directives (RFC 5861) when present,
+   * otherwise falls back to the configured defaults.
+   * Returns `null` when the server signals the response must not be cached
+   * (`no-store`, `no-cache`, or `private`).
+   *
+   * @param res - The HTTP response to inspect
+   * @returns TTL and stale window in milliseconds, or `null` if caching is disallowed
+   */
+  private resolveCacheTtl(res: HttpResponse<unknown>): { ttlMs: number; staleWindowMs: number } | null {
+    const header = res.headers.get('Cache-Control') ?? '';
+
+    if (
+      this.hasDirective(header, 'no-store') ||
+      this.hasDirective(header, 'no-cache') ||
+      this.hasDirective(header, 'private')
+    ) {
+      return null;
+    }
+
+    const maxAge = this.parseDirectiveSeconds(header, 'max-age');
+    const staleWhileRevalidate = this.parseDirectiveSeconds(header, 'stale-while-revalidate');
+
+    return {
+      ttlMs: maxAge !== null ? maxAge * 1000 : this.defaultTtlMs,
+      staleWindowMs: staleWhileRevalidate !== null ? staleWhileRevalidate * 1000 : this.defaultStaleWindowMs
+    };
+  }
+
+  /**
+   * Returns true when a flag directive (no value) is present in a `Cache-Control` header.
+   *
+   * @param header - Raw `Cache-Control` header value
+   * @param directive - Directive name to look up (e.g. `'no-store'`)
+   * @returns Whether the directive is present
+   */
+  private hasDirective(header: string, directive: string): boolean {
+    return new RegExp(`(?:^|,)\\s*${directive}\\s*(?:,|$)`).test(header);
+  }
+
+  /**
+   * Parses a numeric directive value from a `Cache-Control` header string.
+   *
+   * @param header - Raw `Cache-Control` header value
+   * @param directive - Directive name to look up (e.g. `'max-age'`)
+   * @returns The directive value in seconds, or `null` if absent or non-numeric
+   */
+  private parseDirectiveSeconds(header: string, directive: string): number | null {
+    const match = new RegExp(`(?:^|,)\\s*${directive}=(\\d+)`).exec(header);
+    if (!match) return null;
+    const value = parseInt(match[1], 10);
+    return isNaN(value) ? null : value;
   }
 
   private isMutation(req: HttpRequest<unknown>): boolean {

--- a/src/app/core/_interceptors/http-cache.interceptor.ts
+++ b/src/app/core/_interceptors/http-cache.interceptor.ts
@@ -22,8 +22,9 @@ import { HttpCacheService } from '@services/shared/http-cache.service';
  */
 @Injectable()
 export class HttpCacheInterceptor implements HttpInterceptor {
-  private readonly defaultTtlMs = 30_000;
-  private readonly defaultStaleWindowMs = 60_000;
+  private readonly defaultTtlMs = 1;
+  // 30 Minuten
+  private readonly defaultStaleWindowMs = 1_800_000;
 
   private readonly cache = inject(HttpCacheService);
 

--- a/src/app/core/_interceptors/http-cache.interceptor.ts
+++ b/src/app/core/_interceptors/http-cache.interceptor.ts
@@ -1,22 +1,29 @@
 import { Observable, of, tap } from 'rxjs';
 
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { HttpCacheService } from '@services/shared/http-cache.service';
 
 /**
- * Simple HTTP cache interceptor using session-backed cache.
- * - Caches GET requests with a short TTL to speed up UI renders.
- * - Cache keys include user token hash to isolate data per user (prevents data leakage).
- * - Clears cache on mutating requests to avoid stale data.
- * - Skips caching when the header `X-Cache-Skip` is present.
+ * HTTP cache interceptor implementing a stale-while-revalidate strategy.
+ *
+ * @remarks
+ * - GET responses are cached with a short TTL and a longer stale window.
+ * - While the entry is fresh, the cached response is returned immediately.
+ * - While the entry is stale (TTL elapsed but within the stale window), the cached
+ *   response is returned immediately **and** a background revalidation request is fired
+ *   to refresh the cache for subsequent callers.
+ * - Cache keys include a user-token hash to isolate data per user.
+ * - Mutating requests (POST/PUT/PATCH/DELETE) invalidate the entire cache.
+ * - Requests with the `X-Cache-Skip` header bypass caching entirely.
  */
 @Injectable()
 export class HttpCacheInterceptor implements HttpInterceptor {
   private readonly defaultTtlMs = 30_000;
+  private readonly defaultStaleWindowMs = 60_000;
 
-  constructor(private cache: HttpCacheService) {}
+  private readonly cache = inject(HttpCacheService);
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     // Invalidate cache on any mutation to stay fresh
@@ -31,16 +38,39 @@ export class HttpCacheInterceptor implements HttpInterceptor {
 
     const cached = this.cache.get(req);
     if (cached) {
-      return of(cached);
+      if (cached.isStale) {
+        // Serve stale data immediately; refresh the cache in the background
+        this.revalidate(req, next);
+      }
+      return of(cached.response);
     }
 
     return next.handle(req).pipe(
       tap((event) => {
         if (event instanceof HttpResponse) {
-          this.cache.set(req, event, this.defaultTtlMs);
+          this.cache.set(req, event, this.defaultTtlMs, this.defaultStaleWindowMs);
         }
       })
     );
+  }
+
+  /**
+   * Fires a background request to refresh the cache entry without blocking the caller.
+   *
+   * @param req - The original GET request to revalidate
+   * @param next - The next handler in the interceptor chain
+   */
+  private revalidate(req: HttpRequest<unknown>, next: HttpHandler): void {
+    next
+      .handle(req)
+      .pipe(
+        tap((event) => {
+          if (event instanceof HttpResponse) {
+            this.cache.set(req, event, this.defaultTtlMs, this.defaultStaleWindowMs);
+          }
+        })
+      )
+      .subscribe();
   }
 
   private isMutation(req: HttpRequest<unknown>): boolean {

--- a/src/app/core/_interceptors/http-cache.interceptor.ts
+++ b/src/app/core/_interceptors/http-cache.interceptor.ts
@@ -1,4 +1,4 @@
-import { Observable, of, tap } from 'rxjs';
+import { Observable, concat, of, tap } from 'rxjs';
 
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
@@ -45,7 +45,7 @@ export class HttpCacheInterceptor implements HttpInterceptor {
     if (cached) {
       if (cached.isStale) {
         // Serve stale data immediately; refresh the cache in the background
-        this.revalidate(req, next);
+        return concat(of(cached.response), this.revalidate(req, next));
       }
       return of(cached.response);
     }
@@ -66,18 +66,15 @@ export class HttpCacheInterceptor implements HttpInterceptor {
    * @param req - The original GET request to revalidate
    * @param next - The next handler in the interceptor chain
    */
-  private revalidate(req: HttpRequest<unknown>, next: HttpHandler): void {
-    next
-      .handle(req)
-      .pipe(
-        tap((event) => {
-          if (event instanceof HttpResponse) {
-            const ttl = this.resolveCacheTtl(event);
-            if (ttl) this.cache.set(req, event, ttl.ttlMs, ttl.staleWindowMs);
-          }
-        })
-      )
-      .subscribe();
+  private revalidate(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return next.handle(req).pipe(
+      tap((event) => {
+        if (event instanceof HttpResponse) {
+          const ttl = this.resolveCacheTtl(event);
+          if (ttl) this.cache.set(req, event, ttl.ttlMs, ttl.staleWindowMs);
+        }
+      })
+    );
   }
 
   /**

--- a/src/app/core/_interceptors/http-cache.interceptor.ts
+++ b/src/app/core/_interceptors/http-cache.interceptor.ts
@@ -5,6 +5,9 @@ import { Injectable, inject } from '@angular/core';
 
 import { HttpCacheService } from '@services/shared/http-cache.service';
 
+export const DEFAULT_TTL_MS = 1;
+export const DEFAULT_STALE_TIME_MS = 1_800_000; // 30min
+
 /**
  * HTTP cache interceptor implementing a stale-while-revalidate strategy.
  *
@@ -22,9 +25,8 @@ import { HttpCacheService } from '@services/shared/http-cache.service';
  */
 @Injectable()
 export class HttpCacheInterceptor implements HttpInterceptor {
-  private readonly defaultTtlMs = 1;
-  // 30 Minuten
-  private readonly defaultStaleWindowMs = 1_800_000;
+  private readonly defaultTtlMs = DEFAULT_TTL_MS;
+  private readonly defaultStaleWindowMs = DEFAULT_STALE_TIME_MS;
 
   private readonly cache = inject(HttpCacheService);
 

--- a/src/app/core/_services/params/builder-implementation.service.ts
+++ b/src/app/core/_services/params/builder-implementation.service.ts
@@ -25,10 +25,10 @@ export class RequestParamBuilder implements IParamBuilder {
     if (dataSource.pageSize != undefined) {
       this.setPageSize(dataSource.pageSize);
     }
-    if (dataSource.pageAfter != undefined) {
+    if (dataSource.pageAfter != null) {
       this.setPageAfter(dataSource.pageAfter);
     }
-    if (dataSource.pageBefore != undefined) {
+    if (dataSource.pageBefore != null) {
       this.setPageBefore(dataSource.pageBefore);
     }
     if (dataSource.sortingColumn != undefined) {

--- a/src/app/core/_services/shared/http-cache.service.spec.ts
+++ b/src/app/core/_services/shared/http-cache.service.spec.ts
@@ -36,7 +36,8 @@ describe('HttpCacheService', () => {
     const cached = service.get(req);
 
     expect(cached).toBeTruthy();
-    expect(cached?.body).toEqual({ id: 1, name: 'Test' });
+    expect(cached?.response.body).toEqual({ id: 1, name: 'Test' });
+    expect(cached?.isStale).toBeFalse();
   });
 
   it('should return null for uncached requests', () => {
@@ -63,7 +64,7 @@ describe('HttpCacheService', () => {
 
     // User 1 should get the cached response
     const cached1 = service.get(req1);
-    expect(cached1?.body).toEqual({ user: 'user-1' });
+    expect(cached1?.response.body).toEqual({ user: 'user-1' });
 
     // User 2 should not get user 1's cache
     const cached2 = service.get(req2);
@@ -98,7 +99,7 @@ describe('HttpCacheService', () => {
     const cached = service.get(req);
 
     expect(cached).toBeTruthy();
-    expect(cached?.body).toEqual({ id: 1, name: 'Test' });
+    expect(cached?.response.body).toEqual({ id: 1, name: 'Test' });
   });
 
   it('should invalidate cache on command', () => {
@@ -118,7 +119,7 @@ describe('HttpCacheService', () => {
     expect(cached).toBeNull();
   });
 
-  it('should respect TTL expiration', (done) => {
+  it('should mark entries as stale after TTL but keep serving them within the stale window', (done) => {
     const req = new HttpRequest('GET', 'https://api.test.com/data');
     const res = new HttpResponse({
       body: { id: 1, name: 'Test' },
@@ -126,14 +127,34 @@ describe('HttpCacheService', () => {
       statusText: 'OK'
     });
 
-    service.set(req, res, 100); // Expires in 100ms
+    service.set(req, res, 100, 5_000); // TTL 100ms, stale window 5s
 
-    let cached = service.get(req);
-    expect(cached).toBeTruthy();
+    const fresh = service.get(req);
+    expect(fresh).toBeTruthy();
+    expect(fresh?.isStale).toBeFalse();
 
     setTimeout(() => {
-      cached = service.get(req);
-      expect(cached).toBeNull();
+      const stale = service.get(req);
+      expect(stale).toBeTruthy();
+      expect(stale?.isStale).toBeTrue();
+      expect(stale?.response.body).toEqual({ id: 1, name: 'Test' });
+      done();
+    }, 150);
+  });
+
+  it('should return null once the stale window has also elapsed', (done) => {
+    const req = new HttpRequest('GET', 'https://api.test.com/data');
+    const res = new HttpResponse({
+      body: { id: 1, name: 'Test' },
+      status: 200,
+      statusText: 'OK'
+    });
+
+    service.set(req, res, 50, 50); // TTL 50ms, stale window 50ms → fully expired after 100ms
+
+    setTimeout(() => {
+      const result = service.get(req);
+      expect(result).toBeNull();
       done();
     }, 150);
   });
@@ -164,9 +185,23 @@ describe('HttpCacheService', () => {
 
     // Clear memory cache to force retrieval from sessionStorage
     const cached = service.get(req);
-    expect(cached?.body).toEqual({ id: 1, name: 'Test' });
+    expect(cached?.response.body).toEqual({ id: 1, name: 'Test' });
 
     // Verify that data is in sessionStorage (as a sanity check)
     expect(sessionStorage.length).toBeGreaterThan(0);
+  });
+
+  it('should return isStale false for a fresh entry', () => {
+    const req = new HttpRequest('GET', 'https://api.test.com/data');
+    const res = new HttpResponse({
+      body: { id: 1, name: 'Test' },
+      status: 200,
+      statusText: 'OK'
+    });
+
+    service.set(req, res, 30_000, 60_000);
+    const result = service.get(req);
+
+    expect(result?.isStale).toBeFalse();
   });
 });

--- a/src/app/core/_services/shared/http-cache.service.ts
+++ b/src/app/core/_services/shared/http-cache.service.ts
@@ -1,5 +1,5 @@
 import { HttpHeaders, HttpRequest, HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { SessionStorageService } from '@services/storage/session-storage.service';
 
@@ -13,10 +13,21 @@ interface SerializedHttpResponse {
 
 interface CacheEntry {
   expires: number;
+  staleUntil: number;
   response: SerializedHttpResponse;
 }
 
+/**
+ * Result of a cache lookup, including whether the entry is still fresh.
+ */
+export interface CacheGetResult {
+  response: HttpResponse<unknown>;
+  /** True when the TTL has elapsed but the entry is still within the stale window. */
+  isStale: boolean;
+}
+
 const DEFAULT_TTL_MS = 30_000; // Safe default to avoid stale data
+const DEFAULT_STALE_WINDOW_MS = 60_000; // Extra time to serve stale data while revalidating in background
 const CACHE_PREFIX = 'htp-cache:'; // 'htp' = hashtopolis
 
 @Injectable({
@@ -25,9 +36,15 @@ const CACHE_PREFIX = 'htp-cache:'; // 'htp' = hashtopolis
 export class HttpCacheService {
   private readonly memoryCache = new Map<string, CacheEntry>();
 
-  constructor(private sessionStorage: SessionStorageService<CacheEntry>) {}
+  private readonly sessionStorage = inject<SessionStorageService<CacheEntry>>(SessionStorageService);
 
-  get(req: HttpRequest<unknown>): HttpResponse<unknown> | null {
+  /**
+   * Retrieves a cached response for the given request.
+   *
+   * @param req - The outgoing HTTP request used as a cache key
+   * @returns A result with a staleness flag, or null if the entry is absent or fully expired
+   */
+  get(req: HttpRequest<unknown>): CacheGetResult | null {
     const key = this.getKey(req);
 
     const entry = this.memoryCache.get(key) ?? this.sessionStorage.getItem(key);
@@ -35,16 +52,30 @@ export class HttpCacheService {
       return null;
     }
 
-    if (entry.expires && entry.expires <= Date.now()) {
+    const now = Date.now();
+    if (entry.staleUntil <= now) {
       this.delete(key);
       return null;
     }
 
     this.memoryCache.set(key, entry);
-    return this.deserialize(entry.response);
+    return { response: this.deserialize(entry.response), isStale: entry.expires <= now };
   }
 
-  set(req: HttpRequest<unknown>, res: HttpResponse<unknown>, ttlMs: number = DEFAULT_TTL_MS): void {
+  /**
+   * Stores a response in the cache with a fresh TTL and an optional stale window.
+   *
+   * @param req - The HTTP request used as the cache key
+   * @param res - The HTTP response to store
+   * @param ttlMs - Milliseconds before the entry becomes stale
+   * @param staleWindowMs - Extra milliseconds to serve stale data while revalidating in the background
+   */
+  set(
+    req: HttpRequest<unknown>,
+    res: HttpResponse<unknown>,
+    ttlMs: number = DEFAULT_TTL_MS,
+    staleWindowMs: number = DEFAULT_STALE_WINDOW_MS
+  ): void {
     if (ttlMs <= 0) {
       return; // Do not cache
     }
@@ -55,13 +86,15 @@ export class HttpCacheService {
     }
 
     const key = this.getKey(req);
+    const now = Date.now();
     const entry: CacheEntry = {
-      expires: ttlMs ? Date.now() + ttlMs : 0,
+      expires: now + ttlMs,
+      staleUntil: now + ttlMs + staleWindowMs,
       response: this.serialize(res)
     };
 
     this.memoryCache.set(key, entry);
-    this.sessionStorage.setItem(key, entry, ttlMs);
+    this.sessionStorage.setItem(key, entry, ttlMs + staleWindowMs);
   }
 
   /**
@@ -147,10 +180,6 @@ export class HttpCacheService {
     }
 
     // Exclude binary types
-    if (res.body instanceof Blob || res.body instanceof ArrayBuffer) {
-      return false;
-    }
-
-    return true;
+    return !(res.body instanceof Blob || res.body instanceof ArrayBuffer);
   }
 }

--- a/src/app/core/_services/storage/session-storage.service.spec.ts
+++ b/src/app/core/_services/storage/session-storage.service.spec.ts
@@ -105,6 +105,7 @@ describe('SessionStorageService', () => {
     });
 
     it('getItem should remove key and return null when stored data fails schema', () => {
+      spyOn(console, 'error');
       const key = 'schemaInvalid';
       // Write invalid data without schema validation
       service.setItem(key, { name: 123, count: 'bad' }, 1000);
@@ -190,6 +191,7 @@ describe('SessionStorageService', () => {
     });
 
     it('getItem should return defaultValue when schema validation fails', () => {
+      spyOn(console, 'error');
       service.setItem('bad', { name: 999, count: 'bad' }, 1000);
 
       const result = service.getItem('bad', testSchema, defaultObj);
@@ -210,6 +212,26 @@ describe('SessionStorageService', () => {
     it('getItem should return defaultValue without schema when key is missing', () => {
       const result = service.getItem('nope', undefined, 'fallback');
       expect(result).toBe('fallback');
+    });
+  });
+
+  // --- QuotaExceededError handling ---
+
+  describe('QuotaExceededError handling', () => {
+    it('should warn and not throw when sessionStorage quota is exceeded', () => {
+      spyOn(console, 'warn');
+      const quotaError = new DOMException('QuotaExceededError', 'QuotaExceededError');
+      spyOn(sessionStorage, 'setItem').and.throwError(quotaError);
+
+      expect(() => service.setItem('key', 'value', 1000)).not.toThrow();
+      expect(console.warn).toHaveBeenCalledWith(jasmine.stringContaining('quota exceeded'));
+    });
+
+    it('should re-throw non-quota DOMExceptions', () => {
+      const securityError = new DOMException('Access denied', 'SecurityError');
+      spyOn(sessionStorage, 'setItem').and.throwError(securityError);
+
+      expect(() => service.setItem('key', 'value', 1000)).toThrowError(DOMException);
     });
   });
 

--- a/src/app/core/_services/storage/session-storage.service.ts
+++ b/src/app/core/_services/storage/session-storage.service.ts
@@ -2,6 +2,10 @@ import { z } from 'zod';
 
 import { Injectable } from '@angular/core';
 
+// Installs the TypedStorage wrapper on window.sessionStorage and brings in the
+// global Storage type augmentation that makes setItem accept non-string values.
+import '@services/storage/session-storage';
+
 import { BaseStorageService, StorageWrapper } from '@services/storage/base-storage.service';
 
 /**
@@ -84,7 +88,15 @@ export class SessionStorageService<T> extends BaseStorageService<T> {
       value: value
     };
 
-    sessionStorage.setItem(this.decode(key), storedValue);
+    try {
+      sessionStorage.setItem(this.decode(key), storedValue);
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'QuotaExceededError') {
+        console.warn(`SessionStorageService: quota exceeded for key "${key}", skipping sessionStorage write.`);
+      } else {
+        throw e;
+      }
+    }
   }
 
   removeItem(key: string): void {


### PR DESCRIPTION
Implements the **stale-while-revalidate (SWR)** pattern for the HTTP session cache and fixes several related bugs in auto-refresh and pagination.


- Cache entries now have a two-phase expiry: a **fresh TTL** (30 s) followed by a **stale window** (60 s)
- On a cache hit within the stale window, the interceptor returns the cached response **immediately** (zero latency) and fires a **background network request** to refresh the cache for subsequent calls
- Only JSON responses are cached; binary types (`Blob`, `ArrayBuffer`) are excluded

**Auto-refresh:** Invalidates cache on each tick so live data is always fetched, and restores the correct pagination cursor so the current page is reloaded rather than page 1. Previously, the cursor pointing to the next page was mistakenly reused on refresh, causing the task table to alternate between empty and populated (at least in my instance).

The cache behaviour for each response can be controlled by the server via standard `Cache-Control` response headers, but falls back to TTL 30s and stale window 60s, if not present.

**Opt out of caching** (RFC 7234):
```http
Cache-Control: no-store
Cache-Control: no-cache
Cache-Control: private
```

**Override TTL and stale window** (RFC 5861)
```http
Cache-Control: max-age=60, stale-while-revalidate=120
```




