### PR TITLE
Fix multiselect adding removed item at the end of available options a…

### DIFF
--- a/src/app/shared/input/multiselect/multiselect.component.spec.ts
+++ b/src/app/shared/input/multiselect/multiselect.component.spec.ts
@@ -104,6 +104,12 @@ describe('InputMultiSelectComponent', () => {
       component.remove(ITEMS[0]);
       expect(component.filteredItems.find((i) => i.id === ITEMS[0].id)).toBeTruthy();
     });
+
+    it('should restore item at its original position, not at the end', () => {
+      // beforeEach selected ITEMS[0] — removing it should restore it at the front
+      component.remove(ITEMS[0]);
+      expect(component.filteredItems.map((i) => i.id)).toEqual(ITEMS.map((i) => i.id));
+    });
   });
 
   describe('single-select mode', () => {
@@ -122,6 +128,13 @@ describe('InputMultiSelectComponent', () => {
       component.addChip(ITEMS[0]);
       component.addChip(ITEMS[1]);
       expect(component.filteredItems.find((i) => i.id === ITEMS[0].id)).toBeTruthy();
+    });
+
+    it('should preserve original ordering when swapping selection', () => {
+      component.addChip(ITEMS[0]);
+      component.addChip(ITEMS[3]);
+      const expected = ITEMS.filter((i) => i.id !== ITEMS[3].id).map((i) => i.id);
+      expect(component.filteredItems.map((i) => i.id)).toEqual(expected);
     });
   });
 

--- a/src/app/shared/input/multiselect/multiselect.component.ts
+++ b/src/app/shared/input/multiselect/multiselect.component.ts
@@ -16,7 +16,7 @@ import {
   inject
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
-import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { MatAutocomplete, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { MatChipInputEvent } from '@angular/material/chips';
 import { MatInput } from '@angular/material/input';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
@@ -63,6 +63,7 @@ export class InputMultiSelectComponent
 
   @ViewChild('selectInput', { read: MatInput }) selectInput: MatInput;
   @ViewChild(CdkVirtualScrollViewport) virtualViewport: CdkVirtualScrollViewport;
+  @ViewChild(MatAutocomplete) autocomplete: MatAutocomplete;
 
   private searchInputSubject = new Subject<string>();
   private itemsSubject = new Subject<SelectOption[]>();
@@ -133,6 +134,7 @@ export class InputMultiSelectComponent
   onPanelOpened(): void {
     setTimeout(() => {
       this.virtualViewport?.checkViewportSize();
+      this.clearAutocompleteSelectionFlags();
       this.cdr.markForCheck();
     });
   }
@@ -152,18 +154,13 @@ export class InputMultiSelectComponent
       if (this.multiselectEnabled) {
         this.selectedItems.push(item);
       } else {
-        // In single-select mode, restore the previously selected item to available
-        if (this.selectedItems.length > 0) {
-          this.availableItems = [...this.availableItems, this.selectedItems[0]];
-        }
         this.selectedItems = [item];
       }
 
       // Update validation array
       this.chipGridValidation = [...this.selectedItems];
 
-      // Remove item from available list
-      this.availableItems = this.availableItems.filter((i) => i.id !== item.id);
+      this.updateAvailableItems();
       this.itemsSubject.next(this.availableItems);
 
       // Update filtered items
@@ -181,14 +178,29 @@ export class InputMultiSelectComponent
       this.selectedItems.splice(index, 1);
       this.chipGridValidation = [...this.selectedItems];
 
-      // Put back to available items
-      this.availableItems = [...this.availableItems, item];
+      this.updateAvailableItems();
       this.searchInputSubject.next(this.searchTerm);
       this.itemsSubject.next(this.availableItems);
 
       this.onChangeValue(this.selectedItems);
       this.onTouched();
     }
+  }
+
+  /**
+   * Available Items is always all items without the selected ones
+   */
+  private updateAvailableItems(): void {
+    const selectedIds = new Set(this.selectedItems.map((s) => s.id));
+    this.availableItems = this._items.filter((item) => !selectedIds.has(item.id));
+  }
+
+  /**
+   * Reset every MatOption's internal `selected` flag due to virtual scroll reusing options that
+   * might already be selected from previous ones
+   */
+  private clearAutocompleteSelectionFlags(): void {
+    this.autocomplete?.options?.forEach((opt) => opt.deselect());
   }
 
   // When typing a separator key (ENTER, COMMA)
@@ -220,6 +232,7 @@ export class InputMultiSelectComponent
         // ignore
       }
     }
+    this.clearAutocompleteSelectionFlags();
     this.cdr.markForCheck();
   }
 
@@ -299,18 +312,13 @@ export class InputMultiSelectComponent
    */
   public selected(event: MatAutocompleteSelectedEvent): void {
     if (!this.multiselectEnabled) {
-      // For single-select, put back the previous one (if any) then clear selection
-      if (this.selectedItems.length > 0) {
-        this.availableItems = [...this.availableItems, this.selectedItems[0]];
-      }
       this.selectedItems = [];
     }
 
-    // Remove selected option from available list
-    this.availableItems = this.availableItems.filter((i) => i.id !== event.option.value.id);
-
     this.searchTerm = ''; // Reset the search term
     this.selectedItems.push(event.option.value);
+
+    this.updateAvailableItems();
 
     // Update the filteredItems observable
     this.searchInputSubject.next(this.searchTerm);


### PR DESCRIPTION
…nd some options being preselected due to virtual scroll

In multiselect when an option has been selected and then removed again it has been added to the end of the available items list. Therefore it was thought that the option has been completely removed.

Changed this so the availableItems are always recomputed from all items - the selected ones so the order is preserved.

Also found an additional bug that when selecting deselecting due to virtual scroll the chip was correct but the options in the select had checkmarks even though not selected anymore. This happened as the option has internal state for selection, shows a checkmark but does not reset this and in virtual scroll is reused and will show checkmark for non selected items.


Selected options are removed from all available options -> maybe it could also be possible to leave them but display them as selected (with their checkmark) instead?

Issue: https://github.com/hashtopolis/server/issues/1878