### PR TITLE
supertask count is fixed in home

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -295,10 +295,8 @@ export class HomeComponent implements OnInit, OnDestroy {
       .create();
 
     const paramsCompletedSupertasks = new RequestParamBuilder()
-      .addFilter({ field: 'keyspace', operator: FilterType.EQUAL, value: 'keyspaceProgress' })
       .addFilter({ field: 'keyspace', operator: FilterType.GREATER, value: 0 })
       .addFilter({ field: 'taskType', operator: FilterType.EQUAL, value: TaskType.SUPERTASK })
-      .addInclude('tasks')
       .create();
 
     return forkJoin([


### PR DESCRIPTION
Including tasks in home.component.ts was counting de amount of tasks instead of the completed supertasks, makes little sense to me. keyspaceProgress was also  causing incorrect counts by either breaking the request or counting subtasks instead of task wrappers.