### PR TITLE
fix: ensure consistent background color for header rows in the table

### DIFF
--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -55,6 +55,10 @@ table.hashtopolis-table {
     }
   }
 
+  .mat-mdc-header-row {
+    background-color: colors.$primary-800;
+  }
+
   .mat-mdc-row:hover {
     background-color: colors.$primary-100;
   }


### PR DESCRIPTION
I’ve updated the CSS so that the color now covers the entire header.

Regarding the lines, it seems more like a browser-related issue. When I tested it in Chrome they appeared, but not in Firefox. In any case, with this change the lines are a bit less noticeable.