### PR TITLE
1969 enhancement frontend component jwtapikey

### DIFF
--- a/src/app/account/account-routing.module.ts
+++ b/src/app/account/account-routing.module.ts
@@ -85,8 +85,6 @@ const routes: MyRoute[] = [
         canActivate: [IsAuth]
       },
       {
-        // Must come *after* `api-keys/new` so that the literal segment matches
-        // first; with the param-route declared earlier, `:id` would swallow `new`.
         path: 'api-keys/:id',
         component: ApiKeyDetailComponent,
         data: {

--- a/src/app/account/account-routing.module.ts
+++ b/src/app/account/account-routing.module.ts
@@ -6,6 +6,9 @@ import { MyRoute } from '@models/routes.model';
 import { SERV } from '@services/main.config';
 
 import { AccountComponent } from '@src/app/account/account.component';
+import { ApiKeyDetailComponent } from '@src/app/account/api-keys/api-key-detail/api-key-detail.component';
+import { ApiKeysComponent } from '@src/app/account/api-keys/api-keys.component';
+import { NewApiKeyComponent } from '@src/app/account/api-keys/new-api-key/new-api-key.component';
 import { NewNotificationComponent } from '@src/app/account/notifications/notification/new-notification.component';
 import { NotificationsComponent } from '@src/app/account/notifications/notifications.component';
 import { AccountSettingsComponent } from '@src/app/account/settings/acc-settings/acc-settings.component';
@@ -60,6 +63,35 @@ const routes: MyRoute[] = [
         data: {
           kind: 'new-notifications',
           breadcrumb: 'New Notification'
+        },
+        canActivate: [IsAuth]
+      },
+      {
+        path: 'api-keys',
+        component: ApiKeysComponent,
+        data: {
+          kind: 'api-keys',
+          breadcrumb: 'API Keys'
+        },
+        canActivate: [IsAuth]
+      },
+      {
+        path: 'api-keys/new',
+        component: NewApiKeyComponent,
+        data: {
+          kind: 'new-api-key',
+          breadcrumb: 'New API Key'
+        },
+        canActivate: [IsAuth]
+      },
+      {
+        // Must come *after* `api-keys/new` so that the literal segment matches
+        // first; with the param-route declared earlier, `:id` would swallow `new`.
+        path: 'api-keys/:id',
+        component: ApiKeyDetailComponent,
+        data: {
+          kind: 'api-key-detail',
+          breadcrumb: 'API Key Details'
         },
         canActivate: [IsAuth]
       }

--- a/src/app/account/account.module.ts
+++ b/src/app/account/account.module.ts
@@ -1,12 +1,16 @@
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
+import { ClipboardModule } from '@angular/cdk/clipboard';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { RouterModule } from '@angular/router';
@@ -15,11 +19,16 @@ import { CoreComponentsModule } from '@components/core-components.module';
 
 import { AccountRoutingModule } from '@src/app/account/account-routing.module';
 import { AccountComponent } from '@src/app/account/account.component';
+import { ApiKeyDetailComponent } from '@src/app/account/api-keys/api-key-detail/api-key-detail.component';
+import { ApiKeysComponent } from '@src/app/account/api-keys/api-keys.component';
+import { NewApiKeyComponent } from '@src/app/account/api-keys/new-api-key/new-api-key.component';
+import { RevealApiKeyDialogComponent } from '@src/app/account/api-keys/reveal-api-key/reveal-api-key.component';
 import { NewNotificationComponent } from '@src/app/account/notifications/notification/new-notification.component';
 import { NotificationsComponent } from '@src/app/account/notifications/notifications.component';
 import { AccountSettingsComponent } from '@src/app/account/settings/acc-settings/acc-settings.component';
 import { UiSettingsComponent } from '@src/app/account/settings/ui-settings/ui-settings.component';
 import { ComponentsModule } from '@src/app/shared/components.module';
+import { DirectivesModule } from '@src/app/shared/directives.module';
 import { CoreFormsModule } from '@src/app/shared/forms.module';
 import { PipesModule } from '@src/app/shared/pipes.module';
 
@@ -29,7 +38,11 @@ import { PipesModule } from '@src/app/shared/pipes.module';
     AccountSettingsComponent,
     NotificationsComponent,
     UiSettingsComponent,
-    AccountComponent
+    AccountComponent,
+    ApiKeysComponent,
+    ApiKeyDetailComponent,
+    NewApiKeyComponent,
+    RevealApiKeyDialogComponent
   ],
   imports: [
     AccountRoutingModule,
@@ -38,12 +51,17 @@ import { PipesModule } from '@src/app/shared/pipes.module';
     ComponentsModule,
     CoreFormsModule,
     CoreComponentsModule,
+    DirectivesModule,
     RouterModule,
     CommonModule,
     PipesModule,
     FormsModule,
+    ClipboardModule,
+    MatCheckboxModule,
+    MatDialogModule,
     MatFormFieldModule,
     MatInputModule,
+    MatProgressSpinnerModule,
     MatSelectModule,
     MatIconModule,
     MatButtonModule,

--- a/src/app/account/api-keys/api-key-detail/api-key-detail.component.html
+++ b/src/app/account/api-keys/api-key-detail/api-key-detail.component.html
@@ -29,7 +29,7 @@
 
     <div class="flex flex-wrap items-start gap-2">
       <simulate-form-field label="Valid From" [message]="formatTimestamp(token.startValid)"></simulate-form-field>
-      <simulate-form-field label="Valid Until" [message]="formatTimestamp(token.endValid)"></simulate-form-field>
+      <simulate-form-field label="Expires At" [message]="formatExpiry(token.endValid)"></simulate-form-field>
     </div>
 
     <div class="flex flex-wrap items-start gap-2">

--- a/src/app/account/api-keys/api-key-detail/api-key-detail.component.html
+++ b/src/app/account/api-keys/api-key-detail/api-key-detail.component.html
@@ -38,19 +38,6 @@
     </div>
   </grid-main>
 
-  <grid-main>
-    <app-page-subtitle [subtitle]="'Permissions'"></app-page-subtitle>
-    <p class="help-block">
-      Scopes are baked into the signed JWT at creation and not stored server-side, so this matrix shows the permission
-      structure for reference only — the granted scope set cannot be recovered from the API key after issuance.
-    </p>
-    <access-permission-groups-user-table
-      mode="view"
-      [granted]="fullPermissions"
-      [selection]="selection"
-    ></access-permission-groups-user-table>
-  </grid-main>
-
   <grid-buttons>
     <button mat-stroked-button type="button" (click)="goBack()">Back to API Keys</button>
   </grid-buttons>

--- a/src/app/account/api-keys/api-key-detail/api-key-detail.component.html
+++ b/src/app/account/api-keys/api-key-detail/api-key-detail.component.html
@@ -1,0 +1,57 @@
+@if (loading) {
+  <grid-main>
+    <div class="loading-spinner">
+      <mat-spinner diameter="24"></mat-spinner>
+      <span>Loading API key…</span>
+    </div>
+  </grid-main>
+} @else if (notFound || !token) {
+  <grid-main>
+    <app-page-subtitle [subtitle]="'API key not found'"></app-page-subtitle>
+    <p class="help-block">The requested API key could not be loaded. It may have been deleted.</p>
+    <button mat-stroked-button type="button" (click)="goBack()">Back to API Keys</button>
+  </grid-main>
+} @else {
+  <grid-main>
+    <app-page-subtitle [subtitle]="'API Key #' + token.id"></app-page-subtitle>
+
+    <div class="flex flex-wrap items-start gap-2">
+      <simulate-form-field label="ID" [message]="token.id + ''"></simulate-form-field>
+      <simulate-form-field
+        label="Status"
+        [icon]="
+          status === ApiTokenStatus.ACTIVE ? 'check_circle' : status === ApiTokenStatus.REVOKED ? 'block' : 'schedule'
+        "
+        [message]="status ?? '' | titlecase"
+      ></simulate-form-field>
+      <simulate-form-field label="Revoked" [message]="token.isRevoked ? 'Yes' : 'No'"></simulate-form-field>
+    </div>
+
+    <div class="flex flex-wrap items-start gap-2">
+      <simulate-form-field label="Valid From" [message]="formatTimestamp(token.startValid)"></simulate-form-field>
+      <simulate-form-field label="Valid Until" [message]="formatTimestamp(token.endValid)"></simulate-form-field>
+    </div>
+
+    <div class="flex flex-wrap items-start gap-2">
+      <simulate-form-field label="Creator" [message]="token.user?.name ?? '—'"></simulate-form-field>
+      <simulate-form-field label="User ID" [message]="token.userId + ''"></simulate-form-field>
+    </div>
+  </grid-main>
+
+  <grid-main>
+    <app-page-subtitle [subtitle]="'Permissions'"></app-page-subtitle>
+    <p class="help-block">
+      Scopes are baked into the signed JWT at creation and not stored server-side, so this matrix shows the permission
+      structure for reference only — the granted scope set cannot be recovered from the API key after issuance.
+    </p>
+    <access-permission-groups-user-table
+      mode="view"
+      [granted]="fullPermissions"
+      [selection]="selection"
+    ></access-permission-groups-user-table>
+  </grid-main>
+
+  <grid-buttons>
+    <button mat-stroked-button type="button" (click)="goBack()">Back to API Keys</button>
+  </grid-buttons>
+}

--- a/src/app/account/api-keys/api-key-detail/api-key-detail.component.html
+++ b/src/app/account/api-keys/api-key-detail/api-key-detail.component.html
@@ -5,10 +5,16 @@
       <span>Loading API key…</span>
     </div>
   </grid-main>
-} @else if (notFound || !token) {
+} @else if (notFound) {
   <grid-main>
     <app-page-subtitle [subtitle]="'API key not found'"></app-page-subtitle>
     <p class="help-block">The requested API key could not be loaded. It may have been deleted.</p>
+    <button mat-stroked-button type="button" (click)="goBack()">Back to API Keys</button>
+  </grid-main>
+} @else if (loadError || !token) {
+  <grid-main>
+    <app-page-subtitle [subtitle]="'Could not load API key'"></app-page-subtitle>
+    <p class="help-block">Something went wrong while loading this API key. Please try again later.</p>
     <button mat-stroked-button type="button" (click)="goBack()">Back to API Keys</button>
   </grid-main>
 } @else {

--- a/src/app/account/api-keys/api-key-detail/api-key-detail.component.spec.ts
+++ b/src/app/account/api-keys/api-key-detail/api-key-detail.component.spec.ts
@@ -1,0 +1,140 @@
+import { of, throwError } from 'rxjs';
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { JApiToken, computeApiTokenStatus } from '@models/api-token.model';
+import { UIConfig, uiConfigDefault } from '@models/config-ui.model';
+
+import { JsonAPISerializer } from '@services/api/serializer-service';
+import { GlobalService } from '@services/main.service';
+import { AlertService } from '@services/shared/alert.service';
+import { AutoTitleService } from '@services/shared/autotitle.service';
+import { LocalStorageService } from '@services/storage/local-storage.service';
+
+import { ApiKeyDetailComponent } from '@src/app/account/api-keys/api-key-detail/api-key-detail.component';
+import { UISettingsUtilityClass } from '@src/app/shared/utils/config';
+import { mockResponse } from '@src/app/testing/mock-response';
+
+describe('ApiKeyDetailComponent', () => {
+  let component: ApiKeyDetailComponent;
+  let fixture: ComponentFixture<ApiKeyDetailComponent>;
+
+  let mockGlobalService: jasmine.SpyObj<GlobalService>;
+  let mockRouter: jasmine.SpyObj<Router>;
+  let mockAlert: jasmine.SpyObj<AlertService>;
+  let mockTitle: jasmine.SpyObj<AutoTitleService>;
+  let mockStorage: jasmine.SpyObj<LocalStorageService<UIConfig>>;
+  let mockRoute: { snapshot: { params: Record<string, string> } };
+
+  /** Token returned by the (stubbed) deserializer for the happy path. */
+  const loadedToken: JApiToken = {
+    id: 7,
+    type: 'apiToken',
+    startValid: 1_700_000_000,
+    endValid: 1_700_086_400,
+    userId: 42,
+    isRevoked: false
+  };
+
+  /** Build the fixture after wiring the route id, since route params are read in ngOnInit. */
+  function createFixture(routeId: string): void {
+    mockRoute.snapshot.params['id'] = routeId;
+    fixture = TestBed.createComponent(ApiKeyDetailComponent);
+    component = fixture.componentInstance;
+  }
+
+  beforeEach(async () => {
+    mockGlobalService = jasmine.createSpyObj('GlobalService', ['get']);
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockRouter.navigate.and.resolveTo(true);
+    mockAlert = jasmine.createSpyObj('AlertService', ['showSuccessMessage', 'showErrorMessage']);
+    mockTitle = jasmine.createSpyObj('AutoTitleService', ['set']);
+    mockStorage = jasmine.createSpyObj('LocalStorageService', ['getItem', 'setItem', 'removeItem']);
+    mockStorage.getItem.and.returnValue(uiConfigDefault);
+    mockRoute = { snapshot: { params: {} } };
+
+    spyOn(JsonAPISerializer.prototype, 'deserialize').and.returnValue(loadedToken);
+    spyOn(UISettingsUtilityClass.prototype, 'getSetting').and.returnValue(undefined);
+
+    await TestBed.configureTestingModule({
+      declarations: [ApiKeyDetailComponent],
+      providers: [
+        { provide: GlobalService, useValue: mockGlobalService },
+        { provide: Router, useValue: mockRouter },
+        { provide: AlertService, useValue: mockAlert },
+        { provide: AutoTitleService, useValue: mockTitle },
+        { provide: LocalStorageService, useValue: mockStorage },
+        { provide: ActivatedRoute, useValue: mockRoute }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  });
+
+  it('loads the token and computes status on a valid route id', async () => {
+    mockGlobalService.get.and.returnValue(of(mockResponse()));
+    createFixture('7');
+
+    fixture.detectChanges();
+    // Two drains: loadToken awaits firstValueFrom, then synchronously continues — the
+    // second whenStable() ensures any chained microtasks settle before assertions.
+    await fixture.whenStable();
+    await fixture.whenStable();
+
+    expect(mockGlobalService.get).toHaveBeenCalled();
+    expect(component.token).toEqual(loadedToken);
+    expect(component.status).toBe(computeApiTokenStatus(loadedToken));
+    expect(component.loading).toBe(false);
+    expect(component.notFound).toBe(false);
+    expect(component.loadError).toBe(false);
+  });
+
+  it('marks notFound when the route id is not numeric and skips the HTTP call', () => {
+    createFixture('abc');
+
+    fixture.detectChanges();
+
+    expect(mockGlobalService.get).not.toHaveBeenCalled();
+    expect(component.notFound).toBe(true);
+    expect(component.loading).toBe(false);
+  });
+
+  it('marks notFound on a 404 and shows the not-found alert', async () => {
+    mockGlobalService.get.and.returnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+    createFixture('7');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await fixture.whenStable();
+
+    expect(component.notFound).toBe(true);
+    expect(component.loadError).toBe(false);
+    expect(component.loading).toBe(false);
+    expect(mockAlert.showErrorMessage).toHaveBeenCalledWith('Could not load API key.');
+  });
+
+  it('marks loadError on a non-404 error and shows the generic alert', async () => {
+    mockGlobalService.get.and.returnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
+    createFixture('7');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await fixture.whenStable();
+
+    expect(component.notFound).toBe(false);
+    expect(component.loadError).toBe(true);
+    expect(component.loading).toBe(false);
+    expect(mockAlert.showErrorMessage).toHaveBeenCalledWith('Could not load API key — please try again later.');
+  });
+
+  it('formatExpiry returns the same string as formatTimestamp for one second earlier', () => {
+    createFixture('7');
+    // No detectChanges: we only test the pure formatters, which read dateFormat from
+    // the field initializer (uiConfigDefault.timefmt) and don't require ngOnInit.
+
+    const endValidSec = 1_700_086_400;
+    expect(component.formatExpiry(endValidSec)).toBe(component.formatTimestamp(endValidSec - 1));
+  });
+});

--- a/src/app/account/api-keys/api-key-detail/api-key-detail.component.ts
+++ b/src/app/account/api-keys/api-key-detail/api-key-detail.component.ts
@@ -15,10 +15,8 @@ import { AlertService } from '@services/shared/alert.service';
 import { AutoTitleService } from '@services/shared/autotitle.service';
 import { LocalStorageService } from '@services/storage/local-storage.service';
 
-import { Permission } from '@src/app/core/_models/global-permission-group.model';
 import { UISettingsUtilityClass } from '@src/app/shared/utils/config';
 import { formatUnixTimestamp } from '@src/app/shared/utils/datetime';
-import { buildAllPermissionsMap } from '@src/app/shared/utils/permission-matrix';
 
 @Component({
   selector: 'app-api-key-detail',
@@ -40,10 +38,6 @@ export class ApiKeyDetailComponent implements OnInit {
   token: JApiToken | null = null;
   /** Status derived from the token's lifecycle (active / expired / revoked). */
   status: ApiTokenStatus | null = null;
-  /** Resource-by-CRUD map driving the read-only matrix. All keys true → full grid. */
-  fullPermissions: Permission = buildAllPermissionsMap();
-  /** Always empty here: scopes are write-only at creation, never returned. */
-  selection: string[] = [];
   loading = true;
   notFound = false;
 

--- a/src/app/account/api-keys/api-key-detail/api-key-detail.component.ts
+++ b/src/app/account/api-keys/api-key-detail/api-key-detail.component.ts
@@ -16,7 +16,7 @@ import { AutoTitleService } from '@services/shared/autotitle.service';
 import { LocalStorageService } from '@services/storage/local-storage.service';
 
 import { UISettingsUtilityClass } from '@src/app/shared/utils/config';
-import { formatUnixTimestamp } from '@src/app/shared/utils/datetime';
+import { formatUnixTimestamp, lastValidSecond } from '@src/app/shared/utils/datetime';
 
 @Component({
   selector: 'app-api-key-detail',
@@ -34,9 +34,8 @@ export class ApiKeyDetailComponent implements OnInit {
 
   protected readonly ApiTokenStatus = ApiTokenStatus;
 
-  /** Loaded token. Null until the GET resolves; the template gates on this. */
+  // null until fetched
   token: JApiToken | null = null;
-  /** Status derived from the token's lifecycle (active / expired / revoked). */
   status: ApiTokenStatus | null = null;
   loading = true;
   notFound = false;
@@ -50,7 +49,11 @@ export class ApiKeyDetailComponent implements OnInit {
     this.titleService.set(['API Key Details']);
   }
 
-  async ngOnInit(): Promise<void> {
+  ngOnInit() {
+    this.loadToken();
+  }
+
+  private async loadToken(): Promise<void> {
     const id = Number(this.route.snapshot.params['id']);
     if (!Number.isFinite(id)) {
       this.notFound = true;
@@ -76,6 +79,11 @@ export class ApiKeyDetailComponent implements OnInit {
 
   formatTimestamp(ts: number): string {
     return formatUnixTimestamp(ts, this.dateFormat);
+  }
+
+  /** Format an exclusive endValid cutoff as the last second of validity. */
+  formatExpiry(endValidSec: number): string {
+    return formatUnixTimestamp(lastValidSecond(endValidSec), this.dateFormat);
   }
 
   goBack(): void {

--- a/src/app/account/api-keys/api-key-detail/api-key-detail.component.ts
+++ b/src/app/account/api-keys/api-key-detail/api-key-detail.component.ts
@@ -1,6 +1,7 @@
 import { zApiTokenResponse } from '@generated/api/zod';
 import { firstValueFrom } from 'rxjs';
 
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -39,17 +40,16 @@ export class ApiKeyDetailComponent implements OnInit {
   status: ApiTokenStatus | null = null;
   loading = true;
   notFound = false;
+  loadError = false;
 
-  protected dateFormat: string;
-
-  constructor() {
-    const uiSettings = new UISettingsUtilityClass(this.settingsService);
-    const fmt = uiSettings.getSetting('timefmt');
-    this.dateFormat = fmt ? fmt : uiConfigDefault.timefmt;
-    this.titleService.set(['API Key Details']);
-  }
+  protected dateFormat = uiConfigDefault.timefmt;
 
   ngOnInit() {
+    this.titleService.set(['API Key Details']);
+    const fmt = new UISettingsUtilityClass(this.settingsService).getSetting('timefmt');
+    if (fmt) {
+      this.dateFormat = fmt;
+    }
     this.loadToken();
   }
 
@@ -69,9 +69,14 @@ export class ApiKeyDetailComponent implements OnInit {
       });
       this.token = token;
       this.status = computeApiTokenStatus(token);
-    } catch {
-      this.notFound = true;
-      this.alert.showErrorMessage('Could not load API key.');
+    } catch (error) {
+      if (error instanceof HttpErrorResponse && error.status === 404) {
+        this.notFound = true;
+        this.alert.showErrorMessage('Could not load API key.');
+      } else {
+        this.loadError = true;
+        this.alert.showErrorMessage('Could not load API key — please try again later.');
+      }
     } finally {
       this.loading = false;
     }

--- a/src/app/account/api-keys/api-key-detail/api-key-detail.component.ts
+++ b/src/app/account/api-keys/api-key-detail/api-key-detail.component.ts
@@ -1,0 +1,90 @@
+import { zApiTokenResponse } from '@generated/api/zod';
+import { firstValueFrom } from 'rxjs';
+
+import { Component, OnInit, inject } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { ApiTokenStatus, JApiToken, computeApiTokenStatus } from '@models/api-token.model';
+import { UIConfig, uiConfigDefault } from '@models/config-ui.model';
+
+import { JsonAPISerializer } from '@services/api/serializer-service';
+import { SERV } from '@services/main.config';
+import { GlobalService } from '@services/main.service';
+import { RequestParamBuilder } from '@services/params/builder-implementation.service';
+import { AlertService } from '@services/shared/alert.service';
+import { AutoTitleService } from '@services/shared/autotitle.service';
+import { LocalStorageService } from '@services/storage/local-storage.service';
+
+import { Permission } from '@src/app/core/_models/global-permission-group.model';
+import { UISettingsUtilityClass } from '@src/app/shared/utils/config';
+import { formatUnixTimestamp } from '@src/app/shared/utils/datetime';
+import { buildAllPermissionsMap } from '@src/app/shared/utils/permission-matrix';
+
+@Component({
+  selector: 'app-api-key-detail',
+  templateUrl: './api-key-detail.component.html',
+  standalone: false
+})
+export class ApiKeyDetailComponent implements OnInit {
+  private gs = inject(GlobalService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private alert = inject(AlertService);
+  private serializer = inject(JsonAPISerializer);
+  private settingsService = inject<LocalStorageService<UIConfig>>(LocalStorageService);
+  private titleService = inject(AutoTitleService);
+
+  protected readonly ApiTokenStatus = ApiTokenStatus;
+
+  /** Loaded token. Null until the GET resolves; the template gates on this. */
+  token: JApiToken | null = null;
+  /** Status derived from the token's lifecycle (active / expired / revoked). */
+  status: ApiTokenStatus | null = null;
+  /** Resource-by-CRUD map driving the read-only matrix. All keys true → full grid. */
+  fullPermissions: Permission = buildAllPermissionsMap();
+  /** Always empty here: scopes are write-only at creation, never returned. */
+  selection: string[] = [];
+  loading = true;
+  notFound = false;
+
+  protected dateFormat: string;
+
+  constructor() {
+    const uiSettings = new UISettingsUtilityClass(this.settingsService);
+    const fmt = uiSettings.getSetting('timefmt');
+    this.dateFormat = fmt ? fmt : uiConfigDefault.timefmt;
+    this.titleService.set(['API Key Details']);
+  }
+
+  async ngOnInit(): Promise<void> {
+    const id = Number(this.route.snapshot.params['id']);
+    if (!Number.isFinite(id)) {
+      this.notFound = true;
+      this.loading = false;
+      return;
+    }
+
+    try {
+      const params = new RequestParamBuilder().addInclude('user').create();
+      const response = await firstValueFrom(this.gs.get(SERV.API_TOKENS, id, params));
+      const token: JApiToken = this.serializer.deserialize(response, zApiTokenResponse, {
+        include: ['user']
+      });
+      this.token = token;
+      this.status = computeApiTokenStatus(token);
+    } catch {
+      this.notFound = true;
+      this.alert.showErrorMessage('Could not load API key.');
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  formatTimestamp(ts: number): string {
+    return formatUnixTimestamp(ts, this.dateFormat);
+  }
+
+  goBack(): void {
+    void this.router.navigate(['/account/api-keys']);
+  }
+}

--- a/src/app/account/api-keys/api-keys.component.html
+++ b/src/app/account/api-keys/api-keys.component.html
@@ -1,0 +1,9 @@
+<app-table>
+  <app-page-title
+    title="API Keys"
+    buttontitle="New API Key"
+    buttonlink="/account/api-keys/new"
+    [subbutton]="showCreateButton"
+  ></app-page-title>
+  <app-api-tokens-table></app-api-tokens-table>
+</app-table>

--- a/src/app/account/api-keys/api-keys.component.spec.ts
+++ b/src/app/account/api-keys/api-keys.component.spec.ts
@@ -1,0 +1,62 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+
+import { ApiKeyRevealStore } from '@services/api-key-reveal.store';
+import { ApiTokensRoleService } from '@services/roles/user/api-tokens-role.service';
+import { AutoTitleService } from '@services/shared/autotitle.service';
+
+import { ApiKeysComponent } from '@src/app/account/api-keys/api-keys.component';
+import { RevealApiKeyDialogComponent } from '@src/app/account/api-keys/reveal-api-key/reveal-api-key.component';
+
+describe('ApiKeysComponent', () => {
+  let component: ApiKeysComponent;
+  let fixture: ComponentFixture<ApiKeysComponent>;
+
+  let mockStore: jasmine.SpyObj<ApiKeyRevealStore>;
+  let mockDialog: jasmine.SpyObj<MatDialog>;
+  let mockRole: jasmine.SpyObj<ApiTokensRoleService>;
+  let mockTitle: jasmine.SpyObj<AutoTitleService>;
+
+  beforeEach(async () => {
+    mockStore = jasmine.createSpyObj('ApiKeyRevealStore', ['consume', 'set']);
+    mockDialog = jasmine.createSpyObj('MatDialog', ['open']);
+    mockRole = jasmine.createSpyObj('ApiTokensRoleService', ['hasRole']);
+    mockRole.hasRole.and.returnValue(true);
+    mockTitle = jasmine.createSpyObj('AutoTitleService', ['set']);
+
+    await TestBed.configureTestingModule({
+      declarations: [ApiKeysComponent],
+      providers: [
+        { provide: ApiKeyRevealStore, useValue: mockStore },
+        { provide: MatDialog, useValue: mockDialog },
+        { provide: ApiTokensRoleService, useValue: mockRole },
+        { provide: AutoTitleService, useValue: mockTitle }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiKeysComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('opens the reveal dialog with the consumed token on init', () => {
+    mockStore.consume.and.returnValue('jwt-abc');
+
+    fixture.detectChanges();
+
+    expect(mockDialog.open).toHaveBeenCalledWith(
+      RevealApiKeyDialogComponent,
+      jasmine.objectContaining({ data: { token: 'jwt-abc' }, disableClose: true })
+    );
+  });
+
+  it('does not open the reveal dialog when the store is empty', () => {
+    mockStore.consume.and.returnValue(null);
+
+    fixture.detectChanges();
+
+    expect(mockDialog.open).not.toHaveBeenCalled();
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/account/api-keys/api-keys.component.ts
+++ b/src/app/account/api-keys/api-keys.component.ts
@@ -28,7 +28,6 @@ export class ApiKeysComponent implements OnInit {
   }
 
   ngOnInit(): void {
-
     // When we navigate here after creating a key (which is put in the store)
     // show the dialog with the key, is a bit nicer to show it here in the list than on the create screen
     const token = this.revealStore.consume();

--- a/src/app/account/api-keys/api-keys.component.ts
+++ b/src/app/account/api-keys/api-keys.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 
 import { ApiKeyRevealStore } from '@services/api-key-reveal.store';
-import { ApiTokensRoleService } from '@services/roles/user/api-tokens-role.service';
+import { ApiTokensRole, ApiTokensRoleService } from '@services/roles/user/api-tokens-role.service';
 import { AutoTitleService } from '@services/shared/autotitle.service';
 
 import {
@@ -21,7 +21,7 @@ export class ApiKeysComponent implements OnInit {
   private revealStore = inject(ApiKeyRevealStore);
   private dialog = inject(MatDialog);
 
-  protected showCreateButton = this.roleService.hasRole('create');
+  protected showCreateButton = this.roleService.hasRole(ApiTokensRole.CREATE);
 
   constructor() {
     this.titleService.set(['API Keys']);

--- a/src/app/account/api-keys/api-keys.component.ts
+++ b/src/app/account/api-keys/api-keys.component.ts
@@ -1,0 +1,43 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+
+import { ApiKeyRevealStore } from '@services/api-key-reveal.store';
+import { ApiTokensRoleService } from '@services/roles/user/api-tokens-role.service';
+import { AutoTitleService } from '@services/shared/autotitle.service';
+
+import {
+  RevealApiKeyDialogComponent,
+  RevealApiKeyDialogData
+} from '@src/app/account/api-keys/reveal-api-key/reveal-api-key.component';
+
+@Component({
+  selector: 'app-api-keys',
+  templateUrl: './api-keys.component.html',
+  standalone: false
+})
+export class ApiKeysComponent implements OnInit {
+  private roleService = inject(ApiTokensRoleService);
+  private titleService = inject(AutoTitleService);
+  private revealStore = inject(ApiKeyRevealStore);
+  private dialog = inject(MatDialog);
+
+  protected showCreateButton = this.roleService.hasRole('create');
+
+  constructor() {
+    this.titleService.set(['API Keys']);
+  }
+
+  ngOnInit(): void {
+
+    // When we navigate here after creating a key (which is put in the store)
+    // show the dialog with the key, is a bit nicer to show it here in the list than on the create screen
+    const token = this.revealStore.consume();
+    if (token) {
+      this.dialog.open<RevealApiKeyDialogComponent, RevealApiKeyDialogData>(RevealApiKeyDialogComponent, {
+        data: { token },
+        width: '720px',
+        disableClose: true
+      });
+    }
+  }
+}

--- a/src/app/account/api-keys/new-api-key/new-api-key.component.html
+++ b/src/app/account/api-keys/new-api-key/new-api-key.component.html
@@ -7,12 +7,11 @@
       <p class="help-block">The token is shown only once after creation — copy it immediately.</p>
 
       <div class="flex flex-wrap items-start gap-4">
-        <input-date title="Valid From" formControlName="validFrom" hint="DD/MM/YYYY" [isRequired]="true"></input-date>
-        <!-- @TODO -> hint should adhere to format -->
+        <input-date title="Valid From" formControlName="validFrom" [isRequired]="true"></input-date>
         <input-date
           title="Valid Until"
           formControlName="validUntil"
-          hint="DD/MM/YYYY · token valid through end of selected day (23:59:59)"
+          hint="token valid through end of selected day (23:59:59)"
           [isRequired]="true"
         ></input-date>
       </div>

--- a/src/app/account/api-keys/new-api-key/new-api-key.component.html
+++ b/src/app/account/api-keys/new-api-key/new-api-key.component.html
@@ -1,0 +1,57 @@
+<grid-main>
+  <app-page-subtitle [subtitle]="'Create New API Key'"></app-page-subtitle>
+
+  <form [formGroup]="form" (ngSubmit)="onSubmit()">
+    <div class="flex flex-col gap-4">
+      <p class="help-block">API keys let you call the Hashtopolis API programmatically.</p>
+      <p class="help-block">The token is shown only once after creation — copy it immediately.</p>
+
+      <div class="flex flex-wrap items-start gap-4">
+        <input-date title="Valid From" formControlName="validFrom" hint="DD/MM/YYYY" [isRequired]="true"></input-date>
+        <input-date title="Valid Until" formControlName="validUntil" hint="DD/MM/YYYY" [isRequired]="true"></input-date>
+      </div>
+
+      @if (validityDays !== null) {
+        <span class="help-block">Total validity: {{ validityDays }} {{ validityDays === 1 ? 'day' : 'days' }}.</span>
+      }
+
+      @if (form.errors?.['validityRange']) {
+        <span class="help-block text-critical">"Valid Until" must be after "Valid From".</span>
+      }
+
+      <div class="flex flex-col gap-2 mt-2">
+        <span class="font-medium">Scopes</span>
+        @if (loadingScopes) {
+          <div class="loading-spinner">
+            <mat-spinner diameter="24"></mat-spinner>
+            <span>Loading available scopes…</span>
+          </div>
+        } @else if (!granted) {
+          <span class="help-block">No scopes available — you do not currently hold any permissions to grant.</span>
+        } @else {
+          <access-permission-groups-user-table
+            mode="form"
+            [granted]="granted"
+            [selection]="form.controls.scopes.value"
+            (selectionChange)="onSelectionChange($event)"
+          ></access-permission-groups-user-table>
+          @if (form.controls.scopes.touched && form.controls.scopes.hasError('required')) {
+            <span class="help-block text-critical">Pick at least one scope.</span>
+          }
+        }
+      </div>
+    </div>
+
+    <grid-buttons>
+      <div class="flex items-center gap-6">
+        <button mat-stroked-button type="button" routerLink="/account/api-keys">Cancel</button>
+        <button-submit
+          appLoadingButton
+          [loading]="submitting"
+          [name]="submitting ? 'Creating…' : 'Create'"
+          [disabled]="loadingScopes"
+        ></button-submit>
+      </div>
+    </grid-buttons>
+  </form>
+</grid-main>

--- a/src/app/account/api-keys/new-api-key/new-api-key.component.html
+++ b/src/app/account/api-keys/new-api-key/new-api-key.component.html
@@ -8,7 +8,13 @@
 
       <div class="flex flex-wrap items-start gap-4">
         <input-date title="Valid From" formControlName="validFrom" hint="DD/MM/YYYY" [isRequired]="true"></input-date>
-        <input-date title="Valid Until" formControlName="validUntil" hint="DD/MM/YYYY" [isRequired]="true"></input-date>
+        <!-- @TODO -> hint should adhere to format -->
+        <input-date
+          title="Valid Until"
+          formControlName="validUntil"
+          hint="DD/MM/YYYY · token valid through end of selected day (23:59:59)"
+          [isRequired]="true"
+        ></input-date>
       </div>
 
       @if (validityDays !== null) {
@@ -16,7 +22,7 @@
       }
 
       @if (form.errors?.['validityRange']) {
-        <span class="help-block text-critical">"Valid Until" must be after "Valid From".</span>
+        <span class="help-block text-critical">"Valid Until" must be on or after "Valid From".</span>
       }
 
       <div class="flex flex-col gap-2 mt-2">

--- a/src/app/account/api-keys/new-api-key/new-api-key.component.spec.ts
+++ b/src/app/account/api-keys/new-api-key/new-api-key.component.spec.ts
@@ -105,8 +105,9 @@ describe('NewApiKeyComponent', () => {
     component.form.controls.scopes.setValue([Perm.JwtApiKey.READ]);
     mockGlobalService.create.and.returnValue(of(mockResponse()));
 
-    // Pin a specific validUntil so we don't depend on the 90-day default math.
+    const pickedFrom = new Date(2026, 4, 10, 0, 0, 0, 0); // 2026-05-10 local
     const pickedUntil = new Date(2026, 4, 15, 0, 0, 0, 0); // 2026-05-15 local
+    component.form.controls.validFrom.setValue(pickedFrom);
     component.form.controls.validUntil.setValue(pickedUntil);
 
     await component.onSubmit();
@@ -123,7 +124,9 @@ describe('NewApiKeyComponent', () => {
     mockGlobalService.create.and.returnValue(of(mockResponse()));
 
     const pickedFrom = new Date(2026, 4, 1, 9, 30); // 2026-05-01 09:30 local
+    const pickedUntil = new Date(2026, 4, 15, 0, 0, 0, 0); // 2026-05-15 local
     component.form.controls.validFrom.setValue(pickedFrom);
+    component.form.controls.validUntil.setValue(pickedUntil);
 
     await component.onSubmit();
 

--- a/src/app/account/api-keys/new-api-key/new-api-key.component.spec.ts
+++ b/src/app/account/api-keys/new-api-key/new-api-key.component.spec.ts
@@ -1,0 +1,124 @@
+import { of, throwError } from 'rxjs';
+
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+
+import { JApiToken } from '@models/api-token.model';
+import { Permission } from '@models/global-permission-group.model';
+
+import { JsonAPISerializer } from '@services/api/serializer-service';
+import { ApiKeyRevealStore } from '@services/api-key-reveal.store';
+import { SERV } from '@services/main.config';
+import { GlobalService } from '@services/main.service';
+import { PermissionService } from '@services/permission/permission.service';
+import { AlertService } from '@services/shared/alert.service';
+import { AutoTitleService } from '@services/shared/autotitle.service';
+
+import { NewApiKeyComponent } from '@src/app/account/api-keys/new-api-key/new-api-key.component';
+import { mockResponse } from '@src/app/testing/mock-response';
+
+describe('NewApiKeyComponent', () => {
+  let component: NewApiKeyComponent;
+  let fixture: ComponentFixture<NewApiKeyComponent>;
+
+  let mockGlobalService: jasmine.SpyObj<GlobalService>;
+  let mockRouter: jasmine.SpyObj<Router>;
+  let mockAlert: jasmine.SpyObj<AlertService>;
+  let mockPermission: jasmine.SpyObj<PermissionService>;
+  let mockStore: jasmine.SpyObj<ApiKeyRevealStore>;
+  let mockTitle: jasmine.SpyObj<AutoTitleService>;
+  let deserializeSpy: jasmine.Spy;
+
+  /** Token shape returned by the (stubbed) deserializer for the happy path. */
+  const createdToken: JApiToken = {
+    id: 1,
+    type: 'apiToken',
+    startValid: 0,
+    endValid: 1_000,
+    userId: 42,
+    isRevoked: false,
+    token: 'jwt-xyz'
+  };
+
+  beforeEach(async () => {
+    mockGlobalService = jasmine.createSpyObj('GlobalService', ['create']);
+    Object.defineProperty(mockGlobalService, 'userId', { value: 42, configurable: true });
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockRouter.navigate.and.resolveTo(true);
+    mockAlert = jasmine.createSpyObj('AlertService', ['showSuccessMessage', 'showErrorMessage']);
+    mockPermission = jasmine.createSpyObj('PermissionService', ['loadPermissions']);
+    mockPermission.loadPermissions.and.returnValue(of<Permission>({ permJwtApiKeyRead: true }));
+    mockStore = jasmine.createSpyObj('ApiKeyRevealStore', ['set', 'consume']);
+    mockTitle = jasmine.createSpyObj('AutoTitleService', ['set']);
+
+    deserializeSpy = spyOn(JsonAPISerializer.prototype, 'deserialize').and.returnValue(createdToken);
+
+    await TestBed.configureTestingModule({
+      declarations: [NewApiKeyComponent],
+      imports: [ReactiveFormsModule],
+      providers: [
+        { provide: GlobalService, useValue: mockGlobalService },
+        { provide: Router, useValue: mockRouter },
+        { provide: AlertService, useValue: mockAlert },
+        { provide: PermissionService, useValue: mockPermission },
+        { provide: ApiKeyRevealStore, useValue: mockStore },
+        { provide: AutoTitleService, useValue: mockTitle }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NewApiKeyComponent);
+    component = fixture.componentInstance;
+  });
+
+  // We intentionally do not call fixture.detectChanges(): the template binds form
+  // controls to date-picker accessors that aren't declared in this lightweight
+  // module. The form itself is built in the component's field initializer, so
+  // `component.form` is already populated and we can drive onSubmit() directly.
+
+  it('does not call create() when the form is invalid', async () => {
+    // Form starts with empty scopes (Validators.required → invalid).
+    await component.onSubmit();
+
+    expect(mockGlobalService.create).not.toHaveBeenCalled();
+    expect(mockStore.set).not.toHaveBeenCalled();
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+  });
+
+  it('stores the freshly minted token and navigates to the list on success', async () => {
+    component.form.controls.scopes.setValue(['permJwtApiKeyRead']);
+    mockGlobalService.create.and.returnValue(of(mockResponse()));
+
+    await component.onSubmit();
+
+    expect(mockGlobalService.create).toHaveBeenCalledWith(SERV.API_TOKENS, jasmine.objectContaining({ userId: 42 }));
+    expect(mockStore.set).toHaveBeenCalledWith('jwt-xyz');
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/account/api-keys']);
+    expect(mockAlert.showSuccessMessage).toHaveBeenCalled();
+  });
+
+  it('shows an error and navigates without storing when the response has no token', async () => {
+    component.form.controls.scopes.setValue(['permJwtApiKeyRead']);
+    mockGlobalService.create.and.returnValue(of(mockResponse()));
+    deserializeSpy.and.returnValue({ ...createdToken, token: undefined });
+
+    await component.onSubmit();
+
+    expect(mockStore.set).not.toHaveBeenCalled();
+    expect(mockAlert.showErrorMessage).toHaveBeenCalled();
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/account/api-keys']);
+  });
+
+  it('shows an error and does not navigate when the POST fails', async () => {
+    component.form.controls.scopes.setValue(['permJwtApiKeyRead']);
+    mockGlobalService.create.and.returnValue(throwError(() => new Error('boom')));
+
+    await component.onSubmit();
+
+    expect(mockStore.set).not.toHaveBeenCalled();
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+    expect(mockAlert.showErrorMessage).toHaveBeenCalled();
+  });
+});

--- a/src/app/account/api-keys/new-api-key/new-api-key.component.spec.ts
+++ b/src/app/account/api-keys/new-api-key/new-api-key.component.spec.ts
@@ -17,6 +17,7 @@ import { AlertService } from '@services/shared/alert.service';
 import { AutoTitleService } from '@services/shared/autotitle.service';
 
 import { NewApiKeyComponent } from '@src/app/account/api-keys/new-api-key/new-api-key.component';
+import { startOfDay, startOfNextDay, unixTimestampFromDate } from '@src/app/shared/utils/datetime';
 import { mockResponse } from '@src/app/testing/mock-response';
 
 describe('NewApiKeyComponent', () => {
@@ -99,6 +100,39 @@ describe('NewApiKeyComponent', () => {
     expect(mockAlert.showSuccessMessage).toHaveBeenCalled();
   });
 
+  it('sends endValid as the exclusive next-day-midnight cutoff (not end-of-picked-day)', async () => {
+    component.form.controls.scopes.setValue(['permJwtApiKeyRead']);
+    mockGlobalService.create.and.returnValue(of(mockResponse()));
+
+    // Pin a specific validUntil so we don't depend on the 90-day default math.
+    const pickedUntil = new Date(2026, 4, 15, 0, 0, 0, 0); // 2026-05-15 local
+    component.form.controls.validUntil.setValue(pickedUntil);
+
+    await component.onSubmit();
+
+    const expectedEndValid = unixTimestampFromDate(startOfNextDay(pickedUntil));
+    expect(mockGlobalService.create).toHaveBeenCalledWith(
+      SERV.API_TOKENS,
+      jasmine.objectContaining({ endValid: expectedEndValid })
+    );
+  });
+
+  it('sends startValid as start-of-day of the picked validFrom', async () => {
+    component.form.controls.scopes.setValue(['permJwtApiKeyRead']);
+    mockGlobalService.create.and.returnValue(of(mockResponse()));
+
+    const pickedFrom = new Date(2026, 4, 1, 9, 30); // 2026-05-01 09:30 local
+    component.form.controls.validFrom.setValue(pickedFrom);
+
+    await component.onSubmit();
+
+    const expectedStartValid = unixTimestampFromDate(startOfDay(pickedFrom));
+    expect(mockGlobalService.create).toHaveBeenCalledWith(
+      SERV.API_TOKENS,
+      jasmine.objectContaining({ startValid: expectedStartValid })
+    );
+  });
+
   it('shows an error and navigates without storing when the response has no token', async () => {
     component.form.controls.scopes.setValue(['permJwtApiKeyRead']);
     mockGlobalService.create.and.returnValue(of(mockResponse()));
@@ -120,5 +154,64 @@ describe('NewApiKeyComponent', () => {
     expect(mockStore.set).not.toHaveBeenCalled();
     expect(mockRouter.navigate).not.toHaveBeenCalled();
     expect(mockAlert.showErrorMessage).toHaveBeenCalled();
+  });
+
+  describe('validityDays getter', () => {
+    // The mat-datepicker emits picked dates at 00:00:00 local time, so the
+    // getter must normalise to whole-day boundaries to report an inclusive
+    // day count regardless of what time the form value carries.
+
+    it('counts a three-day range inclusively when the picker emits midnight values', () => {
+      component.form.controls.validFrom.setValue(new Date(2026, 4, 11, 0, 0, 0, 0));
+      component.form.controls.validUntil.setValue(new Date(2026, 4, 13, 0, 0, 0, 0));
+
+      expect(component.validityDays).toBe(3);
+    });
+
+    it('counts a same-day pick as one day', () => {
+      const sameDay = new Date(2026, 4, 11, 0, 0, 0, 0);
+      component.form.controls.validFrom.setValue(sameDay);
+      component.form.controls.validUntil.setValue(sameDay);
+
+      expect(component.validityDays).toBe(1);
+    });
+
+    it('returns null when validFrom is missing', () => {
+      component.form.controls.validFrom.setValue(null);
+      component.form.controls.validUntil.setValue(new Date(2026, 4, 13, 0, 0, 0, 0));
+
+      expect(component.validityDays).toBeNull();
+    });
+
+    it('returns null when validUntil is before validFrom', () => {
+      component.form.controls.validFrom.setValue(new Date(2026, 4, 13, 0, 0, 0, 0));
+      component.form.controls.validUntil.setValue(new Date(2026, 4, 11, 0, 0, 0, 0));
+
+      expect(component.validityDays).toBeNull();
+    });
+  });
+
+  describe('validity range validator', () => {
+    it('accepts same-day picks at midnight', () => {
+      const sameDay = new Date(2026, 4, 11, 0, 0, 0, 0);
+      component.form.controls.validFrom.setValue(sameDay);
+      component.form.controls.validUntil.setValue(sameDay);
+
+      expect(component.form.errors?.['validityRange']).toBeFalsy();
+    });
+
+    it('accepts validUntil strictly after validFrom', () => {
+      component.form.controls.validFrom.setValue(new Date(2026, 4, 11, 0, 0, 0, 0));
+      component.form.controls.validUntil.setValue(new Date(2026, 4, 13, 0, 0, 0, 0));
+
+      expect(component.form.errors?.['validityRange']).toBeFalsy();
+    });
+
+    it('rejects validUntil strictly before validFrom', () => {
+      component.form.controls.validFrom.setValue(new Date(2026, 4, 13, 0, 0, 0, 0));
+      component.form.controls.validUntil.setValue(new Date(2026, 4, 11, 0, 0, 0, 0));
+
+      expect(component.form.errors?.['validityRange']).toBeTrue();
+    });
   });
 });

--- a/src/app/account/api-keys/new-api-key/new-api-key.component.spec.ts
+++ b/src/app/account/api-keys/new-api-key/new-api-key.component.spec.ts
@@ -17,6 +17,7 @@ import { AlertService } from '@services/shared/alert.service';
 import { AutoTitleService } from '@services/shared/autotitle.service';
 
 import { NewApiKeyComponent } from '@src/app/account/api-keys/new-api-key/new-api-key.component';
+import { Perm } from '@src/app/core/_constants/userpermissions.config';
 import { startOfDay, startOfNextDay, unixTimestampFromDate } from '@src/app/shared/utils/datetime';
 import { mockResponse } from '@src/app/testing/mock-response';
 
@@ -89,7 +90,7 @@ describe('NewApiKeyComponent', () => {
   });
 
   it('stores the freshly minted token and navigates to the list on success', async () => {
-    component.form.controls.scopes.setValue(['permJwtApiKeyRead']);
+    component.form.controls.scopes.setValue([Perm.JwtApiKey.READ]);
     mockGlobalService.create.and.returnValue(of(mockResponse()));
 
     await component.onSubmit();
@@ -101,7 +102,7 @@ describe('NewApiKeyComponent', () => {
   });
 
   it('sends endValid as the exclusive next-day-midnight cutoff (not end-of-picked-day)', async () => {
-    component.form.controls.scopes.setValue(['permJwtApiKeyRead']);
+    component.form.controls.scopes.setValue([Perm.JwtApiKey.READ]);
     mockGlobalService.create.and.returnValue(of(mockResponse()));
 
     // Pin a specific validUntil so we don't depend on the 90-day default math.
@@ -118,7 +119,7 @@ describe('NewApiKeyComponent', () => {
   });
 
   it('sends startValid as start-of-day of the picked validFrom', async () => {
-    component.form.controls.scopes.setValue(['permJwtApiKeyRead']);
+    component.form.controls.scopes.setValue([Perm.JwtApiKey.READ]);
     mockGlobalService.create.and.returnValue(of(mockResponse()));
 
     const pickedFrom = new Date(2026, 4, 1, 9, 30); // 2026-05-01 09:30 local
@@ -134,7 +135,7 @@ describe('NewApiKeyComponent', () => {
   });
 
   it('shows an error and navigates without storing when the response has no token', async () => {
-    component.form.controls.scopes.setValue(['permJwtApiKeyRead']);
+    component.form.controls.scopes.setValue([Perm.JwtApiKey.READ]);
     mockGlobalService.create.and.returnValue(of(mockResponse()));
     deserializeSpy.and.returnValue({ ...createdToken, token: undefined });
 
@@ -145,8 +146,22 @@ describe('NewApiKeyComponent', () => {
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/account/api-keys']);
   });
 
+  it('shows an error when validFrom is missing even if the form-invalid guard is bypassed', async () => {
+    // Validators.required normally keeps the form invalid when validFrom is null, so
+    // onSubmit() would short-circuit at the first guard. This test exercises the
+    // defensive backstop just below it by forcing form.invalid to false.
+    component.form.controls.scopes.setValue([Perm.JwtApiKey.READ]);
+    component.form.controls.validFrom.setValue(null);
+    spyOnProperty(component.form, 'invalid', 'get').and.returnValue(false);
+
+    await component.onSubmit();
+
+    expect(mockGlobalService.create).not.toHaveBeenCalled();
+    expect(mockAlert.showErrorMessage).toHaveBeenCalled();
+  });
+
   it('shows an error and does not navigate when the POST fails', async () => {
-    component.form.controls.scopes.setValue(['permJwtApiKeyRead']);
+    component.form.controls.scopes.setValue([Perm.JwtApiKey.READ]);
     mockGlobalService.create.and.returnValue(throwError(() => new Error('boom')));
 
     await component.onSubmit();

--- a/src/app/account/api-keys/new-api-key/new-api-key.component.ts
+++ b/src/app/account/api-keys/new-api-key/new-api-key.component.ts
@@ -1,0 +1,123 @@
+import { zApiTokenPostPatchResponse } from '@generated/api/zod';
+import { firstValueFrom } from 'rxjs';
+
+import { Component, OnInit, inject } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { Router } from '@angular/router';
+
+import { JApiToken } from '@models/api-token.model';
+import { Permission } from '@models/global-permission-group.model';
+
+import { JsonAPISerializer } from '@services/api/serializer-service';
+import { ApiKeyRevealStore } from '@services/api-key-reveal.store';
+import { SERV } from '@services/main.config';
+import { GlobalService } from '@services/main.service';
+import { PermissionService } from '@services/permission/permission.service';
+import { AlertService } from '@services/shared/alert.service';
+import { AutoTitleService } from '@services/shared/autotitle.service';
+
+import { NewApiKeyForm, getNewApiKeyForm } from '@src/app/account/api-keys/new-api-key/new-api-key.form';
+import { endOfDay, startOfDay } from '@src/app/shared/utils/datetime';
+
+@Component({
+  selector: 'app-new-api-key',
+  templateUrl: './new-api-key.component.html',
+  standalone: false
+})
+export class NewApiKeyComponent implements OnInit {
+  private gs = inject(GlobalService);
+  private router = inject(Router);
+  private alert = inject(AlertService);
+  private permissionService = inject(PermissionService);
+  private revealStore = inject(ApiKeyRevealStore);
+  private titleService = inject(AutoTitleService);
+
+  form: FormGroup<NewApiKeyForm> = getNewApiKeyForm();
+  /**
+   * The current user's permission map. The matrix only allows toggling cells
+   * the user holds (`granted[key] === true`); the rest render disabled with
+   * an explanatory tooltip. Backend would reject any scope the user can't
+   * grant themselves, so this filter shapes both the UI and avoids
+   * guaranteed-failed requests.
+   */
+  granted?: Permission;
+  loadingScopes = false;
+  submitting = false;
+
+  get validityDays(): number | null {
+    const from = this.form.controls.validFrom.value;
+    const until = this.form.controls.validUntil.value;
+    if (!from || !until) {
+      return null;
+    }
+    const days = Math.round((until.getTime() - from.getTime()) / (24 * 60 * 60 * 1000));
+    return days > 0 ? days : null;
+  }
+
+  ngOnInit(): void {
+    this.titleService.set(['New API Key']);
+    void this.loadGranted();
+  }
+
+  private async loadGranted(): Promise<void> {
+    this.loadingScopes = true;
+    try {
+      this.granted = await firstValueFrom(this.permissionService.loadPermissions());
+      const allGranted = Object.entries(this.granted)
+        .filter(([, held]) => held)
+        .map(([key]) => key);
+      this.form.controls.scopes.setValue(allGranted);
+    } catch {
+      this.alert.showErrorMessage('Could not load available scopes for this user.');
+    } finally {
+      this.loadingScopes = false;
+    }
+  }
+
+  onSelectionChange(next: string[]): void {
+    this.form.controls.scopes.setValue(next);
+    this.form.controls.scopes.markAsDirty();
+  }
+
+  async onSubmit(): Promise<void> {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const { validFrom, validUntil, scopes } = this.form.getRawValue();
+    if (!validFrom || !validUntil) {
+      return;
+    }
+
+    this.submitting = true;
+    try {
+      const payload = {
+        scopes,
+        startValid: Math.floor(startOfDay(validFrom).getTime() / 1000),
+        endValid: Math.floor(endOfDay(validUntil).getTime() / 1000),
+        userId: this.gs.userId,
+        isRevoked: false
+      };
+
+      const response = await firstValueFrom(this.gs.create(SERV.API_TOKENS, payload));
+      const created: JApiToken = new JsonAPISerializer().deserialize(response, zApiTokenPostPatchResponse);
+
+      if (!created.token) {
+        // No token in the response means we can't show the user anything useful;
+        // the row will appear in the list but the secret is unrecoverable.
+        this.alert.showErrorMessage('API key was created but no token was returned. Please contact an administrator.');
+        await this.router.navigate(['/account/api-keys']);
+        return;
+      }
+
+      this.revealStore.set(created.token);
+      this.alert.showSuccessMessage('API key created.');
+      await this.router.navigate(['/account/api-keys']);
+    } catch {
+      this.alert.showErrorMessage('Could not create API key.');
+    } finally {
+      this.submitting = false;
+    }
+  }
+}

--- a/src/app/account/api-keys/new-api-key/new-api-key.component.ts
+++ b/src/app/account/api-keys/new-api-key/new-api-key.component.ts
@@ -17,6 +17,7 @@ import { AlertService } from '@services/shared/alert.service';
 import { AutoTitleService } from '@services/shared/autotitle.service';
 
 import { NewApiKeyForm, getNewApiKeyForm } from '@src/app/account/api-keys/new-api-key/new-api-key.form';
+import { PermissionValues } from '@src/app/core/_constants/userpermissions.config';
 import {
   daysBetween,
   endOfDay,
@@ -52,16 +53,6 @@ export class NewApiKeyComponent implements OnInit {
   loadingScopes = false;
   submitting = false;
 
-  get validityDays(): number | null {
-    const from = this.form.controls.validFrom.value;
-    const until = this.form.controls.validUntil.value;
-    if (!from || !until) {
-      return null;
-    }
-    const days = daysBetween(startOfDay(from), endOfDay(until));
-    return days > 0 ? days : null;
-  }
-
   ngOnInit(): void {
     this.titleService.set(['New API Key']);
     void this.loadGranted();
@@ -71,9 +62,11 @@ export class NewApiKeyComponent implements OnInit {
     this.loadingScopes = true;
     try {
       this.granted = await firstValueFrom(this.permissionService.loadPermissions());
+      // Permission is a Record<string, boolean>, so the filtered keys come back as
+      // string[]. We trust the backend's map to be keyed by valid PermissionValues.
       const allGranted = Object.entries(this.granted)
         .filter(([, held]) => held)
-        .map(([key]) => key);
+        .map(([key]) => key) as PermissionValues[];
       this.form.controls.scopes.setValue(allGranted);
     } catch {
       this.alert.showErrorMessage('Could not load available scopes for this user.');
@@ -82,7 +75,7 @@ export class NewApiKeyComponent implements OnInit {
     }
   }
 
-  onSelectionChange(next: string[]): void {
+  onSelectionChange(next: PermissionValues[]): void {
     this.form.controls.scopes.setValue(next);
     this.form.controls.scopes.markAsDirty();
   }
@@ -95,6 +88,7 @@ export class NewApiKeyComponent implements OnInit {
 
     const { validFrom, validUntil, scopes } = this.form.getRawValue();
     if (!validFrom || !validUntil) {
+      this.alert.showErrorMessage('Please select a valid date range.');
       return;
     }
 
@@ -114,8 +108,6 @@ export class NewApiKeyComponent implements OnInit {
       const created: JApiToken = new JsonAPISerializer().deserialize(response, zApiTokenPostPatchResponse);
 
       if (!created.token) {
-        // No token in the response means we can't show the user anything useful;
-        // the row will appear in the list but the secret is unrecoverable.
         this.alert.showErrorMessage('API key was created but no token was returned. Please contact an administrator.');
         await this.router.navigate(['/account/api-keys']);
         return;
@@ -129,5 +121,15 @@ export class NewApiKeyComponent implements OnInit {
     } finally {
       this.submitting = false;
     }
+  }
+
+  get validityDays(): number | null {
+    const from = this.form.controls.validFrom.value;
+    const until = this.form.controls.validUntil.value;
+    if (!from || !until) {
+      return null;
+    }
+    const days = daysBetween(startOfDay(from), endOfDay(until));
+    return days > 0 ? days : null;
   }
 }

--- a/src/app/account/api-keys/new-api-key/new-api-key.component.ts
+++ b/src/app/account/api-keys/new-api-key/new-api-key.component.ts
@@ -17,7 +17,13 @@ import { AlertService } from '@services/shared/alert.service';
 import { AutoTitleService } from '@services/shared/autotitle.service';
 
 import { NewApiKeyForm, getNewApiKeyForm } from '@src/app/account/api-keys/new-api-key/new-api-key.form';
-import { endOfDay, startOfDay } from '@src/app/shared/utils/datetime';
+import {
+  daysBetween,
+  endOfDay,
+  startOfDay,
+  startOfNextDay,
+  unixTimestampFromDate
+} from '@src/app/shared/utils/datetime';
 
 @Component({
   selector: 'app-new-api-key',
@@ -32,7 +38,9 @@ export class NewApiKeyComponent implements OnInit {
   private revealStore = inject(ApiKeyRevealStore);
   private titleService = inject(AutoTitleService);
 
-  form: FormGroup<NewApiKeyForm> = getNewApiKeyForm();
+  private static readonly DEFAULT_VALIDITY_DAYS = 90;
+
+  form: FormGroup<NewApiKeyForm> = getNewApiKeyForm(NewApiKeyComponent.DEFAULT_VALIDITY_DAYS);
   /**
    * The current user's permission map. The matrix only allows toggling cells
    * the user holds (`granted[key] === true`); the rest render disabled with
@@ -50,7 +58,7 @@ export class NewApiKeyComponent implements OnInit {
     if (!from || !until) {
       return null;
     }
-    const days = Math.round((until.getTime() - from.getTime()) / (24 * 60 * 60 * 1000));
+    const days = daysBetween(startOfDay(from), endOfDay(until));
     return days > 0 ? days : null;
   }
 
@@ -94,8 +102,10 @@ export class NewApiKeyComponent implements OnInit {
     try {
       const payload = {
         scopes,
-        startValid: Math.floor(startOfDay(validFrom).getTime() / 1000),
-        endValid: Math.floor(endOfDay(validUntil).getTime() / 1000),
+        startValid: unixTimestampFromDate(startOfDay(validFrom)),
+        // endValid is an *exclusive* cutoff: the token is valid through the
+        // whole picked day and expires exactly at the next-day midnight.
+        endValid: unixTimestampFromDate(startOfNextDay(validUntil)),
         userId: this.gs.userId,
         isRevoked: false
       };

--- a/src/app/account/api-keys/new-api-key/new-api-key.form.ts
+++ b/src/app/account/api-keys/new-api-key/new-api-key.form.ts
@@ -3,16 +3,11 @@ import { FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } fro
 import { endOfDay, startOfDay } from '@src/app/shared/utils/datetime';
 
 /**
- * Reactive form shape for the New API Key page.
+ * Form for generating a new API key.
  *
  * Times are picked as `Date` objects in the form and converted to unix-second
- * timestamps at submit time (the only place the conversion happens, to keep the
- * UI free of timestamp arithmetic).
- *
+ * timestamps at submit time.
  * `scopes` is an array of permission name strings (e.g. `permTaskRead`).
- * Numeric indices were considered but rejected: the backend matches scopes by
- * name against the user's right-group permission map, so passing names through
- * unchanged avoids an avoidable id↔name lookup.
  */
 export interface NewApiKeyForm {
   validFrom: FormControl<Date | null>;
@@ -20,24 +15,23 @@ export interface NewApiKeyForm {
   scopes: FormControl<string[]>;
 }
 
-const DEFAULT_VALIDITY_DAYS = 90;
-
-const validityRangeValidator: ValidatorFn = (group): ValidationErrors | null => {
-  const from = group.get('validFrom')?.value as Date | null;
-  const until = group.get('validUntil')?.value as Date | null;
-  if (from && until && until.getTime() <= from.getTime()) {
+const validityRangeValidator: ValidatorFn = (control): ValidationErrors | null => {
+  const { validFrom, validUntil } = (control as FormGroup<NewApiKeyForm>).controls;
+  const from = validFrom.value;
+  const until = validUntil.value;
+  if (from && until && startOfDay(until).getTime() < startOfDay(from).getTime()) {
     return { validityRange: true };
   }
   return null;
 };
 
-/** Build a New API Key form pre-filled with sensible defaults (90-day validity, no scopes). */
-export const getNewApiKeyForm = (): FormGroup<NewApiKeyForm> => {
+/** Build a New API Key form pre-filled with sensible defaults (`validityDays` calendar days, no scopes). */
+export const getNewApiKeyForm = (validityDays: number): FormGroup<NewApiKeyForm> => {
   // Inclusive day count: from = today 00:00, until = day (N-1) 23:59:59 → exactly N calendar days.
-  // Using +DEFAULT_VALIDITY_DAYS would inclusive-count to N+1 and the help text would disagree.
+  // Using +validityDays would inclusive-count to N+1 and the help text would disagree.
   const validFrom = startOfDay(new Date());
   const lastDay = new Date(validFrom);
-  lastDay.setDate(lastDay.getDate() + DEFAULT_VALIDITY_DAYS - 1);
+  lastDay.setDate(lastDay.getDate() + validityDays - 1);
   const validUntil = endOfDay(lastDay);
 
   return new FormGroup<NewApiKeyForm>(

--- a/src/app/account/api-keys/new-api-key/new-api-key.form.ts
+++ b/src/app/account/api-keys/new-api-key/new-api-key.form.ts
@@ -1,5 +1,6 @@
 import { FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 
+import { PermissionValues } from '@src/app/core/_constants/userpermissions.config';
 import { endOfDay, startOfDay } from '@src/app/shared/utils/datetime';
 
 /**
@@ -7,12 +8,12 @@ import { endOfDay, startOfDay } from '@src/app/shared/utils/datetime';
  *
  * Times are picked as `Date` objects in the form and converted to unix-second
  * timestamps at submit time.
- * `scopes` is an array of permission name strings (e.g. `permTaskRead`).
+ * `scopes` is an array of permission keys from the `Perm` enum tree (e.g. `permTaskRead`).
  */
 export interface NewApiKeyForm {
   validFrom: FormControl<Date | null>;
   validUntil: FormControl<Date | null>;
-  scopes: FormControl<string[]>;
+  scopes: FormControl<PermissionValues[]>;
 }
 
 const validityRangeValidator: ValidatorFn = (control): ValidationErrors | null => {
@@ -25,10 +26,9 @@ const validityRangeValidator: ValidatorFn = (control): ValidationErrors | null =
   return null;
 };
 
-/** Build a New API Key form pre-filled with sensible defaults (`validityDays` calendar days, no scopes). */
 export const getNewApiKeyForm = (validityDays: number): FormGroup<NewApiKeyForm> => {
   // Inclusive day count: from = today 00:00, until = day (N-1) 23:59:59 → exactly N calendar days.
-  // Using +validityDays would inclusive-count to N+1 and the help text would disagree.
+  // Inclusive day count from today 00:00 to day + (N-1) 23:59:59
   const validFrom = startOfDay(new Date());
   const lastDay = new Date(validFrom);
   lastDay.setDate(lastDay.getDate() + validityDays - 1);
@@ -38,7 +38,7 @@ export const getNewApiKeyForm = (validityDays: number): FormGroup<NewApiKeyForm>
     {
       validFrom: new FormControl<Date | null>(validFrom, [Validators.required]),
       validUntil: new FormControl<Date | null>(validUntil, [Validators.required]),
-      scopes: new FormControl<string[]>([], { nonNullable: true, validators: [Validators.required] })
+      scopes: new FormControl<PermissionValues[]>([], { nonNullable: true, validators: [Validators.required] })
     },
     { validators: [validityRangeValidator] }
   );

--- a/src/app/account/api-keys/new-api-key/new-api-key.form.ts
+++ b/src/app/account/api-keys/new-api-key/new-api-key.form.ts
@@ -1,0 +1,51 @@
+import { FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+
+import { endOfDay, startOfDay } from '@src/app/shared/utils/datetime';
+
+/**
+ * Reactive form shape for the New API Key page.
+ *
+ * Times are picked as `Date` objects in the form and converted to unix-second
+ * timestamps at submit time (the only place the conversion happens, to keep the
+ * UI free of timestamp arithmetic).
+ *
+ * `scopes` is an array of permission name strings (e.g. `permTaskRead`).
+ * Numeric indices were considered but rejected: the backend matches scopes by
+ * name against the user's right-group permission map, so passing names through
+ * unchanged avoids an avoidable id↔name lookup.
+ */
+export interface NewApiKeyForm {
+  validFrom: FormControl<Date | null>;
+  validUntil: FormControl<Date | null>;
+  scopes: FormControl<string[]>;
+}
+
+const DEFAULT_VALIDITY_DAYS = 90;
+
+const validityRangeValidator: ValidatorFn = (group): ValidationErrors | null => {
+  const from = group.get('validFrom')?.value as Date | null;
+  const until = group.get('validUntil')?.value as Date | null;
+  if (from && until && until.getTime() <= from.getTime()) {
+    return { validityRange: true };
+  }
+  return null;
+};
+
+/** Build a New API Key form pre-filled with sensible defaults (90-day validity, no scopes). */
+export const getNewApiKeyForm = (): FormGroup<NewApiKeyForm> => {
+  // Inclusive day count: from = today 00:00, until = day (N-1) 23:59:59 → exactly N calendar days.
+  // Using +DEFAULT_VALIDITY_DAYS would inclusive-count to N+1 and the help text would disagree.
+  const validFrom = startOfDay(new Date());
+  const lastDay = new Date(validFrom);
+  lastDay.setDate(lastDay.getDate() + DEFAULT_VALIDITY_DAYS - 1);
+  const validUntil = endOfDay(lastDay);
+
+  return new FormGroup<NewApiKeyForm>(
+    {
+      validFrom: new FormControl<Date | null>(validFrom, [Validators.required]),
+      validUntil: new FormControl<Date | null>(validUntil, [Validators.required]),
+      scopes: new FormControl<string[]>([], { nonNullable: true, validators: [Validators.required] })
+    },
+    { validators: [validityRangeValidator] }
+  );
+};

--- a/src/app/account/api-keys/reveal-api-key/reveal-api-key.component.html
+++ b/src/app/account/api-keys/reveal-api-key/reveal-api-key.component.html
@@ -1,0 +1,25 @@
+<h2 mat-dialog-title>API Key Created</h2>
+<mat-dialog-content>
+  <div class="flex flex-col gap-4">
+    <div class="p-4 border border-warning rounded text-warning">
+      <strong>Save this token now.</strong> Hashtopolis will never display it again. If you lose it, revoke this key and
+      create a new one.
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <label class="font-medium" for="api-key-token-output">API Key</label>
+      <textarea
+        id="api-key-token-output"
+        class="w-full font-mono text-sm p-2 border rounded"
+        rows="8"
+        readonly
+        [value]="token"
+        (focus)="$any($event.target).select()"
+      ></textarea>
+    </div>
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-stroked-button type="button" (click)="copy()"><mat-icon>content_copy</mat-icon> Copy to Clipboard</button>
+  <button mat-flat-button color="primary" type="button" (click)="done()">Done</button>
+</mat-dialog-actions>

--- a/src/app/account/api-keys/reveal-api-key/reveal-api-key.component.spec.ts
+++ b/src/app/account/api-keys/reveal-api-key/reveal-api-key.component.spec.ts
@@ -1,0 +1,64 @@
+import { Clipboard } from '@angular/cdk/clipboard';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+import { AlertService } from '@services/shared/alert.service';
+
+import { RevealApiKeyDialogComponent } from '@src/app/account/api-keys/reveal-api-key/reveal-api-key.component';
+
+describe('RevealApiKeyDialogComponent', () => {
+  let component: RevealApiKeyDialogComponent;
+  let fixture: ComponentFixture<RevealApiKeyDialogComponent>;
+
+  let mockClipboard: jasmine.SpyObj<Clipboard>;
+  let mockAlert: jasmine.SpyObj<AlertService>;
+  let mockDialogRef: jasmine.SpyObj<MatDialogRef<RevealApiKeyDialogComponent>>;
+
+  beforeEach(async () => {
+    mockClipboard = jasmine.createSpyObj('Clipboard', ['copy']);
+    mockAlert = jasmine.createSpyObj('AlertService', ['showSuccessMessage', 'showErrorMessage']);
+    mockDialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    await TestBed.configureTestingModule({
+      declarations: [RevealApiKeyDialogComponent],
+      providers: [
+        { provide: Clipboard, useValue: mockClipboard },
+        { provide: AlertService, useValue: mockAlert },
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: { token: 'jwt-abc' } }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RevealApiKeyDialogComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('exposes the token from MAT_DIALOG_DATA', () => {
+    expect(component.token).toBe('jwt-abc');
+  });
+
+  it('shows a success message when the clipboard write succeeds', () => {
+    mockClipboard.copy.and.returnValue(true);
+
+    component.copy();
+
+    expect(mockClipboard.copy).toHaveBeenCalledWith('jwt-abc');
+    expect(mockAlert.showSuccessMessage).toHaveBeenCalled();
+  });
+
+  it('shows an error message when the clipboard write fails', () => {
+    mockClipboard.copy.and.returnValue(false);
+
+    component.copy();
+
+    expect(mockAlert.showErrorMessage).toHaveBeenCalled();
+  });
+
+  it('closes the dialog when done() is called', () => {
+    component.done();
+
+    expect(mockDialogRef.close).toHaveBeenCalled();
+  });
+});

--- a/src/app/account/api-keys/reveal-api-key/reveal-api-key.component.ts
+++ b/src/app/account/api-keys/reveal-api-key/reveal-api-key.component.ts
@@ -1,0 +1,36 @@
+import { Clipboard } from '@angular/cdk/clipboard';
+import { Component, inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+import { AlertService } from '@services/shared/alert.service';
+
+export interface RevealApiKeyDialogData {
+  token: string;
+}
+
+@Component({
+  selector: 'app-reveal-api-key-dialog',
+  templateUrl: './reveal-api-key.component.html',
+  standalone: false
+})
+export class RevealApiKeyDialogComponent {
+  private clipboard = inject(Clipboard);
+  private alert = inject(AlertService);
+  private dialogRef = inject(MatDialogRef<RevealApiKeyDialogComponent>);
+
+  /** The freshly minted JWT, handed in by the list page after consuming the reveal store. */
+  readonly token: string = inject<RevealApiKeyDialogData>(MAT_DIALOG_DATA).token;
+
+  copy(): void {
+    const ok = this.clipboard.copy(this.token);
+    if (ok) {
+      this.alert.showSuccessMessage('API key copied to clipboard.');
+    } else {
+      this.alert.showErrorMessage('Could not copy to clipboard. Please copy manually.');
+    }
+  }
+
+  done(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/account/api-keys/reveal-api-key/reveal-api-key.component.ts
+++ b/src/app/account/api-keys/reveal-api-key/reveal-api-key.component.ts
@@ -18,7 +18,6 @@ export class RevealApiKeyDialogComponent {
   private alert = inject(AlertService);
   private dialogRef = inject(MatDialogRef<RevealApiKeyDialogComponent>);
 
-  /** The freshly minted JWT, handed in by the list page after consuming the reveal store. */
   readonly token: string = inject<RevealApiKeyDialogData>(MAT_DIALOG_DATA).token;
 
   copy(): void {

--- a/src/app/core/_components/core-components.module.ts
+++ b/src/app/core/_components/core-components.module.ts
@@ -37,6 +37,7 @@ import { AgentBinariesTableComponent } from '@components/tables/agent-binaries-t
 import { AgentErrorTableComponent } from '@components/tables/agent-error-table/agent-error-table.component';
 import { AgentsStatusTableComponent } from '@components/tables/agents-status-table/agents-status-table.component';
 import { AgentsTableComponent } from '@components/tables/agents-table/agents-table.component';
+import { ApiTokensTableComponent } from '@components/tables/api-tokens-table/api-tokens-table.component';
 import { BaseTableComponent } from '@components/tables/base-table/base-table.component';
 import { ChunksTableComponent } from '@components/tables/chunks-table/chunks-table.component';
 import { ColumnSelectionDialogComponent } from '@components/tables/column-selection-dialog/column-selection-dialog.component';
@@ -120,6 +121,7 @@ import { LastUpdatedComponent } from '@src/app/shared/widgets/last-updated/last-
     AccessPermissionGroupsUserTableComponent,
     AccessPermissionGroupsUsersTableComponent,
     NotificationsTableComponent,
+    ApiTokensTableComponent,
     PermissionsTableComponent,
     CracksTableComponent,
     VouchersTableComponent,
@@ -200,6 +202,7 @@ import { LastUpdatedComponent } from '@src/app/shared/widgets/last-updated/last-
     AccessPermissionGroupsUserTableComponent,
     AccessPermissionGroupsUsersTableComponent,
     NotificationsTableComponent,
+    ApiTokensTableComponent,
     PermissionsTableComponent,
     CracksTableComponent,
     VouchersTableComponent,

--- a/src/app/core/_components/menus/action-menu/action-menu.component.html
+++ b/src/app/core/_components/menus/action-menu/action-menu.component.html
@@ -1,24 +1,26 @@
 @if (openOnMouseEnter) {
-  <button
-    mat-button
-    #menuTrigger="matMenuTrigger"
-    #menuTriggerButton
-    [ngClass]="cls"
-    [matMenuTriggerFor]="actionMenu"
-    (click)="navigateToFirst($event)"
-    (mouseenter)="onMouseEnter()"
-    (mouseleave)="onMouseLeave($event)"
-    (focus)="preventFocus($event)"
-    [disabled]="disabled"
-    [class.active]="isActive"
-  >
-    @if (icon) {
-      <mat-icon>{{ icon }}</mat-icon>
-    }
-    @if (label) {
-      {{ label }}
-    }
-  </button>
+  <span [matTooltip]="disabledTooltip" [matTooltipDisabled]="!disabled || !disabledTooltip">
+    <button
+      mat-button
+      #menuTrigger="matMenuTrigger"
+      #menuTriggerButton
+      [ngClass]="cls"
+      [matMenuTriggerFor]="actionMenu"
+      (click)="navigateToFirst($event)"
+      (mouseenter)="onMouseEnter()"
+      (mouseleave)="onMouseLeave($event)"
+      (focus)="preventFocus($event)"
+      [disabled]="disabled"
+      [class.active]="isActive"
+    >
+      @if (icon) {
+        <mat-icon>{{ icon }}</mat-icon>
+      }
+      @if (label) {
+        {{ label }}
+      }
+    </button>
+  </span>
   <mat-menu
     #actionMenu="matMenu"
     [hasBackdrop]="false"
@@ -78,22 +80,24 @@
 }
 
 @if (!openOnMouseEnter) {
-  <button
-    mat-button
-    [ngClass]="cls"
-    [matMenuTriggerFor]="actionMenu"
-    #menuTrigger="matMenuTrigger"
-    (click)="$event.stopPropagation()"
-    [disabled]="disabled"
-    [class.active]="isActive"
-  >
-    @if (icon) {
-      <mat-icon>{{ icon }}</mat-icon>
-    }
-    @if (label) {
-      {{ label }}
-    }
-  </button>
+  <span [matTooltip]="disabledTooltip" [matTooltipDisabled]="!disabled || !disabledTooltip">
+    <button
+      mat-button
+      [ngClass]="cls"
+      [matMenuTriggerFor]="actionMenu"
+      #menuTrigger="matMenuTrigger"
+      (click)="$event.stopPropagation()"
+      [disabled]="disabled"
+      [class.active]="isActive"
+    >
+      @if (icon) {
+        <mat-icon>{{ icon }}</mat-icon>
+      }
+      @if (label) {
+        {{ label }}
+      }
+    </button>
+  </span>
   <mat-menu #actionMenu="matMenu">
     @for (section of actionMenuItems; track $index; let last = $last) {
       @for (item of section; track item.label) {

--- a/src/app/core/_components/menus/action-menu/action-menu.component.ts
+++ b/src/app/core/_components/menus/action-menu/action-menu.component.ts
@@ -74,6 +74,7 @@ export class ActionMenuComponent implements OnInit, AfterViewInit, OnDestroy {
   @Input() icon: string = '';
   @Input() label: string = '';
   @Input() disabled = false;
+  @Input() disabledTooltip = '';
   @Input() cls = '';
   @Input() data: BaseModel | undefined;
   @Input() actionMenuItems: ActionMenuItem[][] = [];

--- a/src/app/core/_components/menus/row-action-menu/row-action-menu.component.html
+++ b/src/app/core/_components/menus/row-action-menu/row-action-menu.component.html
@@ -1,2 +1,9 @@
-<action-menu cls="row-action" icon="more_horiz" [data]="data" [disabled]="disabled" [actionMenuItems]="actionMenuItems"
-  (menuItemClicked)="onMenuItemClick($event)"></action-menu>
+<action-menu
+  cls="row-action"
+  icon="more_horiz"
+  [data]="data"
+  [disabled]="disabled"
+  [disabledTooltip]="disabledTooltip"
+  [actionMenuItems]="actionMenuItems"
+  (menuItemClicked)="onMenuItemClick($event)"
+></action-menu>

--- a/src/app/core/_components/menus/row-action-menu/row-action-menu.component.ts
+++ b/src/app/core/_components/menus/row-action-menu/row-action-menu.component.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @angular-eslint/component-selector */
 import { Component, Input, OnInit } from '@angular/core';
 
 import { ContextMenuService } from '@services/context-menu/base/context-menu.service';

--- a/src/app/core/_components/menus/row-action-menu/row-action-menu.component.ts
+++ b/src/app/core/_components/menus/row-action-menu/row-action-menu.component.ts
@@ -15,6 +15,7 @@ import { BaseMenuComponent } from '@components/menus/base-menu/base-menu.compone
 })
 export class RowActionMenuComponent extends BaseMenuComponent implements OnInit {
   @Input() contextMenuService: ContextMenuService;
+  @Input() disabledTooltip = 'No actions available';
 
   ngOnInit(): void {
     if (this.contextMenuService) {
@@ -22,5 +23,6 @@ export class RowActionMenuComponent extends BaseMenuComponent implements OnInit 
         this.conditionallyAddMenuItem(item, this.data);
       });
     }
+    this.disabled = this.disabled || this.actionMenuItems.every((section) => !section?.length);
   }
 }

--- a/src/app/core/_components/menus/row-action-menu/row-action-menu.constants.ts
+++ b/src/app/core/_components/menus/row-action-menu/row-action-menu.constants.ts
@@ -63,7 +63,6 @@ export const RowActionMenuLabel = {
   ARCHIVE_PRETASK: 'Archive PreTask',
   UNARCHIVE_PRETASK: 'Unarchive PreTask',
   SHOW_SUBTASK: 'Show Subtasks',
-  REVOKE_API_TOKEN: 'Revoke API Key',
   DELETE_API_TOKEN: 'Delete API Key'
 };
 
@@ -87,8 +86,7 @@ export const RowActionMenuAction = {
   DOWNLOAD: 'download',
   UNARCHIVE: 'unarchive',
   RESET: 'reset',
-  VIEW: 'view',
-  REVOKE: 'revoke'
+  VIEW: 'view'
 };
 
 export const RowActionMenuIcon = {
@@ -105,6 +103,5 @@ export const RowActionMenuIcon = {
   DEACTIVATE: 'remove_circle',
   DOWNLOAD: 'file_download',
   RESET: 'restore',
-  VIEW: 'preview',
-  REVOKE: 'block'
+  VIEW: 'preview'
 };

--- a/src/app/core/_components/menus/row-action-menu/row-action-menu.constants.ts
+++ b/src/app/core/_components/menus/row-action-menu/row-action-menu.constants.ts
@@ -62,7 +62,9 @@ export const RowActionMenuLabel = {
   REMOVE_ACCESSGROUP_USER: 'Remove User',
   ARCHIVE_PRETASK: 'Archive PreTask',
   UNARCHIVE_PRETASK: 'Unarchive PreTask',
-  SHOW_SUBTASK: 'Show Subtasks'
+  SHOW_SUBTASK: 'Show Subtasks',
+  REVOKE_API_TOKEN: 'Revoke API Key',
+  DELETE_API_TOKEN: 'Delete API Key'
 };
 
 export const RowActionMenuAction = {

--- a/src/app/core/_components/menus/row-action-menu/row-action-menu.constants.ts
+++ b/src/app/core/_components/menus/row-action-menu/row-action-menu.constants.ts
@@ -85,7 +85,8 @@ export const RowActionMenuAction = {
   DOWNLOAD: 'download',
   UNARCHIVE: 'unarchive',
   RESET: 'reset',
-  VIEW: 'view'
+  VIEW: 'view',
+  REVOKE: 'revoke'
 };
 
 export const RowActionMenuIcon = {
@@ -102,5 +103,6 @@ export const RowActionMenuIcon = {
   DEACTIVATE: 'remove_circle',
   DOWNLOAD: 'file_download',
   RESET: 'restore',
-  VIEW: 'preview'
+  VIEW: 'preview',
+  REVOKE: 'block'
 };

--- a/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.html
+++ b/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.html
@@ -1,4 +1,16 @@
-<ht-table #table name="accessPermissionGroupsUserTable" dataType="access-permission-groups-user"
-  [columnLabels]="columnLabels" [dataSource]="dataSource" [tableColumns]="tableColumns" [isSelectable]="true"
-  [isFilterable]="isFilterable" filterMode="client" [isPageable]="true" [isDetailPage]="true"
-  (editableCheckbox)="onCheckboxChange($event)" (exportActionClicked)="exportActionClicked($event)" />
+<ht-table
+  #table
+  name="accessPermissionGroupsUserTable"
+  dataType="access-permission-groups-user"
+  [columnLabels]="columnLabels"
+  [dataSource]="dataSource"
+  [tableColumns]="tableColumns"
+  [isSelectable]="mode === 'edit'"
+  [isFilterable]="mode === 'edit' && isFilterable"
+  filterMode="client"
+  [isPageable]="mode === 'edit'"
+  [showExport]="mode === 'edit'"
+  [isDetailPage]="true"
+  (editableCheckbox)="onCheckboxChange($event)"
+  (exportActionClicked)="exportActionClicked($event)"
+/>

--- a/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.ts
+++ b/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.ts
@@ -201,15 +201,41 @@ export class AccessPermissionGroupsUserTableComponent
       id: AccessPermissionGroupsUserTableCol.ROW_TOGGLE,
       isSortable: false,
       alwaysShown: true,
-      checkbox: (perm: UserPermissions) => this.rowToggleCellCheckbox(perm as PermissionMatrixRow)
+      checkbox: (perm: UserPermissions) => this.rowToggleCellCheckbox(perm as PermissionMatrixRow),
+      headerCheckbox: () => this.matrixHeaderCheckbox()
+    };
+  }
+
+  /**
+   * Form-mode-only master toggle living in the ROW_TOGGLE column header. Flips
+   * every grantable cell in the matrix on or off in a single click — the row
+   * axis of the existing column-header "select all" affordance, generalized to
+   * the full grid. Mirrors {@link columnHeaderCheckbox}: only grantable cells
+   * count toward the tri-state, so selecting every cell the user is allowed to
+   * grant promotes the master toggle to CHECKED.
+   */
+  private matrixHeaderCheckbox(): HTTableHeaderCheckbox {
+    const grantedKeys: string[] = [];
+    for (const row of this.rows) {
+      for (const k of Object.values(row.keys ?? {}) as Array<string | undefined>) {
+        if (k && this.granted?.[k]) grantedKeys.push(k);
+      }
+    }
+
+    return {
+      state: getHeaderCheckboxState(grantedKeys, this.selected),
+      change: (next) => this.toggleColumn(grantedKeys, next),
+      tooltip: 'Toggle all permissions'
     };
   }
 
   private rowToggleCellCheckbox(row: PermissionMatrixRow): HTTableEditable<UserPermissions> {
-    // CRUD verbs the resource exposes at all (some resources are read-only, etc.). N/A cells
-    // render visibly as disabled, so the row toggle's tri-state has to account for them.
-    const definedKeys = (Object.values(row.keys ?? {}) as Array<string | undefined>).filter((k): k is string => !!k);
-    const grantedKeys = definedKeys.filter((k) => !!this.granted?.[k]);
+    // Only grantable cells (defined for this resource AND held by the current user) count
+    // toward the row toggle. N/A and denied cells are excluded from the population, so
+    // selecting every cell the user can grant promotes the row to fully checked.
+    const grantedKeys = (Object.values(row.keys ?? {}) as Array<string | undefined>)
+      .filter((k): k is string => Boolean(k))
+      .filter((k) => Boolean(this.granted?.[k]));
     if (grantedKeys.length === 0) {
       // The user holds no CRUD permissions for this resource — nothing to toggle.
       return {
@@ -221,11 +247,10 @@ export class AccessPermissionGroupsUserTableComponent
       };
     }
     const selectedCount = grantedKeys.filter((k) => this.selected.has(k)).length;
-    const allGrantedSelected = selectedCount === grantedKeys.length;
-    const allCellsGrantable = grantedKeys.length === definedKeys.length;
-    // "Fully filled" requires every visible cell to be both grantable and selected; otherwise
-    // there is at least one unchecked-disabled cell on this row, so promote to indeterminate.
-    const fullyChecked = allGrantedSelected && allCellsGrantable;
+    // "Fully filled" means every grantable cell on this row is selected. N/A and denied cells
+    // are excluded from the population entirely, so they no longer block the checked state —
+    // otherwise indeterminate would be a dead-end: the user can never toggle the row "full."
+    const fullyChecked = selectedCount === grantedKeys.length;
     const partial = selectedCount > 0 && !fullyChecked;
     return {
       data: row,
@@ -300,7 +325,7 @@ export class AccessPermissionGroupsUserTableComponent
     }
 
     // Form mode
-    const userHolds = !!this.granted?.[key];
+    const userHolds = Boolean(this.granted?.[key]);
     const checked = this.selected.has(key);
     return {
       data: row,
@@ -312,30 +337,16 @@ export class AccessPermissionGroupsUserTableComponent
   }
 
   private columnHeaderCheckbox(verb: CrudVerb): HTTableHeaderCheckbox {
-    // Mirror rowToggleCellCheckbox's two-set model on the column axis: rows where the verb
-    // is N/A (no key in row.keys) are excluded from both populations entirely, so they don't
-    // drag the header into INDETERMINATE. Denied rows (key defined, user doesn't hold) still
-    // count toward definedKeys but not grantedKeys, so they keep the header indeterminate.
-    const definedKeys = this.rows.map((row) => row.keys?.[verb]).filter((k): k is string => !!k);
-    const grantedKeys = definedKeys.filter((k) => !!this.granted?.[k]);
-    const allDefinedGrantable = grantedKeys.length === definedKeys.length;
-
-    let state: HTTableHeaderCheckboxState;
-    if (grantedKeys.length === 0) {
-      state = HTTableHeaderCheckboxState.UNCHECKED;
-    } else {
-      const selectedCount = grantedKeys.filter((k) => this.selected.has(k)).length;
-      if (selectedCount === 0) {
-        state = HTTableHeaderCheckboxState.UNCHECKED;
-      } else if (selectedCount === grantedKeys.length && allDefinedGrantable) {
-        state = HTTableHeaderCheckboxState.CHECKED;
-      } else {
-        state = HTTableHeaderCheckboxState.INDETERMINATE;
-      }
-    }
+    // Mirror rowToggleCellCheckbox on the column axis: only grantable cells count toward the
+    // header state. Rows where the verb is N/A or denied are excluded from the population,
+    // so selecting every cell the user is allowed to grant promotes the header to CHECKED.
+    const grantedKeys = this.rows
+      .map((row) => row.keys?.[verb])
+      .filter((k): k is string => Boolean(k))
+      .filter((k) => Boolean(this.granted?.[k]));
 
     return {
-      state,
+      state: getHeaderCheckboxState(grantedKeys, this.selected),
       change: (next) => this.toggleColumn(grantedKeys, next),
       label: AccessPermissionGroupsUserTableColumnLabel[VERB_TO_COL[verb]]
     };
@@ -405,7 +416,7 @@ export class AccessPermissionGroupsUserTableComponent
   private handleRowToggle(editable: HTTableEditable<PermissionMatrixRow>): void {
     const row = editable.data;
     const grantedKeys = (Object.values(row.keys ?? {}) as Array<string | undefined>).filter(
-      (k): k is string => !!k && !!this.granted?.[k]
+      (k): k is string => Boolean(k) && Boolean(this.granted?.[k])
     );
     if (grantedKeys.length === 0) return;
     // mat-checkbox flips its value before the (change) event fires — `value` here is post-flip.
@@ -470,4 +481,13 @@ export class AccessPermissionGroupsUserTableComponent
         })
     );
   }
+}
+
+
+function getHeaderCheckboxState(grantedKeys: string[], selected: Set<string>): HTTableHeaderCheckboxState {
+  if (grantedKeys.length === 0) return HTTableHeaderCheckboxState.UNCHECKED;
+  const selectedCount = grantedKeys.filter((k) => selected.has(k)).length;
+  if (selectedCount === 0) return HTTableHeaderCheckboxState.UNCHECKED;
+  if (selectedCount === grantedKeys.length) return HTTableHeaderCheckboxState.CHECKED;
+  return HTTableHeaderCheckboxState.INDETERMINATE;
 }

--- a/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.ts
+++ b/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.ts
@@ -34,6 +34,7 @@ import {
 
 import { AccessPermissionGroupsExpandDataSource } from '@datasources/access-permission-groups-expand.datasource';
 
+import { PermissionValues } from '@src/app/core/_constants/userpermissions.config';
 import {
   CrudVerb,
   PERMISSION_DENIED_TOOLTIP,
@@ -116,7 +117,7 @@ export class AccessPermissionGroupsUserTableComponent
   /** Form mode — matrix rows, kept here so column-toggle helpers can iterate them. */
   private rows: PermissionMatrixRow[] = [];
   /** Form mode — fast lookup for `selection.includes(key)` during render. */
-  private selected: Set<string> = new Set();
+  private selected: Set<PermissionValues> = new Set();
 
   ngOnInit(): void {
     this.setColumnLabels(AccessPermissionGroupsUserTableColumnLabel);
@@ -132,7 +133,7 @@ export class AccessPermissionGroupsUserTableComponent
       }
     } else {
       // Form / view modes — seed the selection set and matrix rows synchronously.
-      this.selected = new Set(this.selection);
+      this.selected = new Set(this.selection as PermissionValues[]);
       if (this.granted) {
         this.rows = buildPermissionMatrix(this.granted);
       }
@@ -152,7 +153,7 @@ export class AccessPermissionGroupsUserTableComponent
       return;
     }
     if (changes['selection']) {
-      this.selected = new Set(this.selection);
+      this.selected = new Set(this.selection as PermissionValues[]);
     }
     if (changes['granted'] && this.granted) {
       this.rows = buildPermissionMatrix(this.granted);
@@ -215,9 +216,9 @@ export class AccessPermissionGroupsUserTableComponent
    * grant promotes the master toggle to CHECKED.
    */
   private matrixHeaderCheckbox(): HTTableHeaderCheckbox {
-    const grantedKeys: string[] = [];
+    const grantedKeys: PermissionValues[] = [];
     for (const row of this.rows) {
-      for (const k of Object.values(row.keys ?? {}) as Array<string | undefined>) {
+      for (const k of Object.values(row.keys ?? {})) {
         if (k && this.granted?.[k]) grantedKeys.push(k);
       }
     }
@@ -233,8 +234,8 @@ export class AccessPermissionGroupsUserTableComponent
     // Only grantable cells (defined for this resource AND held by the current user) count
     // toward the row toggle. N/A and denied cells are excluded from the population, so
     // selecting every cell the user can grant promotes the row to fully checked.
-    const grantedKeys = (Object.values(row.keys ?? {}) as Array<string | undefined>)
-      .filter((k): k is string => Boolean(k))
+    const grantedKeys = Object.values(row.keys ?? {})
+      .filter((k): k is PermissionValues => Boolean(k))
       .filter((k) => Boolean(this.granted?.[k]));
     if (grantedKeys.length === 0) {
       // The user holds no CRUD permissions for this resource — nothing to toggle.
@@ -342,7 +343,7 @@ export class AccessPermissionGroupsUserTableComponent
     // so selecting every cell the user is allowed to grant promotes the header to CHECKED.
     const grantedKeys = this.rows
       .map((row) => row.keys?.[verb])
-      .filter((k): k is string => Boolean(k))
+      .filter((k): k is PermissionValues => Boolean(k))
       .filter((k) => Boolean(this.granted?.[k]));
 
     return {
@@ -352,7 +353,7 @@ export class AccessPermissionGroupsUserTableComponent
     };
   }
 
-  private toggleColumn(grantedKeys: string[], next: boolean): void {
+  private toggleColumn(grantedKeys: PermissionValues[], next: boolean): void {
     const updated = new Set(this.selected);
     for (const key of grantedKeys) {
       if (next) {
@@ -415,8 +416,8 @@ export class AccessPermissionGroupsUserTableComponent
 
   private handleRowToggle(editable: HTTableEditable<PermissionMatrixRow>): void {
     const row = editable.data;
-    const grantedKeys = (Object.values(row.keys ?? {}) as Array<string | undefined>).filter(
-      (k): k is string => Boolean(k) && Boolean(this.granted?.[k])
+    const grantedKeys = Object.values(row.keys ?? {}).filter(
+      (k): k is PermissionValues => Boolean(k) && Boolean(this.granted?.[k])
     );
     if (grantedKeys.length === 0) return;
     // mat-checkbox flips its value before the (change) event fires — `value` here is post-flip.
@@ -432,7 +433,7 @@ export class AccessPermissionGroupsUserTableComponent
     this.emitSelection(updated);
   }
 
-  private emitSelection(updated: Set<string>): void {
+  private emitSelection(updated: Set<PermissionValues>): void {
     this.selected = updated;
     const next = Array.from(updated);
     // Push fresh rows so cells re-render with the updated selection / header state.
@@ -483,8 +484,10 @@ export class AccessPermissionGroupsUserTableComponent
   }
 }
 
-
-function getHeaderCheckboxState(grantedKeys: string[], selected: Set<string>): HTTableHeaderCheckboxState {
+function getHeaderCheckboxState(
+  grantedKeys: PermissionValues[],
+  selected: Set<PermissionValues>
+): HTTableHeaderCheckboxState {
   if (grantedKeys.length === 0) return HTTableHeaderCheckboxState.UNCHECKED;
   const selectedCount = grantedKeys.filter((k) => selected.has(k)).length;
   if (selectedCount === 0) return HTTableHeaderCheckboxState.UNCHECKED;

--- a/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.ts
+++ b/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.ts
@@ -104,10 +104,10 @@ export class AccessPermissionGroupsUserTableComponent
   @Input() granted?: Permission;
 
   /** Form mode — currently-selected permission keys. */
-  @Input() selection: string[] = [];
+  @Input() selection: PermissionValues[] = [];
 
   /** Form mode — emitted when the user toggles a cell or a column header. */
-  @Output() selectionChange = new EventEmitter<string[]>();
+  @Output() selectionChange = new EventEmitter<PermissionValues[]>();
 
   tableColumns: HTTableColumn[] = [];
   dataSource: AccessPermissionGroupsExpandDataSource;
@@ -133,7 +133,7 @@ export class AccessPermissionGroupsUserTableComponent
       }
     } else {
       // Form / view modes — seed the selection set and matrix rows synchronously.
-      this.selected = new Set(this.selection as PermissionValues[]);
+      this.selected = new Set(this.selection);
       if (this.granted) {
         this.rows = buildPermissionMatrix(this.granted);
       }
@@ -153,7 +153,7 @@ export class AccessPermissionGroupsUserTableComponent
       return;
     }
     if (changes['selection']) {
-      this.selected = new Set(this.selection as PermissionValues[]);
+      this.selected = new Set(this.selection);
     }
     if (changes['granted'] && this.granted) {
       this.rows = buildPermissionMatrix(this.granted);

--- a/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.ts
+++ b/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.ts
@@ -1,9 +1,19 @@
 import { catchError } from 'rxjs';
 
-import { AfterViewInit, Component, Input, OnDestroy, OnInit } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges
+} from '@angular/core';
 
 import { DynamicModel } from '@models/base.model';
-import { UserPermissions } from '@models/global-permission-group.model';
+import { Permission, UserPermissions } from '@models/global-permission-group.model';
 import { JUser } from '@models/user.model';
 
 import { SERV } from '@services/main.config';
@@ -15,9 +25,49 @@ import {
   AccessPermissionGroupsUserTableColumnLabel
 } from '@components/tables/access-permission-groups-user-table/access-permission-groups-user-table.constants';
 import { BaseTableComponent } from '@components/tables/base-table/base-table.component';
-import { HTTableColumn, HTTableEditable } from '@components/tables/ht-table/ht-table.models';
+import {
+  HTTableColumn,
+  HTTableEditable,
+  HTTableHeaderCheckbox,
+  HTTableHeaderCheckboxState
+} from '@components/tables/ht-table/ht-table.models';
 
 import { AccessPermissionGroupsExpandDataSource } from '@datasources/access-permission-groups-expand.datasource';
+
+import {
+  CrudVerb,
+  PERMISSION_DENIED_TOOLTIP,
+  PERMISSION_NOT_APPLICABLE_TOOLTIP,
+  PermissionMatrixRow,
+  buildPermissionMatrix
+} from '@src/app/shared/utils/permission-matrix';
+
+export const PermissionTableMode = {
+  EDIT: 'edit',
+  FORM: 'form',
+  /**
+   * Read-only matrix. Like FORM, the data source is seeded from {@link granted}
+   * and {@link selection} drives which cells render checked. Unlike FORM, every
+   * cell is disabled, the row-toggle column is hidden, and no header checkboxes
+   * are exposed — the table is a static visualization, not an input.
+   */
+  VIEW: 'view'
+} as const;
+export type PermissionTableMode = (typeof PermissionTableMode)[keyof typeof PermissionTableMode];
+
+const VERB_TO_COL: Record<CrudVerb, AccessPermissionGroupsUserTableCol> = {
+  [CrudVerb.CREATE]: AccessPermissionGroupsUserTableCol.CREATE,
+  [CrudVerb.READ]: AccessPermissionGroupsUserTableCol.READ,
+  [CrudVerb.UPDATE]: AccessPermissionGroupsUserTableCol.UPDATE,
+  [CrudVerb.DELETE]: AccessPermissionGroupsUserTableCol.DELETE
+};
+
+const VERB_TO_ACTION: Record<CrudVerb, string> = {
+  [CrudVerb.CREATE]: APGUTableEditableAction.CHANGE_CREATE_PERMISSION,
+  [CrudVerb.READ]: APGUTableEditableAction.CHANGE_READ_PERMISSION,
+  [CrudVerb.UPDATE]: APGUTableEditableAction.CHANGE_UPDATE_PERMISSION,
+  [CrudVerb.DELETE]: APGUTableEditableAction.CHANGE_DELETE_PERMISSION
+};
 
 @Component({
   selector: 'access-permission-groups-user-table',
@@ -26,30 +76,92 @@ import { AccessPermissionGroupsExpandDataSource } from '@datasources/access-perm
 })
 export class AccessPermissionGroupsUserTableComponent
   extends BaseTableComponent
-  implements OnInit, OnDestroy, AfterViewInit
+  implements OnInit, OnChanges, OnDestroy, AfterViewInit
 {
+  /**
+   * `'edit'` (default): live-edit a persisted access-permission group. Loads via
+   * the datasource and PATCHes the backend on each cell flip.
+   *
+   * `'form'`: data source seeded from {@link granted}; cell flips mutate the
+   * selection list and emit {@link selectionChange} for a parent reactive form
+   * to consume. No backend writes.
+   *
+   * `'view'`: data source seeded from {@link granted}; every cell renders
+   * disabled and reflects whether its key is in {@link selection}. No
+   * row-toggle column, no header checkboxes, no events emitted.
+   */
+  @Input() mode: PermissionTableMode = PermissionTableMode.EDIT;
+
+  /** Edit mode — id of the permission group to load. */
   @Input() accesspermgroupId = 0;
+
+  /**
+   * Form mode — the current user's permission map (the value returned by
+   * {@link PermissionService.loadPermissions}). Drives the matrix rows and the
+   * `disabled` state of cells the user does not hold.
+   */
+  @Input() granted?: Permission;
+
+  /** Form mode — currently-selected permission keys. */
+  @Input() selection: string[] = [];
+
+  /** Form mode — emitted when the user toggles a cell or a column header. */
+  @Output() selectionChange = new EventEmitter<string[]>();
 
   tableColumns: HTTableColumn[] = [];
   dataSource: AccessPermissionGroupsExpandDataSource;
   expand = 'userMembers';
   permissions = 1;
 
+  /** Form mode — matrix rows, kept here so column-toggle helpers can iterate them. */
+  private rows: PermissionMatrixRow[] = [];
+  /** Form mode — fast lookup for `selection.includes(key)` during render. */
+  private selected: Set<string> = new Set();
+
   ngOnInit(): void {
     this.setColumnLabels(AccessPermissionGroupsUserTableColumnLabel);
-    this.tableColumns = this.getColumns();
     this.dataSource = new AccessPermissionGroupsExpandDataSource(this.injector);
+    this.tableColumns = this.getColumns();
     this.dataSource.setColumns(this.tableColumns);
-    if (this.accesspermgroupId) {
-      this.dataSource.setAccessPermGroupId(this.accesspermgroupId);
-      this.dataSource.setAccessPermGroupExpand(this.expand);
-      this.dataSource.setPermissions(this.permissions);
+
+    if (this.mode === PermissionTableMode.EDIT) {
+      if (this.accesspermgroupId) {
+        this.dataSource.setAccessPermGroupId(this.accesspermgroupId);
+        this.dataSource.setAccessPermGroupExpand(this.expand);
+        this.dataSource.setPermissions(this.permissions);
+      }
+    } else {
+      // Form / view modes — seed the selection set and matrix rows synchronously.
+      this.selected = new Set(this.selection);
+      if (this.granted) {
+        this.rows = buildPermissionMatrix(this.granted);
+      }
     }
   }
 
   ngAfterViewInit(): void {
-    // Wait until paginator is defined
-    this.dataSource.loadAll();
+    if (this.mode === PermissionTableMode.EDIT) {
+      this.dataSource.loadAll();
+    } else if (this.granted) {
+      this.dataSource.loadFromMap(this.granted);
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (this.mode === PermissionTableMode.EDIT || !this.dataSource) {
+      return;
+    }
+    if (changes['selection']) {
+      this.selected = new Set(this.selection);
+    }
+    if (changes['granted'] && this.granted) {
+      this.rows = buildPermissionMatrix(this.granted);
+    }
+    if ((changes['selection'] || changes['granted']) && this.granted) {
+      // Push fresh rows so ht-table's OnPush cells re-instantiate with the
+      // latest derived `value`/`disabled`/`tooltip` from their checkbox callbacks.
+      this.dataSource.loadFromMap(this.granted);
+    }
   }
 
   ngOnDestroy(): void {
@@ -59,66 +171,186 @@ export class AccessPermissionGroupsUserTableComponent
   }
 
   getColumns(): HTTableColumn[] {
-    return [
+    const columns: HTTableColumn[] = [];
+    if (this.mode === PermissionTableMode.FORM) {
+      columns.push(this.rowToggleColumn());
+    }
+    columns.push(
       {
         id: AccessPermissionGroupsUserTableCol.NAME,
         dataKey: 'name',
-        isSortable: true,
+        isSortable: this.mode === PermissionTableMode.EDIT,
         export: async (perm: UserPermissions) => perm.name + ''
       },
-      {
-        id: AccessPermissionGroupsUserTableCol.CREATE,
-        dataKey: 'create',
-        isSortable: true,
-        checkbox: (perm: UserPermissions) => {
-          return {
-            data: perm,
-            value: perm.create + '',
-            action: APGUTableEditableAction.CHANGE_CREATE_PERMISSION
-          };
-        },
-        export: async (perm: UserPermissions) => perm.create + ''
-      },
-      {
-        id: AccessPermissionGroupsUserTableCol.READ,
-        dataKey: 'read',
-        isSortable: true,
-        checkbox: (perm: UserPermissions) => {
-          return {
-            data: perm,
-            value: perm.read + '',
-            action: APGUTableEditableAction.CHANGE_READ_PERMISSION
-          };
-        },
-        export: async (perm: UserPermissions) => perm.read + ''
-      },
-      {
-        id: AccessPermissionGroupsUserTableCol.UPDATE,
-        dataKey: 'update',
-        isSortable: true,
-        checkbox: (perm: UserPermissions) => {
-          return {
-            data: perm,
-            value: perm.update + '',
-            action: APGUTableEditableAction.CHANGE_UPDATE_PERMISSION
-          };
-        },
-        export: async (perm: UserPermissions) => perm.update + ''
-      },
-      {
-        id: AccessPermissionGroupsUserTableCol.DELETE,
-        dataKey: 'delete',
-        isSortable: true,
-        checkbox: (perm: UserPermissions) => {
-          return {
-            data: perm,
-            value: perm.delete + '',
-            action: APGUTableEditableAction.CHANGE_DELETE_PERMISSION
-          };
-        },
-        export: async (perm: UserPermissions) => perm.delete + ''
+      this.crudColumn(CrudVerb.CREATE),
+      this.crudColumn(CrudVerb.READ),
+      this.crudColumn(CrudVerb.UPDATE),
+      this.crudColumn(CrudVerb.DELETE)
+    );
+    return columns;
+  }
+
+  /**
+   * Form-mode-only leading column with a tri-state checkbox per row that toggles every
+   * CRUD permission on that resource the user holds. Mirrors the column-header
+   * "select all in column" affordance, but on the row axis. Marked `alwaysShown`
+   * so it can't be hidden by the table's column-selection dialog.
+   */
+  private rowToggleColumn(): HTTableColumn {
+    return {
+      id: AccessPermissionGroupsUserTableCol.ROW_TOGGLE,
+      isSortable: false,
+      alwaysShown: true,
+      checkbox: (perm: UserPermissions) => this.rowToggleCellCheckbox(perm as PermissionMatrixRow)
+    };
+  }
+
+  private rowToggleCellCheckbox(row: PermissionMatrixRow): HTTableEditable<UserPermissions> {
+    // CRUD verbs the resource exposes at all (some resources are read-only, etc.). N/A cells
+    // render visibly as disabled, so the row toggle's tri-state has to account for them.
+    const definedKeys = (Object.values(row.keys ?? {}) as Array<string | undefined>).filter((k): k is string => !!k);
+    const grantedKeys = definedKeys.filter((k) => !!this.granted?.[k]);
+    if (grantedKeys.length === 0) {
+      // The user holds no CRUD permissions for this resource — nothing to toggle.
+      return {
+        data: row,
+        value: 'false',
+        action: APGUTableEditableAction.CHANGE_ROW_PERMISSION,
+        disabled: true,
+        tooltip: PERMISSION_DENIED_TOOLTIP
+      };
+    }
+    const selectedCount = grantedKeys.filter((k) => this.selected.has(k)).length;
+    const allGrantedSelected = selectedCount === grantedKeys.length;
+    const allCellsGrantable = grantedKeys.length === definedKeys.length;
+    // "Fully filled" requires every visible cell to be both grantable and selected; otherwise
+    // there is at least one unchecked-disabled cell on this row, so promote to indeterminate.
+    const fullyChecked = allGrantedSelected && allCellsGrantable;
+    const partial = selectedCount > 0 && !fullyChecked;
+    return {
+      data: row,
+      value: fullyChecked ? 'true' : 'false',
+      action: APGUTableEditableAction.CHANGE_ROW_PERMISSION,
+      indeterminate: partial,
+      tooltip: 'Toggle all permissions for this resource'
+    };
+  }
+
+  /**
+   * Build a single CRUD column descriptor. The descriptor's `checkbox` callback
+   * shape changes between modes:
+   *   - edit: returns `value = row.<verb>`, no disabled/tooltip — the cell flip
+   *     drives a PATCH.
+   *   - form: returns `value = selection.has(row.keys[verb])`, with `disabled`
+   *     and `tooltip` honoring whether the user holds the permission and
+   *     whether the permission exists for this resource at all.
+   *
+   * In form mode the column also exposes a `headerCheckbox` callback that
+   * drives the column-level toggle.
+   */
+  private crudColumn(verb: CrudVerb): HTTableColumn {
+    const colId = VERB_TO_COL[verb];
+    const action = VERB_TO_ACTION[verb];
+
+    const column: HTTableColumn = {
+      id: colId,
+      dataKey: verb,
+      isSortable: this.mode === PermissionTableMode.EDIT,
+      checkbox: (perm: UserPermissions) => this.cellCheckbox(perm as PermissionMatrixRow, verb, action),
+      export: async (perm: UserPermissions) => (perm[verb] ? 'true' : 'false')
+    };
+
+    if (this.mode === PermissionTableMode.FORM) {
+      column.headerCheckbox = () => this.columnHeaderCheckbox(verb);
+    }
+
+    return column;
+  }
+
+  private cellCheckbox(row: PermissionMatrixRow, verb: CrudVerb, action: string): HTTableEditable<UserPermissions> {
+    if (this.mode === PermissionTableMode.EDIT) {
+      return {
+        data: row,
+        value: row[verb] + '',
+        action
+      };
+    }
+
+    const key = row.keys?.[verb];
+    if (!key) {
+      // No backend permission exists for this row × verb.
+      return {
+        data: row,
+        value: 'false',
+        action,
+        disabled: true,
+        tooltip: PERMISSION_NOT_APPLICABLE_TOOLTIP
+      };
+    }
+
+    if (this.mode === PermissionTableMode.VIEW) {
+      // Read-only: cell reflects selection without regard to `granted`, and is
+      // always disabled. No tooltip — the page-level explanation handles intent.
+      return {
+        data: row,
+        value: this.selected.has(key) + '',
+        action,
+        disabled: true
+      };
+    }
+
+    // Form mode
+    const userHolds = !!this.granted?.[key];
+    const checked = this.selected.has(key);
+    return {
+      data: row,
+      value: checked + '',
+      action,
+      disabled: !userHolds,
+      tooltip: userHolds ? '' : PERMISSION_DENIED_TOOLTIP
+    };
+  }
+
+  private columnHeaderCheckbox(verb: CrudVerb): HTTableHeaderCheckbox {
+    // Mirror rowToggleCellCheckbox's two-set model on the column axis: rows where the verb
+    // is N/A (no key in row.keys) are excluded from both populations entirely, so they don't
+    // drag the header into INDETERMINATE. Denied rows (key defined, user doesn't hold) still
+    // count toward definedKeys but not grantedKeys, so they keep the header indeterminate.
+    const definedKeys = this.rows.map((row) => row.keys?.[verb]).filter((k): k is string => !!k);
+    const grantedKeys = definedKeys.filter((k) => !!this.granted?.[k]);
+    const allDefinedGrantable = grantedKeys.length === definedKeys.length;
+
+    let state: HTTableHeaderCheckboxState;
+    if (grantedKeys.length === 0) {
+      state = HTTableHeaderCheckboxState.UNCHECKED;
+    } else {
+      const selectedCount = grantedKeys.filter((k) => this.selected.has(k)).length;
+      if (selectedCount === 0) {
+        state = HTTableHeaderCheckboxState.UNCHECKED;
+      } else if (selectedCount === grantedKeys.length && allDefinedGrantable) {
+        state = HTTableHeaderCheckboxState.CHECKED;
+      } else {
+        state = HTTableHeaderCheckboxState.INDETERMINATE;
       }
-    ];
+    }
+
+    return {
+      state,
+      change: (next) => this.toggleColumn(grantedKeys, next),
+      label: AccessPermissionGroupsUserTableColumnLabel[VERB_TO_COL[verb]]
+    };
+  }
+
+  private toggleColumn(grantedKeys: string[], next: boolean): void {
+    const updated = new Set(this.selected);
+    for (const key of grantedKeys) {
+      if (next) {
+        updated.add(key);
+      } else {
+        updated.delete(key);
+      }
+    }
+    this.emitSelection(updated);
   }
 
   // --- Action functions ---
@@ -136,7 +368,72 @@ export class AccessPermissionGroupsUserTableComponent
    * @param editable Editable object containing current permission, action and changed value
    */
   onCheckboxChange(editable: HTTableEditable<JUser | UserPermissions>): void {
+    if (this.mode === PermissionTableMode.VIEW) {
+      // All cells are disabled in view mode — mat-checkbox shouldn't fire here,
+      // but guard explicitly so a stray event can't silently mutate state.
+      return;
+    }
+    if (this.mode === PermissionTableMode.FORM) {
+      if (editable.action === APGUTableEditableAction.CHANGE_ROW_PERMISSION) {
+        this.handleRowToggle(editable as HTTableEditable<PermissionMatrixRow>);
+        return;
+      }
+      this.handleFormCellToggle(editable as HTTableEditable<PermissionMatrixRow>);
+      return;
+    }
     this.changePermision(editable as HTTableEditable<UserPermissions>, editable.value);
+  }
+
+  private handleFormCellToggle(editable: HTTableEditable<PermissionMatrixRow>): void {
+    const verb = this.actionToVerb(editable.action);
+    if (!verb) return;
+    const key = editable.data.keys?.[verb];
+    if (!key || !this.granted?.[key]) {
+      // Disabled cell — should not have fired, ignore defensively.
+      return;
+    }
+    const checked = editable.value === 'true';
+    const updated = new Set(this.selected);
+    if (checked) {
+      updated.add(key);
+    } else {
+      updated.delete(key);
+    }
+    this.emitSelection(updated);
+  }
+
+  private handleRowToggle(editable: HTTableEditable<PermissionMatrixRow>): void {
+    const row = editable.data;
+    const grantedKeys = (Object.values(row.keys ?? {}) as Array<string | undefined>).filter(
+      (k): k is string => !!k && !!this.granted?.[k]
+    );
+    if (grantedKeys.length === 0) return;
+    // mat-checkbox flips its value before the (change) event fires — `value` here is post-flip.
+    const next = editable.value === 'true';
+    const updated = new Set(this.selected);
+    for (const key of grantedKeys) {
+      if (next) {
+        updated.add(key);
+      } else {
+        updated.delete(key);
+      }
+    }
+    this.emitSelection(updated);
+  }
+
+  private emitSelection(updated: Set<string>): void {
+    this.selected = updated;
+    const next = Array.from(updated);
+    // Push fresh rows so cells re-render with the updated selection / header state.
+    if (this.granted) {
+      this.dataSource.loadFromMap(this.granted);
+    }
+    this.selectionChange.emit(next);
+  }
+
+  private actionToVerb(action: string): CrudVerb | null {
+    const match = action.match(/-(create|read|update|delete)-/i);
+    return match ? (match[1].toLowerCase() as CrudVerb) : null;
   }
 
   /**

--- a/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.ts
+++ b/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.ts
@@ -12,7 +12,6 @@ import {
   SimpleChanges
 } from '@angular/core';
 
-import { DynamicModel } from '@models/base.model';
 import { Permission, UserPermissions } from '@models/global-permission-group.model';
 import { JUser } from '@models/user.model';
 
@@ -25,12 +24,7 @@ import {
   AccessPermissionGroupsUserTableColumnLabel
 } from '@components/tables/access-permission-groups-user-table/access-permission-groups-user-table.constants';
 import { BaseTableComponent } from '@components/tables/base-table/base-table.component';
-import {
-  HTTableColumn,
-  HTTableEditable,
-  HTTableHeaderCheckbox,
-  HTTableHeaderCheckboxState
-} from '@components/tables/ht-table/ht-table.models';
+import { HTTableColumn, HTTableEditable } from '@components/tables/ht-table/ht-table.models';
 
 import { AccessPermissionGroupsExpandDataSource } from '@datasources/access-permission-groups-expand.datasource';
 
@@ -39,8 +33,7 @@ import {
   CrudVerb,
   PERMISSION_DENIED_TOOLTIP,
   PERMISSION_NOT_APPLICABLE_TOOLTIP,
-  PermissionMatrixRow,
-  buildPermissionMatrix
+  PermissionMatrixRow
 } from '@src/app/shared/utils/permission-matrix';
 
 export const PermissionTableMode = {
@@ -49,8 +42,7 @@ export const PermissionTableMode = {
   /**
    * Read-only matrix. Like FORM, the data source is seeded from {@link granted}
    * and {@link selection} drives which cells render checked. Unlike FORM, every
-   * cell is disabled, the row-toggle column is hidden, and no header checkboxes
-   * are exposed — the table is a static visualization, not an input.
+   * cell is disabled — the table is a static visualization, not an input.
    */
   VIEW: 'view'
 } as const;
@@ -89,7 +81,7 @@ export class AccessPermissionGroupsUserTableComponent
    *
    * `'view'`: data source seeded from {@link granted}; every cell renders
    * disabled and reflects whether its key is in {@link selection}. No
-   * row-toggle column, no header checkboxes, no events emitted.
+   * events emitted.
    */
   @Input() mode: PermissionTableMode = PermissionTableMode.EDIT;
 
@@ -106,7 +98,7 @@ export class AccessPermissionGroupsUserTableComponent
   /** Form mode — currently-selected permission keys. */
   @Input() selection: PermissionValues[] = [];
 
-  /** Form mode — emitted when the user toggles a cell or a column header. */
+  /** Form mode — emitted when the user toggles a cell. */
   @Output() selectionChange = new EventEmitter<PermissionValues[]>();
 
   tableColumns: HTTableColumn[] = [];
@@ -114,8 +106,6 @@ export class AccessPermissionGroupsUserTableComponent
   expand = 'userMembers';
   permissions = 1;
 
-  /** Form mode — matrix rows, kept here so column-toggle helpers can iterate them. */
-  private rows: PermissionMatrixRow[] = [];
   /** Form mode — fast lookup for `selection.includes(key)` during render. */
   private selected: Set<PermissionValues> = new Set();
 
@@ -132,11 +122,8 @@ export class AccessPermissionGroupsUserTableComponent
         this.dataSource.setPermissions(this.permissions);
       }
     } else {
-      // Form / view modes — seed the selection set and matrix rows synchronously.
+      // Form / view modes — seed the selection set synchronously.
       this.selected = new Set(this.selection);
-      if (this.granted) {
-        this.rows = buildPermissionMatrix(this.granted);
-      }
     }
   }
 
@@ -155,9 +142,6 @@ export class AccessPermissionGroupsUserTableComponent
     if (changes['selection']) {
       this.selected = new Set(this.selection);
     }
-    if (changes['granted'] && this.granted) {
-      this.rows = buildPermissionMatrix(this.granted);
-    }
     if ((changes['selection'] || changes['granted']) && this.granted) {
       // Push fresh rows so ht-table's OnPush cells re-instantiate with the
       // latest derived `value`/`disabled`/`tooltip` from their checkbox callbacks.
@@ -172,11 +156,7 @@ export class AccessPermissionGroupsUserTableComponent
   }
 
   getColumns(): HTTableColumn[] {
-    const columns: HTTableColumn[] = [];
-    if (this.mode === PermissionTableMode.FORM) {
-      columns.push(this.rowToggleColumn());
-    }
-    columns.push(
+    return [
       {
         id: AccessPermissionGroupsUserTableCol.NAME,
         dataKey: 'name',
@@ -187,79 +167,7 @@ export class AccessPermissionGroupsUserTableComponent
       this.crudColumn(CrudVerb.READ),
       this.crudColumn(CrudVerb.UPDATE),
       this.crudColumn(CrudVerb.DELETE)
-    );
-    return columns;
-  }
-
-  /**
-   * Form-mode-only leading column with a tri-state checkbox per row that toggles every
-   * CRUD permission on that resource the user holds. Mirrors the column-header
-   * "select all in column" affordance, but on the row axis. Marked `alwaysShown`
-   * so it can't be hidden by the table's column-selection dialog.
-   */
-  private rowToggleColumn(): HTTableColumn {
-    return {
-      id: AccessPermissionGroupsUserTableCol.ROW_TOGGLE,
-      isSortable: false,
-      alwaysShown: true,
-      checkbox: (perm: UserPermissions) => this.rowToggleCellCheckbox(perm as PermissionMatrixRow),
-      headerCheckbox: () => this.matrixHeaderCheckbox()
-    };
-  }
-
-  /**
-   * Form-mode-only master toggle living in the ROW_TOGGLE column header. Flips
-   * every grantable cell in the matrix on or off in a single click — the row
-   * axis of the existing column-header "select all" affordance, generalized to
-   * the full grid. Mirrors {@link columnHeaderCheckbox}: only grantable cells
-   * count toward the tri-state, so selecting every cell the user is allowed to
-   * grant promotes the master toggle to CHECKED.
-   */
-  private matrixHeaderCheckbox(): HTTableHeaderCheckbox {
-    const grantedKeys: PermissionValues[] = [];
-    for (const row of this.rows) {
-      for (const k of Object.values(row.keys ?? {})) {
-        if (k && this.granted?.[k]) grantedKeys.push(k);
-      }
-    }
-
-    return {
-      state: getHeaderCheckboxState(grantedKeys, this.selected),
-      change: (next) => this.toggleColumn(grantedKeys, next),
-      tooltip: 'Toggle all permissions'
-    };
-  }
-
-  private rowToggleCellCheckbox(row: PermissionMatrixRow): HTTableEditable<UserPermissions> {
-    // Only grantable cells (defined for this resource AND held by the current user) count
-    // toward the row toggle. N/A and denied cells are excluded from the population, so
-    // selecting every cell the user can grant promotes the row to fully checked.
-    const grantedKeys = Object.values(row.keys ?? {})
-      .filter((k): k is PermissionValues => Boolean(k))
-      .filter((k) => Boolean(this.granted?.[k]));
-    if (grantedKeys.length === 0) {
-      // The user holds no CRUD permissions for this resource — nothing to toggle.
-      return {
-        data: row,
-        value: 'false',
-        action: APGUTableEditableAction.CHANGE_ROW_PERMISSION,
-        disabled: true,
-        tooltip: PERMISSION_DENIED_TOOLTIP
-      };
-    }
-    const selectedCount = grantedKeys.filter((k) => this.selected.has(k)).length;
-    // "Fully filled" means every grantable cell on this row is selected. N/A and denied cells
-    // are excluded from the population entirely, so they no longer block the checked state —
-    // otherwise indeterminate would be a dead-end: the user can never toggle the row "full."
-    const fullyChecked = selectedCount === grantedKeys.length;
-    const partial = selectedCount > 0 && !fullyChecked;
-    return {
-      data: row,
-      value: fullyChecked ? 'true' : 'false',
-      action: APGUTableEditableAction.CHANGE_ROW_PERMISSION,
-      indeterminate: partial,
-      tooltip: 'Toggle all permissions for this resource'
-    };
+    ];
   }
 
   /**
@@ -270,27 +178,18 @@ export class AccessPermissionGroupsUserTableComponent
    *   - form: returns `value = selection.has(row.keys[verb])`, with `disabled`
    *     and `tooltip` honoring whether the user holds the permission and
    *     whether the permission exists for this resource at all.
-   *
-   * In form mode the column also exposes a `headerCheckbox` callback that
-   * drives the column-level toggle.
    */
   private crudColumn(verb: CrudVerb): HTTableColumn {
     const colId = VERB_TO_COL[verb];
     const action = VERB_TO_ACTION[verb];
 
-    const column: HTTableColumn = {
+    return {
       id: colId,
       dataKey: verb,
       isSortable: this.mode === PermissionTableMode.EDIT,
       checkbox: (perm: UserPermissions) => this.cellCheckbox(perm as PermissionMatrixRow, verb, action),
       export: async (perm: UserPermissions) => (perm[verb] ? 'true' : 'false')
     };
-
-    if (this.mode === PermissionTableMode.FORM) {
-      column.headerCheckbox = () => this.columnHeaderCheckbox(verb);
-    }
-
-    return column;
   }
 
   private cellCheckbox(row: PermissionMatrixRow, verb: CrudVerb, action: string): HTTableEditable<UserPermissions> {
@@ -337,34 +236,6 @@ export class AccessPermissionGroupsUserTableComponent
     };
   }
 
-  private columnHeaderCheckbox(verb: CrudVerb): HTTableHeaderCheckbox {
-    // Mirror rowToggleCellCheckbox on the column axis: only grantable cells count toward the
-    // header state. Rows where the verb is N/A or denied are excluded from the population,
-    // so selecting every cell the user is allowed to grant promotes the header to CHECKED.
-    const grantedKeys = this.rows
-      .map((row) => row.keys?.[verb])
-      .filter((k): k is PermissionValues => Boolean(k))
-      .filter((k) => Boolean(this.granted?.[k]));
-
-    return {
-      state: getHeaderCheckboxState(grantedKeys, this.selected),
-      change: (next) => this.toggleColumn(grantedKeys, next),
-      label: AccessPermissionGroupsUserTableColumnLabel[VERB_TO_COL[verb]]
-    };
-  }
-
-  private toggleColumn(grantedKeys: PermissionValues[], next: boolean): void {
-    const updated = new Set(this.selected);
-    for (const key of grantedKeys) {
-      if (next) {
-        updated.add(key);
-      } else {
-        updated.delete(key);
-      }
-    }
-    this.emitSelection(updated);
-  }
-
   // --- Action functions ---
   exportActionClicked(event: ActionMenuEvent<(JUser | UserPermissions)[]>): void {
     this.exportService.handleExportAction<UserPermissions>(
@@ -386,10 +257,6 @@ export class AccessPermissionGroupsUserTableComponent
       return;
     }
     if (this.mode === PermissionTableMode.FORM) {
-      if (editable.action === APGUTableEditableAction.CHANGE_ROW_PERMISSION) {
-        this.handleRowToggle(editable as HTTableEditable<PermissionMatrixRow>);
-        return;
-      }
       this.handleFormCellToggle(editable as HTTableEditable<PermissionMatrixRow>);
       return;
     }
@@ -414,29 +281,10 @@ export class AccessPermissionGroupsUserTableComponent
     this.emitSelection(updated);
   }
 
-  private handleRowToggle(editable: HTTableEditable<PermissionMatrixRow>): void {
-    const row = editable.data;
-    const grantedKeys = Object.values(row.keys ?? {}).filter(
-      (k): k is PermissionValues => Boolean(k) && Boolean(this.granted?.[k])
-    );
-    if (grantedKeys.length === 0) return;
-    // mat-checkbox flips its value before the (change) event fires — `value` here is post-flip.
-    const next = editable.value === 'true';
-    const updated = new Set(this.selected);
-    for (const key of grantedKeys) {
-      if (next) {
-        updated.add(key);
-      } else {
-        updated.delete(key);
-      }
-    }
-    this.emitSelection(updated);
-  }
-
   private emitSelection(updated: Set<PermissionValues>): void {
     this.selected = updated;
     const next = Array.from(updated);
-    // Push fresh rows so cells re-render with the updated selection / header state.
+    // Push fresh rows so cells re-render with the updated selection.
     if (this.granted) {
       this.dataSource.loadFromMap(this.granted);
     }
@@ -454,10 +302,11 @@ export class AccessPermissionGroupsUserTableComponent
    * @param value The new value for the permission (as a string).
    */
   private changePermision(editable: HTTableEditable<UserPermissions>, value: string): void {
-    const capitalizedPerm = (editable['action'].match(/-(.*?)-/)?.[1] || '')
-      .toLowerCase()
-      .replace(/^\w/, (c) => c.toUpperCase());
-    const keyPerm = String((editable.data as unknown as DynamicModel)['originalName']) + capitalizedPerm;
+    const verb = this.actionToVerb(editable.action);
+    if (!verb) return;
+    const keyPerm = (editable.data as PermissionMatrixRow).keys?.[verb];
+    if (!keyPerm) return;
+    const capitalizedPerm = verb.charAt(0).toUpperCase() + verb.slice(1);
     const boolValue = value === 'true' ? true : value === 'false' ? false : Boolean(value);
     // Payload
     const payload = {
@@ -482,15 +331,4 @@ export class AccessPermissionGroupsUserTableComponent
         })
     );
   }
-}
-
-function getHeaderCheckboxState(
-  grantedKeys: PermissionValues[],
-  selected: Set<PermissionValues>
-): HTTableHeaderCheckboxState {
-  if (grantedKeys.length === 0) return HTTableHeaderCheckboxState.UNCHECKED;
-  const selectedCount = grantedKeys.filter((k) => selected.has(k)).length;
-  if (selectedCount === 0) return HTTableHeaderCheckboxState.UNCHECKED;
-  if (selectedCount === grantedKeys.length) return HTTableHeaderCheckboxState.CHECKED;
-  return HTTableHeaderCheckboxState.INDETERMINATE;
 }

--- a/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.constants.ts
+++ b/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.constants.ts
@@ -1,4 +1,5 @@
 export enum AccessPermissionGroupsUserTableCol {
+  ROW_TOGGLE,
   NAME,
   CREATE,
   READ,
@@ -7,6 +8,7 @@ export enum AccessPermissionGroupsUserTableCol {
 }
 
 export const AccessPermissionGroupsUserTableColumnLabel = {
+  [AccessPermissionGroupsUserTableCol.ROW_TOGGLE]: '',
   [AccessPermissionGroupsUserTableCol.NAME]: 'Name',
   [AccessPermissionGroupsUserTableCol.CREATE]: 'Create',
   [AccessPermissionGroupsUserTableCol.READ]: 'Read',
@@ -18,5 +20,8 @@ export const APGUTableEditableAction = {
   CHANGE_CREATE_PERMISSION: 'change-create-permission',
   CHANGE_READ_PERMISSION: 'change-read-permission',
   CHANGE_UPDATE_PERMISSION: 'change-update-permission',
-  CHANGE_DELETE_PERMISSION: 'change-delete-permission'
+  CHANGE_DELETE_PERMISSION: 'change-delete-permission',
+  // Intentionally has no CRUD verb segment so actionToVerb()'s regex never
+  // classifies it as a per-cell event.
+  CHANGE_ROW_PERMISSION: 'change-row-permissions'
 };

--- a/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.constants.ts
+++ b/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.constants.ts
@@ -1,5 +1,4 @@
 export enum AccessPermissionGroupsUserTableCol {
-  ROW_TOGGLE,
   NAME,
   CREATE,
   READ,
@@ -8,7 +7,6 @@ export enum AccessPermissionGroupsUserTableCol {
 }
 
 export const AccessPermissionGroupsUserTableColumnLabel = {
-  [AccessPermissionGroupsUserTableCol.ROW_TOGGLE]: '',
   [AccessPermissionGroupsUserTableCol.NAME]: 'Name',
   [AccessPermissionGroupsUserTableCol.CREATE]: 'Create',
   [AccessPermissionGroupsUserTableCol.READ]: 'Read',
@@ -20,8 +18,5 @@ export const APGUTableEditableAction = {
   CHANGE_CREATE_PERMISSION: 'change-create-permission',
   CHANGE_READ_PERMISSION: 'change-read-permission',
   CHANGE_UPDATE_PERMISSION: 'change-update-permission',
-  CHANGE_DELETE_PERMISSION: 'change-delete-permission',
-  // Intentionally has no CRUD verb segment so actionToVerb()'s regex never
-  // classifies it as a per-cell event.
-  CHANGE_ROW_PERMISSION: 'change-row-permissions'
+  CHANGE_DELETE_PERMISSION: 'change-delete-permission'
 };

--- a/src/app/core/_components/tables/api-tokens-table/api-tokens-table.component.html
+++ b/src/app/core/_components/tables/api-tokens-table/api-tokens-table.component.html
@@ -1,0 +1,13 @@
+<ht-table
+  #table
+  name="apiTokensTable"
+  dataType="apiTokens"
+  [columnLabels]="columnLabels"
+  [dataSource]="dataSource"
+  [tableColumns]="tableColumns"
+  [isSelectable]="false"
+  [contextMenuService]="contextMenuService"
+  [isFilterable]="false"
+  [isPageable]="true"
+  (rowActionClicked)="rowActionClicked($event)"
+/>

--- a/src/app/core/_components/tables/api-tokens-table/api-tokens-table.component.ts
+++ b/src/app/core/_components/tables/api-tokens-table/api-tokens-table.component.ts
@@ -1,0 +1,212 @@
+import { Observable, catchError, firstValueFrom, of } from 'rxjs';
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { AfterViewInit, Component, OnDestroy, OnInit } from '@angular/core';
+import { SafeHtml } from '@angular/platform-browser';
+
+import { ApiTokenStatus, JApiToken, computeApiTokenStatus } from '@models/api-token.model';
+
+import { ApiTokensContextMenuService } from '@services/context-menu/users/api-tokens-menu.service';
+import { SERV } from '@services/main.config';
+
+import { ActionMenuEvent } from '@components/menus/action-menu/action-menu.model';
+import { RowActionMenuAction } from '@components/menus/row-action-menu/row-action-menu.constants';
+import {
+  ApiTokensTableCol,
+  ApiTokensTableColumnLabel
+} from '@components/tables/api-tokens-table/api-tokens-table.constants';
+import { BaseTableComponent } from '@components/tables/base-table/base-table.component';
+import { HTTableColumn, HTTableIcon, HTTableRouterLink } from '@components/tables/ht-table/ht-table.models';
+import { TableDialogComponent } from '@components/tables/table-dialog/table-dialog.component';
+import { DialogData } from '@components/tables/table-dialog/table-dialog.model';
+
+import { ApiTokensDataSource } from '@datasources/api-tokens.datasource';
+
+import { formatUnixTimestamp } from '@src/app/shared/utils/datetime';
+
+@Component({
+  selector: 'app-api-tokens-table',
+  templateUrl: './api-tokens-table.component.html',
+  standalone: false
+})
+export class ApiTokensTableComponent extends BaseTableComponent implements OnInit, OnDestroy, AfterViewInit {
+  tableColumns: HTTableColumn[] = [];
+  dataSource: ApiTokensDataSource;
+
+  ngOnInit(): void {
+    this.setColumnLabels(ApiTokensTableColumnLabel);
+    this.tableColumns = this.getColumns();
+    this.dataSource = new ApiTokensDataSource(this.injector);
+    this.dataSource.setColumns(this.tableColumns);
+    this.contextMenuService = new ApiTokensContextMenuService(this.permissionService).addContextMenu();
+    this.setupFilterErrorSubscription(this.dataSource);
+  }
+
+  ngAfterViewInit(): void {
+    this.dataSource.loadAll();
+  }
+
+  ngOnDestroy(): void {
+    for (const sub of this.subscriptions) {
+      sub.unsubscribe();
+    }
+  }
+
+  getColumns(): HTTableColumn[] {
+    return [
+      {
+        id: ApiTokensTableCol.ID,
+        dataKey: 'id',
+        isSortable: true,
+        routerLink: (token: JApiToken) => this.renderDetailLink(token),
+        export: async (token: JApiToken) => token.id + ''
+      },
+      {
+        id: ApiTokensTableCol.VALID_FROM,
+        dataKey: 'startValid',
+        render: (token: JApiToken) => formatUnixTimestamp(token.startValid, this.dateFormat),
+        isSortable: true,
+        export: async (token: JApiToken) => formatUnixTimestamp(token.startValid, this.dateFormat)
+      },
+      {
+        id: ApiTokensTableCol.VALID_UNTIL,
+        dataKey: 'endValid',
+        render: (token: JApiToken) => formatUnixTimestamp(token.endValid, this.dateFormat),
+        isSortable: true,
+        export: async (token: JApiToken) => formatUnixTimestamp(token.endValid, this.dateFormat)
+      },
+      {
+        id: ApiTokensTableCol.STATUS,
+        dataKey: 'isRevoked',
+        render: (token: JApiToken) => this.renderStatusLabel(token),
+        icon: (token: JApiToken) => this.renderApiTokenStatusIcon(token),
+        isSortable: true,
+        export: async (token: JApiToken) => computeApiTokenStatus(token)
+      },
+      {
+        id: ApiTokensTableCol.CREATOR,
+        dataKey: 'userId',
+        // Sorting on a relationship name is not supported by the backend filter spec;
+        // the `userId` dataKey above is for export grouping only.
+        isSortable: false,
+        render: (token: JApiToken) => token.user?.name ?? '—',
+        export: async (token: JApiToken) => token.user?.name ?? token.userId + ''
+      }
+    ];
+  }
+
+  /**
+   * Render the ID column as a link into the detail page. Only this cell is
+   * clickable — the underlying ht-table doesn't expose row-level click events,
+   * and per-cell links match the navigation pattern used elsewhere.
+   */
+  private renderDetailLink(token: JApiToken): Observable<HTTableRouterLink[]> {
+    return of([
+      {
+        routerLink: ['/account', 'api-keys', token.id],
+        label: token.id + ''
+      }
+    ]);
+  }
+
+  /** Map the lifecycle status to a Material icon. Reuses existing icon vocabulary. */
+  private renderApiTokenStatusIcon(token: JApiToken): HTTableIcon {
+    const status = computeApiTokenStatus(token);
+    if (status === ApiTokenStatus.ACTIVE) {
+      return { name: 'check_circle', cls: 'text-ok' };
+    }
+    if (status === ApiTokenStatus.REVOKED) {
+      return { name: 'block', cls: 'text-critical' };
+    }
+    return { name: 'schedule', cls: 'text-warning' };
+  }
+
+  private renderStatusLabel(token: JApiToken): SafeHtml {
+    const status = computeApiTokenStatus(token);
+    return status.charAt(0).toUpperCase() + status.slice(1);
+  }
+
+  // --- Action handling ---
+
+  rowActionClicked(event: ActionMenuEvent<JApiToken>): void {
+    switch (event.menuItem.action) {
+      case RowActionMenuAction.REVOKE:
+        this.openDialog({
+          rows: [event.data],
+          title: `Revoke API key #${event.data.id}?`,
+          icon: 'warning',
+          body: 'Once revoked, this token will immediately stop working. This cannot be undone.',
+          warn: true,
+          action: event.menuItem.action
+        });
+        break;
+      case RowActionMenuAction.DELETE:
+        this.openDialog({
+          rows: [event.data],
+          title: `Delete API key #${event.data.id}?`,
+          icon: 'warning',
+          body: 'This permanently removes the expired token record.',
+          warn: true,
+          action: event.menuItem.action
+        });
+        break;
+    }
+  }
+
+  private openDialog(data: DialogData<JApiToken>) {
+    const dialogRef = this.dialog.open(TableDialogComponent, {
+      data: data,
+      width: '450px'
+    });
+
+    this.subscriptions.push(
+      dialogRef.afterClosed().subscribe((result) => {
+        if (!result?.action) {
+          return;
+        }
+        const token: JApiToken = result.data[0];
+        switch (result.action) {
+          case RowActionMenuAction.REVOKE:
+            void this.revoke(token);
+            break;
+          case RowActionMenuAction.DELETE:
+            void this.delete(token);
+            break;
+        }
+      })
+    );
+  }
+
+  private async revoke(token: JApiToken): Promise<void> {
+    try {
+      await firstValueFrom(
+        this.gs.update(SERV.API_TOKENS, token.id, { isRevoked: true }).pipe(
+          catchError((error: HttpErrorResponse) => {
+            throw error;
+          })
+        )
+      );
+      this.alertService.showSuccessMessage(`Successfully revoked API key #${token.id}.`);
+      this.reload();
+    } catch (error) {
+      this.alertService.showErrorMessage(`Could not revoke API key: ${this.extractMessage(error)}`);
+    }
+  }
+
+  private async delete(token: JApiToken): Promise<void> {
+    try {
+      await firstValueFrom(this.gs.delete(SERV.API_TOKENS, token.id));
+      this.alertService.showSuccessMessage(`Successfully deleted API key #${token.id}.`);
+      this.reload();
+    } catch (error) {
+      this.alertService.showErrorMessage(`Could not delete API key: ${this.extractMessage(error)}`);
+    }
+  }
+
+  private extractMessage(error: unknown): string {
+    if (error instanceof HttpErrorResponse) {
+      return error.error?.title || error.statusText || 'Unknown error';
+    }
+    return 'Unknown error';
+  }
+}

--- a/src/app/core/_components/tables/api-tokens-table/api-tokens-table.component.ts
+++ b/src/app/core/_components/tables/api-tokens-table/api-tokens-table.component.ts
@@ -12,6 +12,7 @@ import { SERV } from '@services/main.config';
 import { ActionMenuEvent } from '@components/menus/action-menu/action-menu.model';
 import { RowActionMenuAction } from '@components/menus/row-action-menu/row-action-menu.constants';
 import {
+  ApiTokensRowAction,
   ApiTokensTableCol,
   ApiTokensTableColumnLabel
 } from '@components/tables/api-tokens-table/api-tokens-table.constants';
@@ -130,7 +131,7 @@ export class ApiTokensTableComponent extends BaseTableComponent implements OnIni
 
   rowActionClicked(event: ActionMenuEvent<JApiToken>): void {
     switch (event.menuItem.action) {
-      case RowActionMenuAction.REVOKE:
+      case ApiTokensRowAction.REVOKE:
         this.openDialog({
           rows: [event.data],
           title: `Revoke API key #${event.data.id}?`,
@@ -166,7 +167,7 @@ export class ApiTokensTableComponent extends BaseTableComponent implements OnIni
         }
         const token: JApiToken = result.data[0];
         switch (result.action) {
-          case RowActionMenuAction.REVOKE:
+          case ApiTokensRowAction.REVOKE:
             void this.revoke(token);
             break;
           case RowActionMenuAction.DELETE:

--- a/src/app/core/_components/tables/api-tokens-table/api-tokens-table.component.ts
+++ b/src/app/core/_components/tables/api-tokens-table/api-tokens-table.component.ts
@@ -22,7 +22,7 @@ import { DialogData } from '@components/tables/table-dialog/table-dialog.model';
 
 import { ApiTokensDataSource } from '@datasources/api-tokens.datasource';
 
-import { formatUnixTimestamp } from '@src/app/shared/utils/datetime';
+import { formatUnixTimestamp, lastValidSecond } from '@src/app/shared/utils/datetime';
 
 @Component({
   selector: 'app-api-tokens-table',
@@ -71,9 +71,9 @@ export class ApiTokensTableComponent extends BaseTableComponent implements OnIni
       {
         id: ApiTokensTableCol.VALID_UNTIL,
         dataKey: 'endValid',
-        render: (token: JApiToken) => formatUnixTimestamp(token.endValid, this.dateFormat),
+        render: (token: JApiToken) => formatUnixTimestamp(lastValidSecond(token.endValid), this.dateFormat),
         isSortable: true,
-        export: async (token: JApiToken) => formatUnixTimestamp(token.endValid, this.dateFormat)
+        export: async (token: JApiToken) => formatUnixTimestamp(lastValidSecond(token.endValid), this.dateFormat)
       },
       {
         id: ApiTokensTableCol.STATUS,

--- a/src/app/core/_components/tables/api-tokens-table/api-tokens-table.constants.ts
+++ b/src/app/core/_components/tables/api-tokens-table/api-tokens-table.constants.ts
@@ -1,0 +1,16 @@
+export const ApiTokensTableCol = {
+  ID: 0,
+  VALID_FROM: 1,
+  VALID_UNTIL: 2,
+  STATUS: 3,
+  CREATOR: 4
+} as const;
+export type ApiTokensTableCol = (typeof ApiTokensTableCol)[keyof typeof ApiTokensTableCol];
+
+export const ApiTokensTableColumnLabel: Record<ApiTokensTableCol, string> = {
+  [ApiTokensTableCol.ID]: 'ID',
+  [ApiTokensTableCol.VALID_FROM]: 'Valid From',
+  [ApiTokensTableCol.VALID_UNTIL]: 'Valid Until',
+  [ApiTokensTableCol.STATUS]: 'Status',
+  [ApiTokensTableCol.CREATOR]: 'Creator'
+};

--- a/src/app/core/_components/tables/api-tokens-table/api-tokens-table.constants.ts
+++ b/src/app/core/_components/tables/api-tokens-table/api-tokens-table.constants.ts
@@ -10,7 +10,7 @@ export type ApiTokensTableCol = (typeof ApiTokensTableCol)[keyof typeof ApiToken
 export const ApiTokensTableColumnLabel: Record<ApiTokensTableCol, string> = {
   [ApiTokensTableCol.ID]: 'ID',
   [ApiTokensTableCol.VALID_FROM]: 'Valid From',
-  [ApiTokensTableCol.VALID_UNTIL]: 'Valid Until',
+  [ApiTokensTableCol.VALID_UNTIL]: 'Expires At',
   [ApiTokensTableCol.STATUS]: 'Status',
   [ApiTokensTableCol.CREATOR]: 'Creator'
 };

--- a/src/app/core/_components/tables/api-tokens-table/api-tokens-table.constants.ts
+++ b/src/app/core/_components/tables/api-tokens-table/api-tokens-table.constants.ts
@@ -14,3 +14,9 @@ export const ApiTokensTableColumnLabel: Record<ApiTokensTableCol, string> = {
   [ApiTokensTableCol.STATUS]: 'Status',
   [ApiTokensTableCol.CREATOR]: 'Creator'
 };
+
+export const ApiTokensRowAction = { REVOKE: 'revoke' } as const;
+export type ApiTokensRowAction = (typeof ApiTokensRowAction)[keyof typeof ApiTokensRowAction];
+
+export const ApiTokensRowActionLabel = { REVOKE: 'Revoke API Key' } as const;
+export const ApiTokensRowActionIcon = { REVOKE: 'block' } as const;

--- a/src/app/core/_components/tables/ht-table/ht-table.component.html
+++ b/src/app/core/_components/tables/ht-table/ht-table.component.html
@@ -193,8 +193,22 @@
 
     @for (tableColumn of tableColumns; track tableColumn.id) {
       <ng-container [matColumnDef]="tableColumn.id + ''">
-        <!-- if sortable column header -->
-        @if (tableColumn.isSortable) {
+        <!-- if header checkbox is supplied (matrix-style toggle) -->
+        @if (tableColumn.headerCheckbox; as headerCheckboxFn) {
+          <th *matHeaderCellDef [class.text-right]="tableColumn.position === 'right'" mat-header-cell>
+            @let headerCheckbox = headerCheckboxFn();
+            <mat-checkbox
+              (click)="$event.stopPropagation()"
+              (change)="headerCheckbox.change($event.checked)"
+              [checked]="headerCheckbox.state === 'checked'"
+              [indeterminate]="headerCheckbox.state === 'indeterminate'"
+              [matTooltip]="headerCheckbox.tooltip || ''"
+            >
+              {{ headerCheckbox.label ?? columnLabels[tableColumn.id] }}
+            </mat-checkbox>
+          </th>
+        } @else if (tableColumn.isSortable) {
+          <!-- if sortable column header -->
           <th
             mat-header-cell
             *matHeaderCellDef

--- a/src/app/core/_components/tables/ht-table/ht-table.component.html
+++ b/src/app/core/_components/tables/ht-table/ht-table.component.html
@@ -193,22 +193,8 @@
 
     @for (tableColumn of tableColumns; track tableColumn.id) {
       <ng-container [matColumnDef]="tableColumn.id + ''">
-        <!-- if header checkbox is supplied (matrix-style toggle) -->
-        @if (tableColumn.headerCheckbox; as headerCheckboxFn) {
-          <th *matHeaderCellDef [class.text-right]="tableColumn.position === 'right'" mat-header-cell>
-            @let headerCheckbox = headerCheckboxFn();
-            <mat-checkbox
-              (click)="$event.stopPropagation()"
-              (change)="headerCheckbox.change($event.checked)"
-              [checked]="headerCheckbox.state === 'checked'"
-              [indeterminate]="headerCheckbox.state === 'indeterminate'"
-              [matTooltip]="headerCheckbox.tooltip || ''"
-            >
-              {{ headerCheckbox.label ?? columnLabels[tableColumn.id] }}
-            </mat-checkbox>
-          </th>
-        } @else if (tableColumn.isSortable) {
-          <!-- if sortable column header -->
+        <!-- if sortable column header -->
+        @if (tableColumn.isSortable) {
           <th
             mat-header-cell
             *matHeaderCellDef

--- a/src/app/core/_components/tables/ht-table/ht-table.component.ts
+++ b/src/app/core/_components/tables/ht-table/ht-table.component.ts
@@ -352,7 +352,7 @@ export class HTTableComponent<T extends BaseModel> implements OnInit, AfterViewI
       data: {
         availableColumns: this.filterKeys(
           this.columnLabels,
-          this.tableColumns.map((col) => col.id + '')
+          this.tableColumns.filter((col) => !col.alwaysShown).map((col) => col.id + '')
         ),
         selectedColumns: this.displayedColumns
       }
@@ -433,6 +433,13 @@ export class HTTableComponent<T extends BaseModel> implements OnInit, AfterViewI
     if (this.isSelectable) {
       // Add checkbox if enabled
       this.displayedColumns.push(COL_SELECT + '');
+    }
+    // Pin "structural" columns (alwaysShown) before the user-configurable columns,
+    // so e.g. a row-toggle column survives even if the stored UI config predates it.
+    for (const col of this.tableColumns) {
+      if (col.alwaysShown && !columnNames.includes(col.id)) {
+        this.displayedColumns.push(col.id + '');
+      }
     }
     for (const num of columnNames) {
       if (this.tableColumns.some((col) => col.id === num)) {

--- a/src/app/core/_components/tables/ht-table/ht-table.component.ts
+++ b/src/app/core/_components/tables/ht-table/ht-table.component.ts
@@ -352,7 +352,7 @@ export class HTTableComponent<T extends BaseModel> implements OnInit, AfterViewI
       data: {
         availableColumns: this.filterKeys(
           this.columnLabels,
-          this.tableColumns.filter((col) => !col.alwaysShown).map((col) => col.id + '')
+          this.tableColumns.map((col) => col.id + '')
         ),
         selectedColumns: this.displayedColumns
       }
@@ -433,13 +433,6 @@ export class HTTableComponent<T extends BaseModel> implements OnInit, AfterViewI
     if (this.isSelectable) {
       // Add checkbox if enabled
       this.displayedColumns.push(COL_SELECT + '');
-    }
-    // Pin "structural" columns (alwaysShown) before the user-configurable columns,
-    // so e.g. a row-toggle column survives even if the stored UI config predates it.
-    for (const col of this.tableColumns) {
-      if (col.alwaysShown && !columnNames.includes(col.id)) {
-        this.displayedColumns.push(col.id + '');
-      }
     }
     for (const num of columnNames) {
       if (this.tableColumns.some((col) => col.id === num)) {

--- a/src/app/core/_components/tables/ht-table/ht-table.models.ts
+++ b/src/app/core/_components/tables/ht-table/ht-table.models.ts
@@ -75,25 +75,6 @@ export interface HTTableEditable<T> {
   indeterminate?: boolean;
 }
 
-// indeterminate means some are checked, dash line in checkbox instead of checkmark
-export const HTTableHeaderCheckboxState = {
-  CHECKED: 'checked',
-  UNCHECKED: 'unchecked',
-  INDETERMINATE: 'indeterminate'
-} as const;
-export type HTTableHeaderCheckboxState = (typeof HTTableHeaderCheckboxState)[keyof typeof HTTableHeaderCheckboxState];
-
-// allow rendering checkbox in the header instead of just label
-export interface HTTableHeaderCheckbox {
-  // state of checkbox based on column if all are selected, none are selected or some
-  state: HTTableHeaderCheckboxState;
-  // invoked when user clicks on the header checkbox
-  change: (next: boolean) => void;
-  tooltip?: string;
-  // optional label shown next to the checkbox (column label)
-  label?: string;
-}
-
 /** Column type for checkbox toggle events in attack file tables. */
 export type CheckboxColumnType = 'CMD' | 'CMD_PREPRO';
 
@@ -127,14 +108,6 @@ export interface HTTableColumn {
   icon?(data: BaseModel): HTTableIcon;
   isCopy?: boolean;
   parent?: string; //parent is to build relation sort query in format "task.taskName"
-  // if passed render a checkbox in the header instead of just label
-  headerCheckbox?(): HTTableHeaderCheckbox;
-  /**
-   * When true, this column is treated as structural: it is always rendered (regardless
-   * of the user's stored column-visibility config) and is hidden from the column-selection
-   * dialog. Use for control columns like a per-row toggle that the form depends on.
-   */
-  alwaysShown?: boolean;
 }
 
 /** Stringified column enum value used as mat-table column identifier */

--- a/src/app/core/_components/tables/ht-table/ht-table.models.ts
+++ b/src/app/core/_components/tables/ht-table/ht-table.models.ts
@@ -29,6 +29,7 @@ export type DataType =
   | 'users'
   | 'notifications'
   | 'agent-binaries'
+  | 'apiTokens'
   | 'health-checks'
   | 'health-check-agents'
   | 'logs'
@@ -67,6 +68,41 @@ export interface HTTableEditable<T> {
   data: T;
   value: string;
   action: string;
+  /** When true, the cell's checkbox renders as disabled and ignores clicks. */
+  disabled?: boolean;
+  /** Optional matTooltip text for the cell — useful for explaining why a disabled cell can't be toggled. */
+  tooltip?: string;
+  /**
+   * When true, the cell's checkbox renders in indeterminate state (a partial selection
+   * representation), regardless of `value`. Used by row-toggle cells in matrix-style
+   * tables when only some — but not all — sub-items in the row are selected.
+   */
+  indeterminate?: boolean;
+}
+
+/** Tri-state of a header checkbox driving "select all in column" toggles. */
+export const HTTableHeaderCheckboxState = {
+  CHECKED: 'checked',
+  UNCHECKED: 'unchecked',
+  INDETERMINATE: 'indeterminate'
+} as const;
+export type HTTableHeaderCheckboxState = (typeof HTTableHeaderCheckboxState)[keyof typeof HTTableHeaderCheckboxState];
+
+/**
+ * Header-level checkbox descriptor for a column. When a column's
+ * `headerCheckbox` callback is supplied, ht-table renders a `<mat-checkbox>`
+ * in the column header instead of the static label. Used to drive
+ * "select all rows in this column" toggles for matrix-style tables.
+ */
+export interface HTTableHeaderCheckbox {
+  /** Tri-state representing the column's aggregate selection. */
+  state: HTTableHeaderCheckboxState;
+  /** Invoked when the user clicks the header checkbox. */
+  change: (next: boolean) => void;
+  /** Optional matTooltip text displayed on the header checkbox. */
+  tooltip?: string;
+  /** Optional label rendered next to the checkbox (defaults to the column label). */
+  label?: string;
 }
 
 /** Column type for checkbox toggle events in attack file tables. */
@@ -102,6 +138,18 @@ export interface HTTableColumn {
   icon?(data: BaseModel): HTTableIcon;
   isCopy?: boolean;
   parent?: string; //parent is to build relation sort query in format "task.taskName"
+  /**
+   * When supplied, the column header renders a mat-checkbox bound to the returned
+   * descriptor instead of (or in addition to) the static label. Used by matrix-style
+   * tables to expose a "select all rows in this column" toggle.
+   */
+  headerCheckbox?(): HTTableHeaderCheckbox;
+  /**
+   * When true, this column is treated as structural: it is always rendered (regardless
+   * of the user's stored column-visibility config) and is hidden from the column-selection
+   * dialog. Use for control columns like a per-row toggle that the form depends on.
+   */
+  alwaysShown?: boolean;
 }
 
 /** Stringified column enum value used as mat-table column identifier */

--- a/src/app/core/_components/tables/ht-table/ht-table.models.ts
+++ b/src/app/core/_components/tables/ht-table/ht-table.models.ts
@@ -68,19 +68,14 @@ export interface HTTableEditable<T> {
   data: T;
   value: string;
   action: string;
-  /** When true, the cell's checkbox renders as disabled and ignores clicks. */
   disabled?: boolean;
-  /** Optional matTooltip text for the cell — useful for explaining why a disabled cell can't be toggled. */
+  // Optional matTooltip text for the cell — useful for explaining why a disabled cell can't be toggled.
   tooltip?: string;
-  /**
-   * When true, the cell's checkbox renders in indeterminate state (a partial selection
-   * representation), regardless of `value`. Used by row-toggle cells in matrix-style
-   * tables when only some — but not all — sub-items in the row are selected.
-   */
+  // indeterminate if checkbox is half filled (instead of full check) so we know that only some and not all entries are checked
   indeterminate?: boolean;
 }
 
-/** Tri-state of a header checkbox driving "select all in column" toggles. */
+// indeterminate means some are checked, dash line in checkbox instead of checkmark
 export const HTTableHeaderCheckboxState = {
   CHECKED: 'checked',
   UNCHECKED: 'unchecked',
@@ -88,20 +83,14 @@ export const HTTableHeaderCheckboxState = {
 } as const;
 export type HTTableHeaderCheckboxState = (typeof HTTableHeaderCheckboxState)[keyof typeof HTTableHeaderCheckboxState];
 
-/**
- * Header-level checkbox descriptor for a column. When a column's
- * `headerCheckbox` callback is supplied, ht-table renders a `<mat-checkbox>`
- * in the column header instead of the static label. Used to drive
- * "select all rows in this column" toggles for matrix-style tables.
- */
+// allow rendering checkbox in the header instead of just label
 export interface HTTableHeaderCheckbox {
-  /** Tri-state representing the column's aggregate selection. */
+  // state of checkbox based on column if all are selected, none are selected or some
   state: HTTableHeaderCheckboxState;
-  /** Invoked when the user clicks the header checkbox. */
+  // invoked when user clicks on the header checkbox
   change: (next: boolean) => void;
-  /** Optional matTooltip text displayed on the header checkbox. */
   tooltip?: string;
-  /** Optional label rendered next to the checkbox (defaults to the column label). */
+  // optional label shown next to the checkbox (column label)
   label?: string;
 }
 
@@ -138,11 +127,7 @@ export interface HTTableColumn {
   icon?(data: BaseModel): HTTableIcon;
   isCopy?: boolean;
   parent?: string; //parent is to build relation sort query in format "task.taskName"
-  /**
-   * When supplied, the column header renders a mat-checkbox bound to the returned
-   * descriptor instead of (or in addition to) the static label. Used by matrix-style
-   * tables to expose a "select all rows in this column" toggle.
-   */
+  // if passed render a checkbox in the header instead of just label
   headerCheckbox?(): HTTableHeaderCheckbox;
   /**
    * When true, this column is treated as structural: it is always rendered (regardless

--- a/src/app/core/_components/tables/ht-table/type/editable/editable-checkbox/ht-table-type-editable-checkbox.component.html
+++ b/src/app/core/_components/tables/ht-table/type/editable/editable-checkbox/ht-table-type-editable-checkbox.component.html
@@ -1,12 +1,19 @@
 @if (tableColumn.checkbox) {
   <div class="editable-container">
     @if (checkbox.value !== 'undefined') {
-      <mat-checkbox
-        class="editable-checkbox"
-        [ngModel]="parseCheckboxValue(checkbox.value)"
-        (change)="onEditableInputSaved($event.checked)"
-        matTooltip="Click to edit value"
-      ></mat-checkbox>
+      <!-- Tooltip lives on the wrapper, not the checkbox: Material's MDC checkbox sets
+           pointer-events: none when disabled, so a matTooltip bound directly on it never
+           fires. The span keeps receiving hover events, so disabled cells still surface
+           their reason. -->
+      <span [matTooltip]="checkbox.tooltip || 'Click to edit value'">
+        <mat-checkbox
+          class="editable-checkbox"
+          [ngModel]="parseCheckboxValue(checkbox.value)"
+          [indeterminate]="!!checkbox.indeterminate"
+          (change)="onEditableInputSaved($event.checked)"
+          [disabled]="!!checkbox.disabled"
+        ></mat-checkbox>
+      </span>
     }
   </div>
 }

--- a/src/app/core/_components/tables/ht-table/type/editable/editable-checkbox/ht-table-type-editable-checkbox.component.html
+++ b/src/app/core/_components/tables/ht-table/type/editable/editable-checkbox/ht-table-type-editable-checkbox.component.html
@@ -1,10 +1,7 @@
 @if (tableColumn.checkbox) {
   <div class="editable-container">
     @if (checkbox.value !== 'undefined') {
-      <!-- Tooltip lives on the wrapper, not the checkbox: Material's MDC checkbox sets
-           pointer-events: none when disabled, so a matTooltip bound directly on it never
-           fires. The span keeps receiving hover events, so disabled cells still surface
-           their reason. -->
+      <!-- Tooltip is on wrapper because when checkbox is disabled -> no tooltip is shown but here we want the tooltip to always show -->
       <span [matTooltip]="checkbox.tooltip || 'Click to edit value'">
         <mat-checkbox
           class="editable-checkbox"

--- a/src/app/core/_components/tables/ht-table/type/editable/editable-checkbox/ht-table-type-editable-checkbox.component.ts
+++ b/src/app/core/_components/tables/ht-table/type/editable/editable-checkbox/ht-table-type-editable-checkbox.component.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges
+} from '@angular/core';
 
 import { BaseModel } from '@models/base.model';
 
@@ -10,7 +18,7 @@ import { HTTableColumn, HTTableEditable } from '@components/tables/ht-table/ht-t
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false
 })
-export class HTTableTypeEditableCheckboxComponent implements OnInit {
+export class HTTableTypeEditableCheckboxComponent implements OnChanges {
   checkbox: HTTableEditable<BaseModel>;
   original: string;
 
@@ -23,8 +31,11 @@ export class HTTableTypeEditableCheckboxComponent implements OnInit {
 
   editMode = false;
 
-  ngOnInit(): void {
-    if (this.tableColumn.checkbox) {
+  // Recompute on every input change so the cell reflects the latest parent state when a
+  // sibling cell or a column/row toggle updates the underlying selection. The column header
+  // already refreshes per CD cycle via `@let`; this keeps row cells consistent.
+  ngOnChanges(changes: SimpleChanges): void {
+    if ((changes['element'] || changes['tableColumn']) && this.tableColumn?.checkbox) {
       this.checkbox = this.tableColumn.checkbox(this.element);
       this.original = this.checkbox.value;
     }

--- a/src/app/core/_constants/userpermissions.config.ts
+++ b/src/app/core/_constants/userpermissions.config.ts
@@ -185,6 +185,13 @@ export enum Notif {
   READ = 'permNotificationSettingRead',
   UPDATE = 'permNotificationSettingUpdate'
 }
+// // JWT API KEY
+export enum JwtApiKey {
+  CREATE = 'permJwtApiKeyCreate',
+  DELETE = 'permJwtApiKeyDelete',
+  READ = 'permJwtApiKeyRead',
+  UPDATE = 'permJwtApiKeyUpdate'
+}
 
 export class Perm {
   static readonly Agent = Agent;
@@ -215,6 +222,7 @@ export class Perm {
   static readonly RightGroup = RightGroup;
   static readonly GroupAccess = GroupAccess;
   static readonly Notif = Notif;
+  static readonly JwtApiKey = JwtApiKey;
 }
 
 type NestedEnumValues<T> = T extends Record<string, string> ? T[keyof T] : never;

--- a/src/app/core/_datasources/access-permission-groups-expand.datasource.ts
+++ b/src/app/core/_datasources/access-permission-groups-expand.datasource.ts
@@ -1,7 +1,7 @@
 import { zGlobalPermissionGroupResponse } from '@generated/api/zod';
 import { EMPTY, catchError, finalize } from 'rxjs';
 
-import { JGlobalPermissionGroup, UserPermissions } from '@models/global-permission-group.model';
+import { Permission } from '@models/global-permission-group.model';
 import { ResponseWrapper } from '@models/response.model';
 import { JUser } from '@models/user.model';
 
@@ -10,7 +10,9 @@ import { RequestParamBuilder } from '@services/params/builder-implementation.ser
 
 import { BaseDataSource } from '@datasources/base.datasource';
 
-export class AccessPermissionGroupsExpandDataSource extends BaseDataSource<JUser | UserPermissions> {
+import { PermissionMatrixRow, buildPermissionMatrix } from '@src/app/shared/utils/permission-matrix';
+
+export class AccessPermissionGroupsExpandDataSource extends BaseDataSource<JUser | PermissionMatrixRow> {
   private _accesspermgroupId = 0;
   private _expand = '';
   private _perm = 0;
@@ -43,47 +45,27 @@ export class AccessPermissionGroupsExpandDataSource extends BaseDataSource<JUser
           const globalPermissionGroup = this.serializer.deserialize(response, zGlobalPermissionGroupResponse, {
             include: ['userMembers'] as const
           });
-          let data: (UserPermissions | JUser)[];
-          if (this._perm) {
-            data = this.processPermissions(globalPermissionGroup);
-          } else {
-            data = globalPermissionGroup.userMembers;
-          }
+          const data: (PermissionMatrixRow | JUser)[] = this._perm
+            ? buildPermissionMatrix(globalPermissionGroup.permissions)
+            : globalPermissionGroup.userMembers;
           this.setData(data);
         })
     );
   }
 
+  /**
+   * Populate the table synchronously from a flat permission map (no API call).
+   * Used by form-mode consumers (e.g. the API-key creation form) where the
+   * matrix is driven by the current user's `granted` map rather than a
+   * persisted permission group.
+   */
+  loadFromMap(permissions: Permission): void {
+    this.loading = false;
+    this.setData(buildPermissionMatrix(permissions));
+  }
+
   reload(): void {
     this.clearSelection();
     this.loadAll();
-  }
-
-  private processPermissions(globalPermissionGroup: JGlobalPermissionGroup): UserPermissions[] {
-    let permId = 0;
-    return Object.entries(globalPermissionGroup.permissions).reduce<UserPermissions[]>((acc, [key, value]) => {
-      const operation = key.replace(/^perm/, '').replace(/(Create|Delete|Read|Update)$/, '');
-      let operationName = operation.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase();
-      operationName = operationName.charAt(0).toUpperCase() + operationName.slice(1);
-      const type = key.match(/(Create|Delete|Read|Update)$/)?.[0];
-      const existingPermission = acc.find((item) => item.name === operationName && item.key === operation);
-      if (existingPermission && type) {
-        existingPermission[type.toLowerCase() as 'create' | 'read' | 'update' | 'delete'] = value;
-      } else {
-        const newPermission: UserPermissions = {
-          id: permId++,
-          type: 'userPermission',
-          name: operationName,
-          key: operation,
-          create: false,
-          read: false,
-          update: false,
-          delete: false,
-          ...(type ? { [type.toLowerCase()]: value } : {})
-        };
-        acc.push(newPermission);
-      }
-      return acc;
-    }, []);
   }
 }

--- a/src/app/core/_datasources/api-tokens.datasource.ts
+++ b/src/app/core/_datasources/api-tokens.datasource.ts
@@ -1,0 +1,68 @@
+import { zApiTokenListResponse } from '@generated/api/zod';
+import { EMPTY, catchError, finalize } from 'rxjs';
+
+import { ApiTokenStatus, JApiToken, computeApiTokenStatus } from '@models/api-token.model';
+import { ResponseWrapper } from '@models/response.model';
+
+import { SERV } from '@services/main.config';
+import { RequestParamBuilder } from '@services/params/builder-implementation.service';
+
+import { BaseDataSource } from '@datasources/base.datasource';
+
+/**
+ * Each row is annotated with two derived boolean flags so the context-menu can
+ * gate Revoke (active only) and Delete (expired only) — the menu's
+ * ContextMenuCondition machinery only supports boolean keys.
+ */
+type ApiTokenRow = JApiToken & {
+  isActive: boolean;
+  isExpired: boolean;
+};
+
+export class ApiTokensDataSource extends BaseDataSource<JApiToken> {
+  loadAll(): void {
+    this.loading = true;
+
+    const params = new RequestParamBuilder().addInitial(this).addInclude('user');
+    const tokens$ = this.service.getAll(SERV.API_TOKENS, params.create());
+
+    this.subscriptions.push(
+      tokens$
+        .pipe(
+          catchError((error) => {
+            this.handleFilterError(error);
+            return EMPTY;
+          }),
+          finalize(() => (this.loading = false))
+        )
+        .subscribe((response: ResponseWrapper) => {
+          const tokens: JApiToken[] = this.serializer.deserialize(response, zApiTokenListResponse, {
+            include: ['user']
+          });
+
+          const annotated: ApiTokenRow[] = tokens.map((t) => {
+            const status = computeApiTokenStatus(t);
+            return {
+              ...t,
+              isActive: status === ApiTokenStatus.ACTIVE,
+              isExpired: status === ApiTokenStatus.EXPIRED
+            };
+          });
+
+          const length = response.meta.page.total_elements;
+          const nextLink = response.links.next;
+          const prevLink = response.links.prev;
+          const after = nextLink ? new URL(nextLink).searchParams.get('page[after]') : null;
+          const before = prevLink ? new URL(prevLink).searchParams.get('page[before]') : null;
+
+          this.setPaginationConfig(this.pageSize, length, after, before, this.index);
+          this.setData(annotated);
+        })
+    );
+  }
+
+  reload(): void {
+    this.clearSelection();
+    this.loadAll();
+  }
+}

--- a/src/app/core/_models/api-token.model.spec.ts
+++ b/src/app/core/_models/api-token.model.spec.ts
@@ -1,0 +1,31 @@
+import { ApiTokenStatus, JApiToken, computeApiTokenStatus } from '@models/api-token.model';
+
+describe('computeApiTokenStatus', () => {
+  function token(overrides: Partial<JApiToken> = {}): JApiToken {
+    return {
+      id: 1,
+      type: 'apiToken',
+      startValid: 0,
+      endValid: 1_000,
+      userId: 1,
+      isRevoked: false,
+      ...overrides
+    };
+  }
+
+  it('returns ACTIVE when nowSec is before endValid and not revoked', () => {
+    expect(computeApiTokenStatus(token({ endValid: 2_000 }), 1_000)).toBe(ApiTokenStatus.ACTIVE);
+  });
+
+  it('returns EXPIRED when nowSec equals endValid and not revoked', () => {
+    expect(computeApiTokenStatus(token({ endValid: 1_000 }), 1_000)).toBe(ApiTokenStatus.EXPIRED);
+  });
+
+  it('returns REVOKED when isRevoked is true even if the token is otherwise active', () => {
+    expect(computeApiTokenStatus(token({ isRevoked: true, endValid: 2_000 }), 1_000)).toBe(ApiTokenStatus.REVOKED);
+  });
+
+  it('prefers REVOKED over EXPIRED when a revoked token has also expired', () => {
+    expect(computeApiTokenStatus(token({ isRevoked: true, endValid: 500 }), 1_000)).toBe(ApiTokenStatus.REVOKED);
+  });
+});

--- a/src/app/core/_models/api-token.model.ts
+++ b/src/app/core/_models/api-token.model.ts
@@ -1,0 +1,51 @@
+import { BaseModel } from '@models/base.model';
+import { UserId } from '@models/id.types';
+import { JUser } from '@models/user.model';
+
+/**
+ * Interface definition for a JWT API token.
+ *
+ * The `token` field is only populated on the response of a POST (creation);
+ * subsequent reads do not return it. UI flows must capture and surface it
+ * exactly once.
+ *
+ * Scopes are intentionally absent: they are write-only at creation and baked
+ * into the signed JWT payload, never persisted server-side. Detail views must
+ * show the matrix structure without a true selection state.
+ *
+ * `user` is the included creator relationship (populated when the request
+ * uses `?include=user`).
+ *
+ * @extends BaseModel
+ */
+export interface JApiToken extends BaseModel {
+  startValid: number;
+  endValid: number;
+  userId: UserId;
+  isRevoked: boolean;
+  token?: string | undefined;
+  user?: JUser | null;
+}
+
+/** Lifecycle state of a token, derived from its attributes plus the current time. */
+export const ApiTokenStatus = {
+  ACTIVE: 'active',
+  REVOKED: 'revoked',
+  EXPIRED: 'expired'
+} as const;
+export type ApiTokenStatus = (typeof ApiTokenStatus)[keyof typeof ApiTokenStatus];
+
+/**
+ * Compute a token's lifecycle state. `nowSec` is the current unix timestamp in
+ * seconds; injectable for deterministic tests, otherwise sampled from the
+ * system clock at call time. Revoked beats expired so a token revoked after
+ * expiry still reads as "Revoked" — closer to user intent than the raw clock
+ * comparison.
+ */
+export function computeApiTokenStatus(token: JApiToken, nowSec?: number): ApiTokenStatus {
+  if (token.isRevoked) {
+    return ApiTokenStatus.REVOKED;
+  }
+  const now = nowSec ?? Math.floor(Date.now() / 1000);
+  return now >= token.endValid ? ApiTokenStatus.EXPIRED : ApiTokenStatus.ACTIVE;
+}

--- a/src/app/core/_models/api-token.model.ts
+++ b/src/app/core/_models/api-token.model.ts
@@ -12,10 +12,7 @@ import { JUser } from '@models/user.model';
  * Scopes are intentionally absent: they are write-only at creation and baked
  * into the signed JWT payload, never persisted server-side. Detail views must
  * show the matrix structure without a true selection state.
- *
- * `user` is the included creator relationship (populated when the request
- * uses `?include=user`).
- *
+ * @TODO -> improvement here would  be to add a name field (currently not supported by backend) as well as permissions again
  * @extends BaseModel
  */
 export interface JApiToken extends BaseModel {
@@ -27,7 +24,6 @@ export interface JApiToken extends BaseModel {
   user?: JUser | null;
 }
 
-/** Lifecycle state of a token, derived from its attributes plus the current time. */
 export const ApiTokenStatus = {
   ACTIVE: 'active',
   REVOKED: 'revoked',
@@ -35,13 +31,6 @@ export const ApiTokenStatus = {
 } as const;
 export type ApiTokenStatus = (typeof ApiTokenStatus)[keyof typeof ApiTokenStatus];
 
-/**
- * Compute a token's lifecycle state. `nowSec` is the current unix timestamp in
- * seconds; injectable for deterministic tests, otherwise sampled from the
- * system clock at call time. Revoked beats expired so a token revoked after
- * expiry still reads as "Revoked" — closer to user intent than the raw clock
- * comparison.
- */
 export function computeApiTokenStatus(token: JApiToken, nowSec?: number): ApiTokenStatus {
   if (token.isRevoked) {
     return ApiTokenStatus.REVOKED;

--- a/src/app/core/_models/auth-user.model.ts
+++ b/src/app/core/_models/auth-user.model.ts
@@ -6,6 +6,7 @@ import { UserId } from '@models/id.types';
  * @prop _token     access token
  * @prop _username  Name of user
  */
+
 export interface AuthData {
   _expires: Date | string;
   _token: string;

--- a/src/app/core/_models/config-ui.model.ts
+++ b/src/app/core/_models/config-ui.model.ts
@@ -126,7 +126,8 @@ const _uiConfigDefault = {
         ApiTokensTableCol.ID,
         ApiTokensTableCol.VALID_FROM,
         ApiTokensTableCol.VALID_UNTIL,
-        ApiTokensTableCol.STATUS
+        ApiTokensTableCol.STATUS,
+        ApiTokensTableCol.CREATOR
       ],
       order: {
         id: ApiTokensTableCol.ID,

--- a/src/app/core/_models/config-ui.model.ts
+++ b/src/app/core/_models/config-ui.model.ts
@@ -7,6 +7,7 @@ import { AgentBinariesTableCol } from '@components/tables/agent-binaries-table/a
 import { AgentErrorTableCol } from '@components/tables/agent-error-table/agent-error-table.constants';
 import { AgentsStatusTableCol } from '@components/tables/agents-status-table/agents-status-table.constants';
 import { AgentsTableCol } from '@components/tables/agents-table/agents-table.constants';
+import { ApiTokensTableCol } from '@components/tables/api-tokens-table/api-tokens-table.constants';
 import { ChunksTableCol } from '@components/tables/chunks-table/chunks-table.constants';
 import { CrackersTableCol } from '@components/tables/crackers-table/crackers-table.constants';
 import { CracksTableCol } from '@components/tables/cracks-table/cracks-table.constants';
@@ -116,6 +117,22 @@ const _uiConfigDefault = {
         dataKey: 'id',
         isSortable: true,
         direction: 'asc'
+      },
+      search: ''
+    },
+    apiTokensTable: {
+      page: 25,
+      columns: [
+        ApiTokensTableCol.ID,
+        ApiTokensTableCol.VALID_FROM,
+        ApiTokensTableCol.VALID_UNTIL,
+        ApiTokensTableCol.STATUS
+      ],
+      order: {
+        id: ApiTokensTableCol.ID,
+        dataKey: 'id',
+        isSortable: true,
+        direction: 'desc'
       },
       search: ''
     },

--- a/src/app/core/_models/config-ui.schema.spec.ts
+++ b/src/app/core/_models/config-ui.schema.spec.ts
@@ -121,14 +121,70 @@ describe('uiConfigSchema', () => {
     }
   });
 
-  it('should fail on invalid tableSettings entry', () => {
+  it('should replace an invalid tableSettings entry with the default and not fail', () => {
     const config = {
       ...defaults,
       tableSettings: {
-        brokenTable: { columns: 'not-an-array', page: 'bad' }
+        usersTable: { columns: 'not-an-array', page: 'bad' }
       }
     };
 
+    const result = uiConfigSchema.safeParse(config);
+    expect(result.success).toBeTrue();
+    if (result.success) {
+      const expected = uiConfigDefault.tableSettings['usersTable'] as TableConfig;
+      const repaired = result.data.tableSettings['usersTable'] as TableConfig;
+      expect(repaired.columns).toEqual([...expected.columns]);
+      expect(result.data.theme).toBe(defaults.theme);
+      expect(result.data.layout).toBe(defaults.layout);
+    }
+  });
+
+  it('should drop stale keys whose shape is invalid and which have no default', () => {
+    const config = {
+      ...defaults,
+      tableSettings: {
+        legacyDeadTable: { columns: 'nope', page: 'bad' }
+      }
+    };
+
+    const result = uiConfigSchema.safeParse(config);
+    expect(result.success).toBeTrue();
+    if (result.success) {
+      expect(result.data.tableSettings['legacyDeadTable']).toBeUndefined();
+    }
+  });
+
+  it('should preserve valid entries when sibling entries are repaired', () => {
+    const customColumns = [4, 2, 0];
+    const config = {
+      ...defaults,
+      tableSettings: {
+        usersTable: { columns: 'not-an-array', page: 'bad' },
+        agentsTable: {
+          columns: customColumns,
+          page: 25,
+          search: '',
+          order: { id: 0, dataKey: 'id', isSortable: true, direction: 'asc' as const }
+        }
+      }
+    };
+
+    const result = uiConfigSchema.safeParse(config);
+    expect(result.success).toBeTrue();
+    if (result.success) {
+      // bad entry repaired from default
+      const repaired = result.data.tableSettings['usersTable'] as TableConfig;
+      const usersDefault = uiConfigDefault.tableSettings['usersTable'] as TableConfig;
+      expect(repaired.columns).toEqual([...usersDefault.columns]);
+      // sibling custom entry kept
+      const kept = result.data.tableSettings['agentsTable'] as TableConfig;
+      expect(kept.columns).toEqual(customColumns);
+    }
+  });
+
+  it('should still fail when tableSettings itself is non-object garbage', () => {
+    const config = { ...defaults, tableSettings: 'string' };
     const result = uiConfigSchema.safeParse(config);
     expect(result.success).toBeFalse();
   });

--- a/src/app/core/_models/config-ui.schema.spec.ts
+++ b/src/app/core/_models/config-ui.schema.spec.ts
@@ -96,6 +96,31 @@ describe('uiConfigSchema', () => {
     }
   });
 
+  it('should backfill missing tableSettings keys from uiConfigDefault while preserving stored entries', () => {
+    const customColumns = [9, 8, 7];
+    const config = {
+      ...defaults,
+      tableSettings: {
+        usersTable: {
+          columns: customColumns,
+          page: 25,
+          search: '',
+          order: { id: 0, dataKey: 'id', isSortable: true, direction: 'asc' as const }
+        }
+      }
+    };
+
+    const result = uiConfigSchema.safeParse(config);
+    expect(result.success).toBeTrue();
+    if (result.success) {
+      // stored entry wins
+      expect((result.data.tableSettings['usersTable'] as TableConfig).columns).toEqual(customColumns);
+      // missing default keys are filled
+      expect(result.data.tableSettings['notificationsTable']).toBeDefined();
+      expect(result.data.tableSettings['apiTokensTable']).toBeDefined();
+    }
+  });
+
   it('should fail on invalid tableSettings entry', () => {
     const config = {
       ...defaults,

--- a/src/app/core/_models/config-ui.schema.ts
+++ b/src/app/core/_models/config-ui.schema.ts
@@ -110,8 +110,14 @@ export const tableConfigSchema = z.object({
  * Zod schema for the full tableSettings record.
  * Compile-time table name typing is handled by the `TableSettingsKey` union in config-ui.model.ts.
  * The runtime schema intentionally stays permissive (z.record) to tolerate stale/extra keys in localStorage.
+ *
+ * `.transform()` shallow-merges in any default entries missing from the stored object so configs written
+ * before a new table was added still yield a complete map. Stored entries win on conflict, preserving
+ * user customisation. The merged result is what `LocalStorageService.setItem` persists on the next write.
  */
-export const tableSettingsSchema = z.record(z.string(), z.union([z.array(z.coerce.number()), tableConfigSchema]));
+export const tableSettingsSchema = z
+  .record(z.string(), z.union([z.array(z.coerce.number()), tableConfigSchema]))
+  .transform((stored) => ({ ...uiConfigDefault.tableSettings, ...stored }));
 
 /**
  * Zod schema for the top-level UIConfig.

--- a/src/app/core/_models/config-ui.schema.ts
+++ b/src/app/core/_models/config-ui.schema.ts
@@ -95,6 +95,11 @@ export const sortingSchema = z.object({
  * @TODO -> The numeric field conversion exists for the moment to not break first introduction of this schema.
  * Maybe remove if we want to migrate certain user data, otherwise just change to number and let the local storage data be reset.
  * - Numeric fields use coercion to tolerate string representations in stored data.
+ *
+ * NOTE: If you add a *required* field here, also add it to every entry in
+ * `uiConfigDefault.tableSettings` (config-ui.model.ts). Otherwise the defaults themselves
+ * fail `tableEntrySchema`, the per-entry repair below cannot heal stored data, and the whole
+ * `ui-config` ends up wiped by `LocalStorageService`'s self-heal.
  */
 export const tableConfigSchema = z.object({
   columns: z.array(z.coerce.number()),
@@ -107,17 +112,34 @@ export const tableConfigSchema = z.object({
 });
 
 /**
- * Zod schema for the full tableSettings record.
- * Compile-time table name typing is handled by the `TableSettingsKey` union in config-ui.model.ts.
- * The runtime schema intentionally stays permissive (z.record) to tolerate stale/extra keys in localStorage.
- *
- * `.transform()` shallow-merges in any default entries missing from the stored object so configs written
- * before a new table was added still yield a complete map. Stored entries win on conflict, preserving
- * user customisation. The merged result is what `LocalStorageService.setItem` persists on the next write.
+ * @TODO -> can probably be refactored so that we only have the new tableConfigSchema?
+ * Shape of a single tableSettings entry: either a legacy column-id array or a full TableConfig.
  */
-export const tableSettingsSchema = z
-  .record(z.string(), z.union([z.array(z.coerce.number()), tableConfigSchema]))
-  .transform((stored) => ({ ...uiConfigDefault.tableSettings, ...stored }));
+const tableEntrySchema = z.union([z.array(z.coerce.number()), tableConfigSchema]);
+
+/**
+ * Full tableSettings record.
+ *
+ * The preprocess seeds defaults for missing keys and overlays only stored entries that pass
+ * `tableEntrySchema`. Invalid entries with a matching default stay defaulted; invalid entries
+ * without a default are dropped. Non-object inputs fall through so the outer record rejects
+ * them, triggering `LocalStorageService`'s self-heal for fully-corrupt data.
+ */
+export const tableSettingsSchema = z.preprocess(
+  (val) => {
+    if (!val || typeof val !== 'object' || Array.isArray(val)) {
+      return val;
+    }
+    const result: Record<string, unknown> = { ...uiConfigDefault.tableSettings };
+    for (const [k, v] of Object.entries(val)) {
+      if (tableEntrySchema.safeParse(v).success) {
+        result[k] = v;
+      }
+    }
+    return result;
+  },
+  z.record(z.string(), tableEntrySchema)
+);
 
 /**
  * Zod schema for the top-level UIConfig.

--- a/src/app/core/_services/api-key-reveal.store.spec.ts
+++ b/src/app/core/_services/api-key-reveal.store.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ApiKeyRevealStore } from '@services/api-key-reveal.store';
+
+describe('ApiKeyRevealStore', () => {
+  let store: ApiKeyRevealStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    store = TestBed.inject(ApiKeyRevealStore);
+  });
+
+  it('returns null when nothing has been set', () => {
+    expect(store.consume()).toBeNull();
+  });
+
+  it('returns the value previously set', () => {
+    store.set('jwt-abc');
+    expect(store.consume()).toBe('jwt-abc');
+  });
+
+  it('clears the value so a second consume returns null', () => {
+    store.set('jwt-abc');
+    store.consume();
+    expect(store.consume()).toBeNull();
+  });
+
+  it('set() overwrites a previous unread token', () => {
+    store.set('first');
+    store.set('second');
+    expect(store.consume()).toBe('second');
+  });
+});

--- a/src/app/core/_services/api-key-reveal.store.ts
+++ b/src/app/core/_services/api-key-reveal.store.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * Single-use in-memory carrier for a freshly-minted JWT.
+ *
+ * The backend only returns the actual token on the POST response; subsequent
+ * reads never expose it. The create page stashes the secret here and immediately
+ * navigates to the reveal page, which `consume()`s it once. We deliberately
+ * don't persist or pass it via URL/history — a refresh on the reveal page must
+ * fail closed (token gone, redirect to list).
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class ApiKeyRevealStore {
+  private token: string | null = null;
+
+  set(token: string): void {
+    this.token = token;
+  }
+
+  consume(): string | null {
+    const value = this.token;
+    this.token = null;
+    return value;
+  }
+}

--- a/src/app/core/_services/api-key-reveal.store.ts
+++ b/src/app/core/_services/api-key-reveal.store.ts
@@ -1,13 +1,8 @@
 import { Injectable } from '@angular/core';
 
 /**
- * Single-use in-memory carrier for a freshly-minted JWT.
- *
- * The backend only returns the actual token on the POST response; subsequent
- * reads never expose it. The create page stashes the secret here and immediately
- * navigates to the reveal page, which `consume()`s it once. We deliberately
- * don't persist or pass it via URL/history — a refresh on the reveal page must
- * fail closed (token gone, redirect to list).
+ * Single-use short time in memory store for passing a newly created JWT api token from the create screen to the reveal screen.
+ * The key is only visible on creation (afterwards not accessible anymore), and will be consumed once on the reveal screen.
  */
 @Injectable({
   providedIn: 'root'

--- a/src/app/core/_services/context-menu/base/context-menu.service.ts
+++ b/src/app/core/_services/context-menu/base/context-menu.service.ts
@@ -225,30 +225,6 @@ export abstract class ContextMenuService {
   }
 
   /**
-   * Add a new revoke entry to context menu. Distinct from delete so destructive
-   * but reversible-by-policy actions (e.g. revoking a token) read clearly.
-   * @param label - label of the entry
-   * @param permissions - list of permissions which must be granted to the user to display the menu entry
-   * @param condition - condition to check for display state of menu entry
-   */
-  protected addCtxRevokeItem(
-    label: string,
-    permissions: Array<PermissionValues>,
-    condition: ContextMenuCondition = { key: '', value: false }
-  ): void {
-    this.createMenuItem(
-      label,
-      1,
-      RowActionMenuAction.REVOKE,
-      RowActionMenuIcon.REVOKE,
-      permissions,
-      condition,
-      true,
-      true
-    );
-  }
-
-  /**
    * Add a new copy entry to context menu
    * @param label - label of the entry
    * @param action - copy action event to emit on click
@@ -377,6 +353,33 @@ export abstract class ContextMenuService {
    */
   protected addCtxViewItem(label: string, permissions: Array<PermissionValues>): void {
     this.createMenuItem(label, 0, RowActionMenuAction.VIEW, RowActionMenuIcon.VIEW, permissions);
+  }
+
+  /**
+   * Register a subclass-local context-menu item. Use this for actions that are
+   * specific to a single table and don't warrant a shared `addCtx*Item` helper
+   * on the base class.
+   */
+  protected addCtxCustomItem(opts: {
+    label: string;
+    action: string;
+    icon: string;
+    permissions: Array<PermissionValues>;
+    condition?: ContextMenuCondition;
+    groupIndex?: number;
+    toContextMenu?: boolean;
+    warning?: boolean;
+  }): void {
+    this.createMenuItem(
+      opts.label,
+      opts.groupIndex ?? 0,
+      opts.action,
+      opts.icon,
+      opts.permissions,
+      opts.condition ?? { key: '', value: false },
+      opts.toContextMenu ?? true,
+      opts.warning ?? false
+    );
   }
 
   /**

--- a/src/app/core/_services/context-menu/base/context-menu.service.ts
+++ b/src/app/core/_services/context-menu/base/context-menu.service.ts
@@ -225,6 +225,30 @@ export abstract class ContextMenuService {
   }
 
   /**
+   * Add a new revoke entry to context menu. Distinct from delete so destructive
+   * but reversible-by-policy actions (e.g. revoking a token) read clearly.
+   * @param label - label of the entry
+   * @param permissions - list of permissions which must be granted to the user to display the menu entry
+   * @param condition - condition to check for display state of menu entry
+   */
+  protected addCtxRevokeItem(
+    label: string,
+    permissions: Array<PermissionValues>,
+    condition: ContextMenuCondition = { key: '', value: false }
+  ): void {
+    this.createMenuItem(
+      label,
+      1,
+      RowActionMenuAction.REVOKE,
+      RowActionMenuIcon.REVOKE,
+      permissions,
+      condition,
+      true,
+      true
+    );
+  }
+
+  /**
    * Add a new copy entry to context menu
    * @param label - label of the entry
    * @param action - copy action event to emit on click

--- a/src/app/core/_services/context-menu/users/api-tokens-menu.service.ts
+++ b/src/app/core/_services/context-menu/users/api-tokens-menu.service.ts
@@ -2,6 +2,11 @@ import { ContextMenuCondition, ContextMenuService } from '@services/context-menu
 import { PermissionService } from '@services/permission/permission.service';
 
 import { RowActionMenuLabel } from '@components/menus/row-action-menu/row-action-menu.constants';
+import {
+  ApiTokensRowAction,
+  ApiTokensRowActionIcon,
+  ApiTokensRowActionLabel
+} from '@components/tables/api-tokens-table/api-tokens-table.constants';
 
 import { Perm, PermissionValues } from '@src/app/core/_constants/userpermissions.config';
 
@@ -21,7 +26,15 @@ export class ApiTokensContextMenuService extends ContextMenuService {
     // delete that the server is going to 403.
     const deleteCondition: ContextMenuCondition = { key: 'isExpired', value: true };
 
-    this.addCtxRevokeItem(RowActionMenuLabel.REVOKE_API_TOKEN, permUpdate, revokeCondition);
+    this.addCtxCustomItem({
+      label: ApiTokensRowActionLabel.REVOKE,
+      action: ApiTokensRowAction.REVOKE,
+      icon: ApiTokensRowActionIcon.REVOKE,
+      permissions: permUpdate,
+      condition: revokeCondition,
+      groupIndex: 1,
+      warning: true
+    });
     this.addCtxDeleteItem(RowActionMenuLabel.DELETE_API_TOKEN, permDelete, deleteCondition);
 
     return this;

--- a/src/app/core/_services/context-menu/users/api-tokens-menu.service.ts
+++ b/src/app/core/_services/context-menu/users/api-tokens-menu.service.ts
@@ -19,11 +19,9 @@ export class ApiTokensContextMenuService extends ContextMenuService {
     const permUpdate: Array<PermissionValues> = [Perm.JwtApiKey.UPDATE];
     const permDelete: Array<PermissionValues> = [Perm.JwtApiKey.DELETE];
 
-    // Revoke shows only for active rows; once revoked the action is meaningless.
+    // only allow revoke if not already revoked
     const revokeCondition: ContextMenuCondition = { key: 'isActive', value: true };
-    // Backend only permits hard delete after the validity window has lapsed —
-    // the row datasource sets `isExpired` from `endValid` so we never offer a
-    // delete that the server is going to 403.
+    // We can only delete expired tokens therefore only show in this case
     const deleteCondition: ContextMenuCondition = { key: 'isExpired', value: true };
 
     this.addCtxCustomItem({

--- a/src/app/core/_services/context-menu/users/api-tokens-menu.service.ts
+++ b/src/app/core/_services/context-menu/users/api-tokens-menu.service.ts
@@ -1,0 +1,29 @@
+import { ContextMenuCondition, ContextMenuService } from '@services/context-menu/base/context-menu.service';
+import { PermissionService } from '@services/permission/permission.service';
+
+import { RowActionMenuLabel } from '@components/menus/row-action-menu/row-action-menu.constants';
+
+import { Perm, PermissionValues } from '@src/app/core/_constants/userpermissions.config';
+
+export class ApiTokensContextMenuService extends ContextMenuService {
+  constructor(override permissionService: PermissionService) {
+    super(permissionService);
+  }
+
+  addContextMenu(): ApiTokensContextMenuService {
+    const permUpdate: Array<PermissionValues> = [Perm.JwtApiKey.UPDATE];
+    const permDelete: Array<PermissionValues> = [Perm.JwtApiKey.DELETE];
+
+    // Revoke shows only for active rows; once revoked the action is meaningless.
+    const revokeCondition: ContextMenuCondition = { key: 'isActive', value: true };
+    // Backend only permits hard delete after the validity window has lapsed —
+    // the row datasource sets `isExpired` from `endValid` so we never offer a
+    // delete that the server is going to 403.
+    const deleteCondition: ContextMenuCondition = { key: 'isExpired', value: true };
+
+    this.addCtxRevokeItem(RowActionMenuLabel.REVOKE_API_TOKEN, permUpdate, revokeCondition);
+    this.addCtxDeleteItem(RowActionMenuLabel.DELETE_API_TOKEN, permDelete, deleteCondition);
+
+    return this;
+  }
+}

--- a/src/app/core/_services/main.config.ts
+++ b/src/app/core/_services/main.config.ts
@@ -89,6 +89,8 @@ export class SERV {
   public static NOTIFICATIONS = { URL: '/ui/notifications', RESOURCE: 'Notifications' };
   public static USERS = { URL: '/ui/users', RESOURCE: 'Users' };
   public static FORGOT = { URL: '/helper/resetUserPassword', RESOURCE: 'resetUserPassword' };
+  // API TOKENS
+  public static API_TOKENS = { URL: '/ui/apiTokens', RESOURCE: 'apiToken' };
   // PROJECTS
   public static PROJECTS = { URL: '/ui/tasks', RESOURCE: 'Projects' };
 }

--- a/src/app/core/_services/roles/user/api-tokens-role.service.ts
+++ b/src/app/core/_services/roles/user/api-tokens-role.service.ts
@@ -1,0 +1,20 @@
+import { Perm } from '@constants/userpermissions.config';
+
+import { Injectable } from '@angular/core';
+
+import { PermissionService } from '@services/permission/permission.service';
+import { RoleService } from '@services/roles/base/role.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ApiTokensRoleService extends RoleService {
+  constructor(permissionService: PermissionService) {
+    super(permissionService, {
+      read: [Perm.JwtApiKey.READ],
+      create: [Perm.JwtApiKey.CREATE],
+      update: [Perm.JwtApiKey.UPDATE],
+      delete: [Perm.JwtApiKey.DELETE]
+    });
+  }
+}

--- a/src/app/core/_services/roles/user/api-tokens-role.service.ts
+++ b/src/app/core/_services/roles/user/api-tokens-role.service.ts
@@ -5,16 +5,24 @@ import { Injectable } from '@angular/core';
 import { PermissionService } from '@services/permission/permission.service';
 import { RoleService } from '@services/roles/base/role.service';
 
+export const ApiTokensRole = {
+  READ: 'read',
+  CREATE: 'create',
+  UPDATE: 'update',
+  DELETE: 'delete'
+} as const;
+export type ApiTokensRole = (typeof ApiTokensRole)[keyof typeof ApiTokensRole];
+
 @Injectable({
   providedIn: 'root'
 })
 export class ApiTokensRoleService extends RoleService {
   constructor(permissionService: PermissionService) {
     super(permissionService, {
-      read: [Perm.JwtApiKey.READ],
-      create: [Perm.JwtApiKey.CREATE],
-      update: [Perm.JwtApiKey.UPDATE],
-      delete: [Perm.JwtApiKey.DELETE]
+      [ApiTokensRole.READ]: [Perm.JwtApiKey.READ],
+      [ApiTokensRole.CREATE]: [Perm.JwtApiKey.CREATE],
+      [ApiTokensRole.UPDATE]: [Perm.JwtApiKey.UPDATE],
+      [ApiTokensRole.DELETE]: [Perm.JwtApiKey.DELETE]
     });
   }
 }

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -19,6 +19,7 @@ import { SuperHashListRoleService } from '@services/roles/hashlists/superhashlis
 import { PreconfiguredTasksRoleService } from '@services/roles/tasks/preconfiguredTasks-role.service';
 import { SupertasksRoleService } from '@services/roles/tasks/supertasks-role.service';
 import { TasksRoleService } from '@services/roles/tasks/tasks-role.service';
+import { ApiTokensRoleService } from '@services/roles/user/api-tokens-role.service';
 import { UserRoleWrapperService } from '@services/roles/user/user-role-wrapper.service';
 import { ThemeService } from '@services/shared/theme.service';
 import { LocalStorageService } from '@services/storage/local-storage.service';
@@ -55,6 +56,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   private preprocessorRoleService = inject(PreprocessorRoleService);
   private configRoleWrapper = inject(ConfigRoleWrapperService);
   private userRoleWrapperService = inject(UserRoleWrapperService);
+  private apiTokensRoleService = inject(ApiTokensRoleService);
 
   private subscriptions: Subscription[] = [];
   protected uiSettings: UISettingsUtilityClass;
@@ -376,6 +378,13 @@ export class HeaderComponent implements OnInit, OnDestroy {
       actions.push({
         label: 'Notifications',
         routerLink: ['account', 'notifications']
+      });
+    }
+
+    if (this.apiTokensRoleService.hasRole('read')) {
+      actions.push({
+        label: 'API Keys',
+        routerLink: ['account', 'api-keys']
       });
     }
 

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -19,7 +19,7 @@ import { SuperHashListRoleService } from '@services/roles/hashlists/superhashlis
 import { PreconfiguredTasksRoleService } from '@services/roles/tasks/preconfiguredTasks-role.service';
 import { SupertasksRoleService } from '@services/roles/tasks/supertasks-role.service';
 import { TasksRoleService } from '@services/roles/tasks/tasks-role.service';
-import { ApiTokensRoleService } from '@services/roles/user/api-tokens-role.service';
+import { ApiTokensRole, ApiTokensRoleService } from '@services/roles/user/api-tokens-role.service';
 import { UserRoleWrapperService } from '@services/roles/user/user-role-wrapper.service';
 import { ThemeService } from '@services/shared/theme.service';
 import { LocalStorageService } from '@services/storage/local-storage.service';
@@ -381,7 +381,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
       });
     }
 
-    if (this.apiTokensRoleService.hasRole('read')) {
+    if (this.apiTokensRoleService.hasRole(ApiTokensRole.READ)) {
       actions.push({
         label: 'API Keys',
         routerLink: ['account', 'api-keys']

--- a/src/app/shared/utils/config.spec.ts
+++ b/src/app/shared/utils/config.spec.ts
@@ -1,0 +1,78 @@
+import { TableConfig, UIConfig, uiConfigDefault } from '@models/config-ui.model';
+import { uiConfigSchema } from '@models/config-ui.schema';
+
+import { LocalStorageService } from '@services/storage/local-storage.service';
+
+import { UISettingsUtilityClass } from '@src/app/shared/utils/config';
+
+/**
+ * Unit tests for the constructor's `tableSettings` backfill: when a stored
+ * `ui-config` lacks keys present in `uiConfigDefault.tableSettings` (because
+ * the user's localStorage predates a freshly-added table entry), the missing
+ * keys must be populated from defaults so consumers (`getTableSettings`,
+ * `getTableConfig`) don't render empty data tables.
+ */
+describe('UISettingsUtilityClass — backfillMissingTableSettings', () => {
+  let setItemSpy: jasmine.Spy;
+
+  function makeStorage(stored: UIConfig): LocalStorageService<UIConfig> {
+    setItemSpy = jasmine.createSpy('setItem');
+    return {
+      getItem: jasmine.createSpy('getItem').and.returnValue(stored),
+      setItem: setItemSpy
+    } as unknown as LocalStorageService<UIConfig>;
+  }
+
+  function cloneDefault(): UIConfig {
+    return JSON.parse(JSON.stringify(uiConfigDefault));
+  }
+
+  it('backfills a missing default key so getTableSettings returns the default columns and does not log', () => {
+    const errorSpy = spyOn(console, 'error');
+    const stored = cloneDefault();
+    delete (stored.tableSettings as Record<string, unknown>)['apiTokensTable'];
+
+    const utility = new UISettingsUtilityClass(makeStorage(stored));
+
+    const expected = (uiConfigDefault.tableSettings['apiTokensTable'] as TableConfig).columns;
+    expect(utility.getTableSettings('apiTokensTable')).toEqual([...expected]);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('preserves user-customised entries when their key already exists in storage', () => {
+    const stored = cloneDefault();
+    const customColumns = [99, 7, 3];
+    (stored.tableSettings as Record<string, TableConfig>)['usersTable'] = {
+      columns: customColumns,
+      page: 25,
+      search: ''
+    };
+
+    const utility = new UISettingsUtilityClass(makeStorage(stored));
+
+    expect(utility.getTableSettings('usersTable')).toEqual(customColumns);
+  });
+
+  it('persists the merged config exactly once when keys were missing', () => {
+    const stored = cloneDefault();
+    delete (stored.tableSettings as Record<string, unknown>)['apiTokensTable'];
+
+    new UISettingsUtilityClass(makeStorage(stored));
+
+    expect(setItemSpy).toHaveBeenCalledTimes(1);
+    expect(setItemSpy).toHaveBeenCalledWith(
+      UISettingsUtilityClass.KEY,
+      jasmine.objectContaining({
+        tableSettings: jasmine.objectContaining({ apiTokensTable: jasmine.anything() })
+      }),
+      0,
+      uiConfigSchema
+    );
+  });
+
+  it('does not call setItem when storage already contains every default key', () => {
+    new UISettingsUtilityClass(makeStorage(cloneDefault()));
+
+    expect(setItemSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/shared/utils/config.spec.ts
+++ b/src/app/shared/utils/config.spec.ts
@@ -1,25 +1,33 @@
+import { z } from 'zod';
+
 import { TableConfig, UIConfig, uiConfigDefault } from '@models/config-ui.model';
-import { uiConfigSchema } from '@models/config-ui.schema';
 
 import { LocalStorageService } from '@services/storage/local-storage.service';
 
 import { UISettingsUtilityClass } from '@src/app/shared/utils/config';
 
 /**
- * Unit tests for the constructor's `tableSettings` backfill: when a stored
- * `ui-config` lacks keys present in `uiConfigDefault.tableSettings` (because
- * the user's localStorage predates a freshly-added table entry), the missing
- * keys must be populated from defaults so consumers (`getTableSettings`,
- * `getTableConfig`) don't render empty data tables.
+ * Verifies that the constructor loads a complete `tableSettings` map even when the stored value lacks
+ * newly-added default keys. The merge itself is performed by `tableSettingsSchema.transform(...)`; this
+ * suite exercises the integration through the utility class so consumers (`getTableSettings`,
+ * `getTableConfig`) never see a partial map.
  */
-describe('UISettingsUtilityClass — backfillMissingTableSettings', () => {
-  let setItemSpy: jasmine.Spy;
-
+describe('UISettingsUtilityClass — tableSettings backfill via schema', () => {
+  /**
+   * Mocks `LocalStorageService` so it routes `getItem` through the provided Zod schema, matching the
+   * real implementation. Without this, the utility would receive the raw partial object and bypass the
+   * schema-level merge entirely.
+   */
   function makeStorage(stored: UIConfig): LocalStorageService<UIConfig> {
-    setItemSpy = jasmine.createSpy('setItem');
     return {
-      getItem: jasmine.createSpy('getItem').and.returnValue(stored),
-      setItem: setItemSpy
+      getItem: jasmine.createSpy('getItem').and.callFake((_key: string, schema?: z.ZodType<UIConfig>) => {
+        if (!schema) {
+          return stored;
+        }
+        const result = schema.safeParse(stored);
+        return result.success ? result.data : stored;
+      }),
+      setItem: jasmine.createSpy('setItem')
     } as unknown as LocalStorageService<UIConfig>;
   }
 
@@ -27,7 +35,7 @@ describe('UISettingsUtilityClass — backfillMissingTableSettings', () => {
     return JSON.parse(JSON.stringify(uiConfigDefault));
   }
 
-  it('backfills a missing default key so getTableSettings returns the default columns and does not log', () => {
+  it('backfills a missing default key so getTableSettings returns the default columns', () => {
     const errorSpy = spyOn(console, 'error');
     const stored = cloneDefault();
     delete (stored.tableSettings as Record<string, unknown>)['apiTokensTable'];
@@ -51,28 +59,5 @@ describe('UISettingsUtilityClass — backfillMissingTableSettings', () => {
     const utility = new UISettingsUtilityClass(makeStorage(stored));
 
     expect(utility.getTableSettings('usersTable')).toEqual(customColumns);
-  });
-
-  it('persists the merged config exactly once when keys were missing', () => {
-    const stored = cloneDefault();
-    delete (stored.tableSettings as Record<string, unknown>)['apiTokensTable'];
-
-    new UISettingsUtilityClass(makeStorage(stored));
-
-    expect(setItemSpy).toHaveBeenCalledTimes(1);
-    expect(setItemSpy).toHaveBeenCalledWith(
-      UISettingsUtilityClass.KEY,
-      jasmine.objectContaining({
-        tableSettings: jasmine.objectContaining({ apiTokensTable: jasmine.anything() })
-      }),
-      0,
-      uiConfigSchema
-    );
-  });
-
-  it('does not call setItem when storage already contains every default key', () => {
-    new UISettingsUtilityClass(makeStorage(cloneDefault()));
-
-    expect(setItemSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/app/shared/utils/config.ts
+++ b/src/app/shared/utils/config.ts
@@ -32,9 +32,28 @@ export class UISettingsUtilityClass {
     private themeService?: ThemeService
   ) {
     this.uiConfig = storage.getItem(UISettingsUtilityClass.KEY, uiConfigSchema, uiConfigDefault);
+    this.backfillMissingTableSettings();
     if (this.themeService && this.uiConfig.theme) {
       this.themeService.theme = this.uiConfig.theme;
     }
+  }
+
+  /**
+   * Stored configs from prior sessions can lack newly-added entries in `uiConfigDefault.tableSettings` —
+   * `tableSettingsSchema` is `z.record(...)` and parses such stored values verbatim, so missing keys would
+   * later make `getTableSettings` return `[]` and tables render with no data columns. Shallow-merge defaults
+   * for keys absent from storage (existing user customisation wins for keys that are present), then persist
+   * the merged config so the migration is one-shot.
+   */
+  private backfillMissingTableSettings(): void {
+    const defaults = structuredClone(uiConfigDefault.tableSettings);
+    const stored = this.uiConfig.tableSettings;
+    const missing = Object.keys(defaults).filter((k) => !(k in stored));
+    if (missing.length === 0) {
+      return;
+    }
+    this.uiConfig = { ...this.uiConfig, tableSettings: { ...defaults, ...stored } };
+    this.storage.setItem(UISettingsUtilityClass.KEY, this.uiConfig, 0, uiConfigSchema);
   }
 
   /**

--- a/src/app/shared/utils/config.ts
+++ b/src/app/shared/utils/config.ts
@@ -32,28 +32,9 @@ export class UISettingsUtilityClass {
     private themeService?: ThemeService
   ) {
     this.uiConfig = storage.getItem(UISettingsUtilityClass.KEY, uiConfigSchema, uiConfigDefault);
-    this.backfillMissingTableSettings();
     if (this.themeService && this.uiConfig.theme) {
       this.themeService.theme = this.uiConfig.theme;
     }
-  }
-
-  /**
-   * Stored configs from prior sessions can lack newly-added entries in `uiConfigDefault.tableSettings` —
-   * `tableSettingsSchema` is `z.record(...)` and parses such stored values verbatim, so missing keys would
-   * later make `getTableSettings` return `[]` and tables render with no data columns. Shallow-merge defaults
-   * for keys absent from storage (existing user customisation wins for keys that are present), then persist
-   * the merged config so the migration is one-shot.
-   */
-  private backfillMissingTableSettings(): void {
-    const defaults = structuredClone(uiConfigDefault.tableSettings);
-    const stored = this.uiConfig.tableSettings;
-    const missing = Object.keys(defaults).filter((k) => !(k in stored));
-    if (missing.length === 0) {
-      return;
-    }
-    this.uiConfig = { ...this.uiConfig, tableSettings: { ...defaults, ...stored } };
-    this.storage.setItem(UISettingsUtilityClass.KEY, this.uiConfig, 0, uiConfigSchema);
   }
 
   /**

--- a/src/app/shared/utils/datetime.spec.ts
+++ b/src/app/shared/utils/datetime.spec.ts
@@ -1,0 +1,50 @@
+import { lastValidSecond, startOfNextDay, unixTimestampFromDate } from '@src/app/shared/utils/datetime';
+
+describe('startOfNextDay', () => {
+  it('returns local-time 00:00 of the next calendar day', () => {
+    const input = new Date(2026, 7, 13, 15, 30, 45, 123); // 2026-08-13 15:30:45.123 local
+    const result = startOfNextDay(input);
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(7);
+    expect(result.getDate()).toBe(14);
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+  });
+
+  it('does not mutate the input date', () => {
+    const input = new Date(2026, 7, 13, 15, 30);
+    const before = input.getTime();
+    startOfNextDay(input);
+    expect(input.getTime()).toBe(before);
+  });
+
+  it('rolls over the month boundary', () => {
+    const input = new Date(2026, 7, 31, 12); // 2026-08-31 noon
+    const result = startOfNextDay(input);
+    expect(result.getMonth()).toBe(8); // September
+    expect(result.getDate()).toBe(1);
+  });
+
+  it('rolls over the year boundary', () => {
+    const input = new Date(2026, 11, 31, 23, 59); // 2026-12-31 23:59
+    const result = startOfNextDay(input);
+    expect(result.getFullYear()).toBe(2027);
+    expect(result.getMonth()).toBe(0);
+    expect(result.getDate()).toBe(1);
+  });
+
+  it('produces a unix-second cutoff one second after lastValidSecond of itself', () => {
+    // Round-trip property: floor(startOfNextDay(d)/1000) - 1 === last valid second.
+    const input = new Date(2026, 4, 15, 9);
+    const cutoff = unixTimestampFromDate(startOfNextDay(input));
+    expect(lastValidSecond(cutoff)).toBe(cutoff - 1);
+  });
+});
+
+describe('lastValidSecond', () => {
+  it('returns the input minus one', () => {
+    expect(lastValidSecond(1_000)).toBe(999);
+  });
+});

--- a/src/app/shared/utils/datetime.ts
+++ b/src/app/shared/utils/datetime.ts
@@ -1,8 +1,8 @@
 //import moment from 'moment';
 
-type Seconds = number
-type Days = number
-type UnixTimestampSeconds = number
+type Seconds = number;
+type Days = number;
+type UnixTimestampSeconds = number;
 
 /**
  * Returns a copy of the given date set to the start of its local-time calendar day (00:00:00.000).

--- a/src/app/shared/utils/datetime.ts
+++ b/src/app/shared/utils/datetime.ts
@@ -1,5 +1,9 @@
 //import moment from 'moment';
 
+type Seconds = number
+type Days = number
+type UnixTimestampSeconds = number
+
 /**
  * Returns a copy of the given date set to the start of its local-time calendar day (00:00:00.000).
  * Non-mutating: the input is not modified.
@@ -21,16 +25,49 @@ export const endOfDay = (date: Date): Date => {
 };
 
 /**
+ * Returns 00:00:00.000 of the day after the given date in local time.
+ */
+export const startOfNextDay = (date: Date): Date => {
+  const copy = startOfDay(date);
+  copy.setDate(copy.getDate() + 1);
+  return copy;
+};
+
+/**
+ * Given an exclusive end-of-validity cutoff in unix seconds (i.e. the first
+ * instant at which a token is considered expired), returns the unix second
+ * at which it is still valid for the last time.
+ */
+export const lastValidSecond = (endValidSec: Seconds): number => endValidSec - 1;
+
+/**
  * Calculate a Unix timestamp for a date in the past.
  *
  * @param {number} days - The number of days to go back in the past.
  * @returns {number} The Unix timestamp (in seconds) for the specified date in the past.
  */
-export const unixTimestampInPast = (days: number): number => {
+export const unixTimestampInPast = (days: Days): UnixTimestampSeconds => {
   const currentDate = new Date();
   const inPast = new Date(currentDate.getTime() - days * 24 * 60 * 60 * 1000);
 
-  return Math.floor(inPast.getTime() / 1000);
+  return unixTimestampFromDate(inPast);
+};
+
+/**
+ * Returns the number of whole days between two dates, rounded to the nearest day.
+ * The result is signed: positive when `until` is after `from`, negative when before.
+ * Caller is responsible for clamping if non-positive ranges should be excluded.
+ */
+export const daysBetween = (from: Date, until: Date): Days => {
+  return Math.round((until.getTime() - from.getTime()) / (24 * 60 * 60 * 1000));
+};
+
+/**
+ * Converts a Date to a Unix timestamp in seconds, flooring sub-second precision
+ * to match Unix epoch convention.
+ */
+export const unixTimestampFromDate = (date: Date): UnixTimestampSeconds => {
+  return Math.floor(date.getTime() / 1000);
 };
 
 /**

--- a/src/app/shared/utils/datetime.ts
+++ b/src/app/shared/utils/datetime.ts
@@ -1,6 +1,26 @@
 //import moment from 'moment';
 
 /**
+ * Returns a copy of the given date set to the start of its local-time calendar day (00:00:00.000).
+ * Non-mutating: the input is not modified.
+ */
+export const startOfDay = (date: Date): Date => {
+  const copy = new Date(date);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+};
+
+/**
+ * Returns a copy of the given date set to the end of its local-time calendar day (23:59:59.999).
+ * Non-mutating: the input is not modified.
+ */
+export const endOfDay = (date: Date): Date => {
+  const copy = new Date(date);
+  copy.setHours(23, 59, 59, 999);
+  return copy;
+};
+
+/**
  * Calculate a Unix timestamp for a date in the past.
  *
  * @param {number} days - The number of days to go back in the past.
@@ -33,10 +53,7 @@ export const unixTimestampInPast = (days: number): number => {
  *
  * @returns The formatted date-time string.
  */
-export function formatUnixTimestamp(
-  unixTimestamp: number,
-  fmt: string
-): string {
+export function formatUnixTimestamp(unixTimestamp: number, fmt: string): string {
   if (unixTimestamp === 0) {
     return 'N/A';
   }

--- a/src/app/shared/utils/permission-matrix.ts
+++ b/src/app/shared/utils/permission-matrix.ts
@@ -1,0 +1,107 @@
+import { Permission, UserPermissions } from '@models/global-permission-group.model';
+
+import { Perm } from '@src/app/core/_constants/userpermissions.config';
+
+/**
+ * One row of the CRUD permission matrix.
+ *
+ * Each CRUD field is a `boolean` indicating whether the user *holds* that
+ * permission (true = granted). The companion `keys` map records the actual
+ * backend permission key for each existing CRUD verb on this resource — keys
+ * are absent (undefined) when the backend has no permission for that
+ * row × verb combination (e.g. there is no `permHashCreate`, only
+ * `permHashRead`).
+ *
+ * Consumers can therefore distinguish three cell states:
+ *   - cell granted  : `keys[verb]` is defined AND the verb boolean is true
+ *   - cell denied   : `keys[verb]` is defined AND the verb boolean is false
+ *   - cell n/a      : `keys[verb]` is undefined
+ */
+export interface PermissionMatrixRow extends UserPermissions {
+  keys: {
+    create?: string;
+    read?: string;
+    update?: string;
+    delete?: string;
+  };
+}
+
+export const CrudVerb = {
+  CREATE: 'create',
+  READ: 'read',
+  UPDATE: 'update',
+  DELETE: 'delete'
+} as const;
+export type CrudVerb = (typeof CrudVerb)[keyof typeof CrudVerb];
+
+const VERB_PATTERN = /(Create|Delete|Read|Update)$/;
+
+/**
+ * Group a flat permission map (e.g. `{ permTaskRead: true, permTaskUpdate: false, ... }`)
+ * into one row per resource with CRUD booleans + key lookup. Sorted alphabetically
+ * by display name.
+ *
+ * Replaces the inline grouping previously hidden inside
+ * `AccessPermissionGroupsExpandDataSource.processPermissions()` so the same
+ * structure can be consumed by the live-edit table and the API-key creation form.
+ */
+export function buildPermissionMatrix(permissions: Permission): PermissionMatrixRow[] {
+  let permId = 0;
+  const rows = Object.entries(permissions).reduce<PermissionMatrixRow[]>((acc, [key, value]) => {
+    const operation = key.replace(/^perm/, '').replace(VERB_PATTERN, '');
+    const verbMatch = key.match(VERB_PATTERN)?.[0];
+    if (!verbMatch) {
+      return acc;
+    }
+    const verb = verbMatch.toLowerCase() as CrudVerb;
+    const operationName = humanizeResourceName(operation);
+
+    let row = acc.find((item) => item.key === operation);
+    if (!row) {
+      row = {
+        id: permId++,
+        type: 'userPermission',
+        name: operationName,
+        key: operation,
+        create: false,
+        read: false,
+        update: false,
+        delete: false,
+        keys: {}
+      };
+      acc.push(row);
+    }
+    row[verb] = value;
+    row.keys[verb] = key;
+    return acc;
+  }, []);
+
+  return rows.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Build a permission map containing every backend permission key set to `true`.
+ *
+ * Used by read-only consumers (e.g. the API-key detail page) that need to
+ * render the *full* CRUD matrix regardless of what the current user holds —
+ * the per-cell selection state is then driven by the resource's stored scopes,
+ * not by `granted`. Source-of-truth is the static {@link Perm} catalogue, so
+ * the matrix stays in lockstep with the frontend's known permission keys.
+ */
+export function buildAllPermissionsMap(): Permission {
+  const all: Permission = {};
+  for (const group of Object.values(Perm) as Array<Record<string, string>>) {
+    for (const key of Object.values(group)) {
+      all[key] = true;
+    }
+  }
+  return all;
+}
+
+function humanizeResourceName(operation: string): string {
+  const spaced = operation.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+export const PERMISSION_DENIED_TOOLTIP = 'You can only grant permissions you hold yourself.';
+export const PERMISSION_NOT_APPLICABLE_TOOLTIP = 'This action does not exist for this resource.';

--- a/src/app/shared/utils/permission-matrix.ts
+++ b/src/app/shared/utils/permission-matrix.ts
@@ -1,6 +1,6 @@
 import { Permission, UserPermissions } from '@models/global-permission-group.model';
 
-import { Perm } from '@src/app/core/_constants/userpermissions.config';
+import { Perm, PermissionValues } from '@src/app/core/_constants/userpermissions.config';
 
 /**
  * One row of the CRUD permission matrix.
@@ -19,10 +19,10 @@ import { Perm } from '@src/app/core/_constants/userpermissions.config';
  */
 export interface PermissionMatrixRow extends UserPermissions {
   keys: {
-    create?: string;
-    read?: string;
-    update?: string;
-    delete?: string;
+    create?: PermissionValues;
+    read?: PermissionValues;
+    update?: PermissionValues;
+    delete?: PermissionValues;
   };
 }
 
@@ -72,7 +72,7 @@ export function buildPermissionMatrix(permissions: Permission): PermissionMatrix
       acc.push(row);
     }
     row[verb] = value;
-    row.keys[verb] = key;
+    row.keys[verb] = key as PermissionValues;
     return acc;
   }, []);
 

--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -53,6 +53,14 @@ table.hashtopolis-table {
     .mat-sort-header-arrow {
       color: #fff;
     }
+
+    // Headers rendered inside a mat-checkbox (matrix-style toggle columns)
+    // declare their label color via Material's own MDC token, which doesn't
+    // inherit the header cell color above. Force it to match so checkbox
+    // headers read the same as sortable text headers.
+    .mat-mdc-checkbox label {
+      color: #fff;
+    }
   }
 
   .mat-mdc-row:hover {
@@ -122,17 +130,17 @@ table.hashtopolis-table {
       align-items: center;
       position: relative;
 
-      
-      button[mat-icon-button], .mat-mdc-icon-button {
-       display: inline-flex;
-       align-items: center;
-       justify-content: center;
-       width: 40px;
-       height: 40px;
-       padding: 0;
-       margin: 0 2px;
-       vertical-align: middle;
-       box-sizing: border-box;
+      button[mat-icon-button],
+      .mat-mdc-icon-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        padding: 0;
+        margin: 0 2px;
+        vertical-align: middle;
+        box-sizing: border-box;
       }
 
       button[mat-icon-button] .mat-icon,
@@ -185,10 +193,10 @@ table.hashtopolis-table {
   top: 50%;
   transform: translateY(-50%);
 }
-.filter-container{
-  display: flex; 
-  align-items: center; 
-  gap: 16px
+.filter-container {
+  display: flex;
+  align-items: center;
+  gap: 16px;
 }
 div.table-actions {
   display: flex;

--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -54,10 +54,7 @@ table.hashtopolis-table {
       color: #fff;
     }
 
-    // Headers rendered inside a mat-checkbox (matrix-style toggle columns)
-    // declare their label color via Material's own MDC token, which doesn't
-    // inherit the header cell color above. Force it to match so checkbox
-    // headers read the same as sortable text headers.
+    // When rendering a checkbox with label within the column have the same label color
     .mat-mdc-checkbox label {
       color: #fff;
     }


### PR DESCRIPTION
Adds a table under nav section admin where users can create, revoke or delete jwt api keys.

Delete only possible if expired, otherwise can only be revoked!

Issue: https://github.com/hashtopolis/server/issues/1969

Can only be merged when https://github.com/hashtopolis/server/pull/2067/changes has been accepted.