### PR TITLE
Widen pageAfter type to string as well and do not discard strings as …

### DIFF
--- a/src/app/core/_models/request-params.model.ts
+++ b/src/app/core/_models/request-params.model.ts
@@ -39,8 +39,8 @@ export interface Filter {
 interface IRequestParams {
   page?: {
     size?: number;
-    after?: number;
-    before?: number;
+    after?: number | string;
+    before?: number | string;
   };
   //array of object names to include ex. [files, speeds]
   include?: Array<string>;

--- a/src/app/core/_services/params/builder-implementation.service.ts
+++ b/src/app/core/_services/params/builder-implementation.service.ts
@@ -27,10 +27,10 @@ export class RequestParamBuilder implements IParamBuilder {
     if (dataSource.pageSize != undefined) {
       this.setPageSize(dataSource.pageSize);
     }
-    if (dataSource.pageAfter != null && typeof dataSource.pageAfter === 'number') {
+    if (dataSource.pageAfter != null) {
       this.setPageAfter(dataSource.pageAfter);
     }
-    if (dataSource.pageBefore != null && typeof dataSource.pageBefore === 'number') {
+    if (dataSource.pageBefore != null) {
       this.setPageBefore(dataSource.pageBefore);
     }
     if (dataSource.sortingColumn != undefined) {
@@ -55,7 +55,7 @@ export class RequestParamBuilder implements IParamBuilder {
    * @param pageBefore
    * @returns object instance
    */
-  setPageBefore(pageBefore: number | undefined): IParamBuilder {
+  setPageBefore(pageBefore: number | string | undefined): IParamBuilder {
     this.params.pageBefore = pageBefore;
     return this;
   }
@@ -65,7 +65,7 @@ export class RequestParamBuilder implements IParamBuilder {
    * @param pageAfter
    * @returns object instance
    */
-  setPageAfter(pageAfter: number | undefined): IParamBuilder {
+  setPageAfter(pageAfter: number | string | undefined): IParamBuilder {
     this.params.pageAfter = pageAfter;
     return this;
   }

--- a/src/app/core/_services/params/builder-types.service.ts
+++ b/src/app/core/_services/params/builder-types.service.ts
@@ -14,8 +14,8 @@ import { Filter, type RequestParams } from '@src/app/core/_models/request-params
  */
 export class RequestParamsIntermediate {
   public pageSize?: number;
-  public pageBefore?: number | undefined;
-  public pageAfter?: number | undefined;
+  public pageBefore?: number | string | undefined;
+  public pageAfter?: number | string | undefined;
   public includes?: Array<string>;
   public filters?: Array<Filter>;
   public sortOrder?: Array<string>;
@@ -28,9 +28,9 @@ export class RequestParamsIntermediate {
 export interface IParamBuilder {
   setPageSize(pageSize: number): IParamBuilder;
 
-  setPageBefore(pageBefore: number | undefined): IParamBuilder;
+  setPageBefore(pageBefore: number | string | undefined): IParamBuilder;
 
-  setPageAfter(pageAfter: number | undefined): IParamBuilder;
+  setPageAfter(pageAfter: number | string | undefined): IParamBuilder;
 
   addInclude(include: string): IParamBuilder;
 


### PR DESCRIPTION
…cursor pagination query params are always base64 encoded strings