### PR TITLE
Use backend helper that fetches access groups scoped by user so that …

### DIFF
--- a/src/app/core/_services/main.config.ts
+++ b/src/app/core/_services/main.config.ts
@@ -18,6 +18,7 @@ export const HELPER_ENDPOINTS = [
   'getUserPermission',
   'getBestTasksAgent',
   'getCracksOfTask',
+  'getAccessGroups',
   // POST helpers (chelper)
   'changeOwnPassword',
   'importFile',

--- a/src/app/files/new-files/new-files.component.spec.ts
+++ b/src/app/files/new-files/new-files.component.spec.ts
@@ -9,7 +9,7 @@ import { By } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { UploadTUSService } from '@services/files/files_tus.service';
-import { RelationshipType, SERV } from '@services/main.config';
+import { SERV } from '@services/main.config';
 import { GlobalService } from '@services/main.service';
 import { AlertService } from '@services/shared/alert.service';
 import { UnsubscribeService } from '@services/unsubscribe.service';
@@ -35,7 +35,7 @@ class MockUploadTUSService {
 
 class MockGlobalService {
   getAll = jasmine.createSpy('getAll').and.returnValue(of(mockResponse()));
-  getRelationships = jasmine.createSpy('getRelationships').and.returnValue(of(mockResponse()));
+  ghelper = jasmine.createSpy('ghelper').and.returnValue(of(mockResponse()));
   create = jasmine.createSpy('create').and.returnValue(of({}));
   userId = 1;
 }
@@ -208,12 +208,12 @@ describe('NewFilesComponent', () => {
   });
 
   describe('Access group scoping', () => {
-    it('should fetch access groups via getRelationships for the current user, not getAll', () => {
+    it('should fetch access groups via the getAccessGroups helper, not getAll', () => {
       setup('wordlist-new');
       const gs = TestBed.inject(GlobalService) as unknown as MockGlobalService;
 
-      // Component must use getRelationships to get user-scoped access groups
-      expect(gs.getRelationships).toHaveBeenCalledWith(SERV.USERS, 1, RelationshipType.ACCESSGROUPS);
+      // Component must use the helper endpoint to get user-scoped access groups
+      expect(gs.ghelper).toHaveBeenCalledWith(SERV.HELPER, 'getAccessGroups');
 
       // getAll must NOT be called — the component should not fetch all access groups
       expect(gs.getAll).not.toHaveBeenCalled();

--- a/src/app/files/new-files/new-files.component.ts
+++ b/src/app/files/new-files/new-files.component.ts
@@ -14,7 +14,7 @@ import { ResponseWrapper } from '@models/response.model';
 
 import { JsonAPISerializer } from '@services/api/serializer-service';
 import { UploadTUSService } from '@services/files/files_tus.service';
-import { RelationshipType, SERV } from '@services/main.config';
+import { SERV } from '@services/main.config';
 import { GlobalService } from '@services/main.service';
 import { AlertService } from '@services/shared/alert.service';
 import { AutoTitleService } from '@services/shared/autotitle.service';
@@ -178,9 +178,7 @@ export class NewFilesComponent implements OnInit, OnDestroy {
     this.isLoading = true;
 
     try {
-      const response: ResponseWrapper = await firstValueFrom(
-        this.gs.getRelationships(SERV.USERS, this.gs.userId!, RelationshipType.ACCESSGROUPS)
-      );
+      const response: ResponseWrapper = await firstValueFrom(this.gs.ghelper(SERV.HELPER, 'getAccessGroups'));
 
       const accessGroups: JAccessGroup[] = new JsonAPISerializer().deserialize(response, zAccessGroupListResponse);
 

--- a/src/app/hashlists/edit-hashlist/edit-hashlist.component.ts
+++ b/src/app/hashlists/edit-hashlist/edit-hashlist.component.ts
@@ -12,7 +12,7 @@ import { AccessGroupId } from '@models/id.types';
 import { ResponseWrapper } from '@models/response.model';
 
 import { JsonAPISerializer } from '@services/api/serializer-service';
-import { RelationshipType, SERV } from '@services/main.config';
+import { SERV } from '@services/main.config';
 import { GlobalService } from '@services/main.service';
 import { HashListRoleService } from '@services/roles/hashlists/hashlist-role.service';
 import { AlertService } from '@services/shared/alert.service';
@@ -193,9 +193,7 @@ export class EditHashlistComponent implements OnInit, OnDestroy, CanComponentDea
     if (!this.roleService.hasRole('groups')) {
       return;
     }
-    const response = await firstValueFrom<ResponseWrapper>(
-      this.gs.getRelationships(SERV.USERS, this.gs.userId!, RelationshipType.ACCESSGROUPS)
-    );
+    const response = await firstValueFrom<ResponseWrapper>(this.gs.ghelper(SERV.HELPER, 'getAccessGroups'));
 
     const accessGroups = new JsonAPISerializer().deserialize(response, zAccessGroupListResponse);
 

--- a/src/app/hashlists/new-hashlist/new-hashlist.component.spec.ts
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.spec.ts
@@ -12,7 +12,7 @@ import { Router } from '@angular/router';
 import { ResponseWrapper } from '@models/response.model';
 
 import { UploadTUSService } from '@services/files/files_tus.service';
-import { RelationshipType, SERV } from '@services/main.config';
+import { SERV } from '@services/main.config';
 import { GlobalService } from '@services/main.service';
 import { AlertService } from '@services/shared/alert.service';
 import { AutoTitleService } from '@services/shared/autotitle.service';
@@ -102,7 +102,7 @@ describe('NewHashlistComponent', () => {
   let dialogSpy: jasmine.SpyObj<MatDialog>;
 
   beforeEach(async () => {
-    gsSpy = jasmine.createSpyObj('GlobalService', ['getAll', 'get', 'create', 'getRelationships']);
+    gsSpy = jasmine.createSpyObj('GlobalService', ['getAll', 'get', 'create', 'ghelper']);
     Object.defineProperty(gsSpy, 'userId', { get: () => 1 });
     uploadSpy = jasmine.createSpyObj('UploadTUSService', ['uploadFile']);
     alertSpy = jasmine.createSpyObj('AlertService', ['showSuccessMessage', 'showErrorMessage']);
@@ -136,7 +136,7 @@ describe('NewHashlistComponent', () => {
   });
 
   beforeEach(() => {
-    gsSpy.getRelationships.and.returnValue(of(mockAccessGroups));
+    gsSpy.ghelper.and.returnValue(of(mockAccessGroups));
     gsSpy.getAll.withArgs(SERV.HASHTYPES).and.returnValue(of(mockHashtypes));
     (gsSpy.get as jasmine.Spy).withArgs(SERV.CONFIGS, 66).and.returnValue(of(mockConfigs));
     dialogSpy.open.and.returnValue({
@@ -321,8 +321,8 @@ describe('NewHashlistComponent', () => {
   });
 
   describe('Access group scoping', () => {
-    it('should fetch access groups via getRelationships for the current user, not getAll', () => {
-      expect(gsSpy.getRelationships).toHaveBeenCalledWith(SERV.USERS, 1, RelationshipType.ACCESSGROUPS);
+    it('should fetch access groups via the getAccessGroups helper, not getAll', () => {
+      expect(gsSpy.ghelper).toHaveBeenCalledWith(SERV.HELPER, 'getAccessGroups');
       expect(gsSpy.getAll).not.toHaveBeenCalledWith(SERV.ACCESS_GROUPS);
     });
   });

--- a/src/app/hashlists/new-hashlist/new-hashlist.component.ts
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.ts
@@ -18,7 +18,7 @@ import { ResponseWrapper } from '@models/response.model';
 
 import { JsonAPISerializer } from '@services/api/serializer-service';
 import { UploadTUSService } from '@services/files/files_tus.service';
-import { RelationshipType, SERV } from '@services/main.config';
+import { SERV } from '@services/main.config';
 import { GlobalService } from '@services/main.service';
 import { AlertService } from '@services/shared/alert.service';
 import { AutoTitleService } from '@services/shared/autotitle.service';
@@ -167,7 +167,7 @@ export class NewHashlistComponent implements OnInit, OnDestroy {
   loadData(): void {
     this.loadConfigs();
     const accessGroupSubscription = this.gs
-      .getRelationships(SERV.USERS, this.gs.userId!, RelationshipType.ACCESSGROUPS)
+      .ghelper(SERV.HELPER, 'getAccessGroups')
       .subscribe((response: ResponseWrapper) => {
         const accessGroups: JAccessGroup[] = new JsonAPISerializer().deserialize(response, zAccessGroupListResponse);
         this.selectAccessgroup = transformSelectOptions(accessGroups, ACCESS_GROUP_FIELD_MAPPING);


### PR DESCRIPTION
Use backend helper that fetches access groups scoped by user so that users without general read access can still create hashlists or files given their access groups

Fixes https://github.com/hashtopolis/server/issues/1955 