### PR TITLE
Fix header active state for nested and sibling routes

### DIFF
--- a/src/app/core/_components/menus/action-menu/action-menu.component.spec.ts
+++ b/src/app/core/_components/menus/action-menu/action-menu.component.spec.ts
@@ -1,0 +1,177 @@
+/// <reference types="jasmine" />
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDividerModule } from '@angular/material/divider';
+import { Router, NavigationEnd } from '@angular/router';
+import { Subject } from 'rxjs';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { ActionMenuComponent } from './action-menu.component';
+import { AutoTitleService } from '@services/shared/autotitle.service';
+import { LocalStorageService } from '@services/storage/local-storage.service';
+import { UIConfig } from '@models/config-ui.model';
+
+@Component({
+  template: '<action-menu [actionMenuItems]="[]" label="Test"></action-menu>',
+  standalone: false
+})
+class TestHostComponent {}
+
+describe('ActionMenuComponent', () => {
+  let component: ActionMenuComponent;
+  let fixture: ComponentFixture<ActionMenuComponent>;
+  let routerEvents$: Subject<NavigationEnd>;
+  let routerSpy: jasmine.SpyObj<Router>;
+  let storageSpy: jasmine.SpyObj<LocalStorageService<UIConfig>>;
+
+  beforeEach(async () => {
+    routerEvents$ = new Subject<NavigationEnd>();
+    routerSpy = jasmine.createSpyObj('Router', ['navigate'], {
+      events: routerEvents$.asObservable()
+    });
+    storageSpy = jasmine.createSpyObj('LocalStorageService', ['getItem', 'setItem']);
+    storageSpy.getItem.and.returnValue(null);
+
+    await TestBed.configureTestingModule({
+      declarations: [ActionMenuComponent],
+      imports: [
+        NoopAnimationsModule,
+        MatMenuModule,
+        MatButtonModule,
+        MatIconModule,
+        MatDividerModule,
+        FontAwesomeModule
+      ],
+      providers: [
+        { provide: Router, useValue: routerSpy },
+        { provide: LocalStorageService, useValue: storageSpy }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ActionMenuComponent);
+    component = fixture.componentInstance;
+    component.actionMenuItems = [];
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('checkIsActive', () => {
+    it('should be inactive by default', () => {
+      component.currentUrl = ['agents', 'show-agents'];
+      component.actionMenuItems = [];
+      component.checkIsActive();
+      expect(component.isActive).toBeFalse();
+    });
+
+    it('should be active when currentUrl matches routerLink exactly', () => {
+      component.currentUrl = ['agents', 'show-agents'];
+      component.actionMenuItems = [[{ label: 'Agents', routerLink: ['agents', 'show-agents'] }]];
+      component.checkIsActive();
+      expect(component.isActive).toBeTrue();
+    });
+
+    it('should be active when currentUrl is deeper than routerLink (prefix match)', () => {
+      component.currentUrl = ['files', 'wordlist', 'new-wordlist'];
+      component.actionMenuItems = [[{ label: 'Wordlists', routerLink: ['files', 'wordlist'] }]];
+      component.checkIsActive();
+      expect(component.isActive).toBeTrue();
+    });
+
+    it('should NOT be active when currentUrl does not match routerLink', () => {
+      component.currentUrl = ['hashlists', 'hashlist'];
+      component.actionMenuItems = [[{ label: 'Agents', routerLink: ['agents', 'show-agents'] }]];
+      component.checkIsActive();
+      expect(component.isActive).toBeFalse();
+    });
+
+    it('should be active when currentUrl matches routerLinkAdd', () => {
+      component.currentUrl = ['agents', 'new-agent'];
+      component.actionMenuItems = [[{
+        label: 'Agents',
+        routerLink: ['agents', 'show-agents'],
+        routerLinkAdd: ['agents', 'new-agent']
+      }]];
+      component.checkIsActive();
+      expect(component.isActive).toBeTrue();
+    });
+
+    it('should NOT be active when routerLink matches but routerLinkAdd does not', () => {
+      component.currentUrl = ['agents', 'something-else'];
+      component.actionMenuItems = [[{
+        label: 'Agents',
+        routerLink: ['agents', 'show-agents'],
+        routerLinkAdd: ['agents', 'new-agent']
+      }]];
+      component.checkIsActive();
+      expect(component.isActive).toBeFalse();
+    });
+
+    it('should be active when currentUrl matches an activeRoute', () => {
+      component.currentUrl = ['config', 'task-chunk'];
+      component.actionMenuItems = [[{
+        label: 'Settings',
+        routerLink: ['config', 'agent'],
+        activeRoutes: [['config', 'task-chunk'], ['config', 'hch']]
+      }]];
+      component.checkIsActive();
+      expect(component.isActive).toBeTrue();
+    });
+
+    it('should be active when currentUrl matches second activeRoute', () => {
+      component.currentUrl = ['config', 'hch'];
+      component.actionMenuItems = [[{
+        label: 'Settings',
+        routerLink: ['config', 'agent'],
+        activeRoutes: [['config', 'task-chunk'], ['config', 'hch']]
+      }]];
+      component.checkIsActive();
+      expect(component.isActive).toBeTrue();
+    });
+
+    it('should NOT be active when currentUrl does not match any activeRoute', () => {
+      component.currentUrl = ['config', 'something-else'];
+      component.actionMenuItems = [[{
+        label: 'Settings',
+        routerLink: ['config', 'agent'],
+        activeRoutes: [['config', 'task-chunk'], ['config', 'hch']]
+      }]];
+      component.checkIsActive();
+      expect(component.isActive).toBeFalse();
+    });
+
+    it('should be active when currentUrl matches a 3-segment activeRoute', () => {
+      component.currentUrl = ['tasks', 'import-supertasks', 'wrbulk'];
+      component.actionMenuItems = [[{
+        label: 'Supertask Builder',
+        routerLink: ['tasks', 'import-supertasks', 'masks'],
+        activeRoutes: [['tasks', 'import-supertasks', 'wrbulk']]
+      }]];
+      component.checkIsActive();
+      expect(component.isActive).toBeTrue();
+    });
+
+    it('should be active when matching item is in a second section', () => {
+      component.currentUrl = ['hashlists', 'hashlist'];
+      component.actionMenuItems = [
+        [{ label: 'Agents', routerLink: ['agents', 'show-agents'] }],
+        [{ label: 'Hashlists', routerLink: ['hashlists', 'hashlist'] }]
+      ];
+      component.checkIsActive();
+      expect(component.isActive).toBeTrue();
+    });
+
+    it('should handle item with no routerLink, routerLinkAdd or activeRoutes', () => {
+      component.currentUrl = ['agents', 'show-agents'];
+      component.actionMenuItems = [[{ label: 'Logout', action: 'logout' }]];
+      component.checkIsActive();
+      expect(component.isActive).toBeFalse();
+    });
+  });
+});

--- a/src/app/core/_components/menus/action-menu/action-menu.component.ts
+++ b/src/app/core/_components/menus/action-menu/action-menu.component.ts
@@ -204,13 +204,16 @@ export class ActionMenuComponent implements OnInit, AfterViewInit, OnDestroy {
     for (const section of this.actionMenuItems) {
       if (this.isActive) break;
       for (const item of section) {
-        if (item.routerLink) {
-          const partial = this.currentUrl.slice(0, item.routerLink.length);
-          if (partial.every((value, index) => value === item.routerLink![index])) {
-            this.isActive = true;
-            break;
+        for (const link of [item.routerLink, item.routerLinkAdd, ...(item.activeRoutes ?? [])]) {
+          if (link?.length) {
+            const partial = this.currentUrl.slice(0, link.length);
+            if (partial.every((value, index) => value === link[index])) {
+              this.isActive = true;
+              break;
+            }
           }
         }
+        if (this.isActive) break;
       }
     }
   }

--- a/src/app/core/_components/menus/action-menu/action-menu.model.ts
+++ b/src/app/core/_components/menus/action-menu/action-menu.model.ts
@@ -14,4 +14,5 @@ export interface ActionMenuItem {
   showAddButton?: boolean;
   routerLinkAdd?: string[];
   tooltipAddButton?: string;
+  activeRoutes?: string[][];
 }

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -231,7 +231,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
     if (this.supertaksRoleService.hasRole('createSupertaskBuilder')) {
       taskActions.push({
         label: HeaderMenuLabel.IMPORT_SUPERTASK,
-        routerLink: ['tasks', 'import-supertasks', 'masks']
+        routerLink: ['tasks', 'import-supertasks', 'masks'],
+        activeRoutes: [['tasks', 'import-supertasks', 'wrbulk']]
       });
     }
 
@@ -438,7 +439,14 @@ export class HeaderComponent implements OnInit, OnDestroy {
     if (this.configRoleWrapper.hasSettingsRole('read')) {
       actions.push({
         label: HeaderMenuLabel.SETTINGS,
-        routerLink: ['config', 'agent']
+        routerLink: ['config', 'agent'],
+        activeRoutes: [
+          ['config', 'task-chunk'],
+          ['config', 'hch'],
+          ['config', 'notifications'],
+          ['config', 'general-settings'],
+          ['config', 'server-actions']
+        ]
       });
     }
     if (this.configRoleWrapper.hasHashTypesRole('read')) {

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -273,7 +273,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
         routerLink: ['hashlists', 'hashlist'],
         showAddButton: this.hashListRoleService.hasRole('create'),
         routerLinkAdd: ['hashlists', 'new-hashlist'],
-        tooltipAddButton: 'New Hashlist'
+        tooltipAddButton: 'New Hashlist',
+        activeRoutes: [['hashlists']]
       });
     }
 

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -329,7 +329,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
           routerLink: ['files', 'wordlist'],
           showAddButton: canCreateFiles,
           routerLinkAdd: ['files', 'wordlist', 'new-wordlist'],
-          tooltipAddButton: 'New Wordlist'
+          tooltipAddButton: 'New Wordlist',
+          activeRoutes: [['files']]
         },
         {
           label: HeaderMenuLabel.RULES,
@@ -408,7 +409,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
     if (this.userRoleWrapperService.hasUserRole('read')) {
       actions.push({
         label: HeaderMenuLabel.ALL_USERS,
-        routerLink: ['users', 'all-users']
+        routerLink: ['users', 'all-users'],
+        activeRoutes: [['users']]
       });
     }
     if (this.userRoleWrapperService.hasPermissionRole('read')) {

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -214,7 +214,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
         routerLink: ['tasks', 'preconfigured-tasks'],
         showAddButton: this.pretasksRoleService.hasRole('create'),
         routerLinkAdd: ['tasks', 'new-preconfigured-tasks'],
-        tooltipAddButton: 'New Preconfigured Task'
+        tooltipAddButton: 'New Preconfigured Task',
+        activeRoutes: [['tasks']]
       });
     }
 


### PR DESCRIPTION
Added activeRoutes field to ActionMenuItem to support marking a menu button as active on routes not directly listed as routerLink or routerLinkAdd. Updated checkIsActive to check all three route types, and configured Config and Tasks menus with the missing sub-routes.