### PR TITLE
Fix bulk actions not working by passing selected rows to action handler and unit tests for it

### DIFF
--- a/src/app/core/_components/tables/ht-table/ht-table.component.spec.ts
+++ b/src/app/core/_components/tables/ht-table/ht-table.component.spec.ts
@@ -1,0 +1,109 @@
+/// <reference types="jasmine" />
+import { SelectionModel } from '@angular/cdk/collections';
+
+import { BaseModel } from '@models/base.model';
+
+import { ActionMenuEvent } from '@components/menus/action-menu/action-menu.model';
+
+import { HTTableComponent } from './ht-table.component';
+import { BaseDataSource } from '@datasources/base.datasource';
+
+interface TestModel extends BaseModel {
+  name: string;
+}
+
+function makeComponent() {
+  const component = Object.create(HTTableComponent.prototype) as HTTableComponent<TestModel>;
+
+  const selectedRows: TestModel[] = [];
+  const mockSelection = new SelectionModel<TestModel>(true, selectedRows);
+
+  const mockDataSource = {
+    selection: mockSelection
+  } as unknown as BaseDataSource<TestModel>;
+
+  component['dataSource'] = mockDataSource;
+  component['bulkActionClicked'] = {
+    emit: jasmine.createSpy('emit')
+  } as never;
+
+  return { component, mockSelection };
+}
+
+describe('HTTableComponent', () => {
+  describe('bulkAction', () => {
+    it('should emit bulkActionClicked with selected rows as data', () => {
+      const { component, mockSelection } = makeComponent();
+
+      const row1: TestModel = { id: 1, type: 'task', name: 'Task A' };
+      const row2: TestModel = { id: 2, type: 'task', name: 'Task B' };
+      mockSelection.select(row1, row2);
+
+      const event: ActionMenuEvent<BaseModel> = {
+        menuItem: { label: 'Delete', action: 'delete' },
+        data: { id: 0 } as BaseModel
+      };
+
+      component.bulkAction(event);
+
+      expect(component['bulkActionClicked'].emit).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          data: [row1, row2]
+        })
+      );
+    });
+
+    it('should preserve menuItem from original event', () => {
+      const { component } = makeComponent();
+
+      const event: ActionMenuEvent<BaseModel> = {
+        menuItem: { label: 'Archive', action: 'archive' },
+        data: { id: 0 } as BaseModel
+      };
+
+      component.bulkAction(event);
+
+      expect(component['bulkActionClicked'].emit).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          menuItem: { label: 'Archive', action: 'archive' }
+        })
+      );
+    });
+
+    it('should replace dummy data object with actual selected rows', () => {
+      const { component, mockSelection } = makeComponent();
+
+      const selectedRow: TestModel = { id: 5, type: 'task', name: 'Real Task' };
+      mockSelection.select(selectedRow);
+
+      const dummyData = { id: 0 } as BaseModel;
+      const event: ActionMenuEvent<BaseModel> = {
+        menuItem: { label: 'Delete', action: 'delete' },
+        data: dummyData
+      };
+
+      component.bulkAction(event);
+
+      const emittedEvent = (component['bulkActionClicked'].emit as jasmine.Spy).calls.mostRecent().args[0];
+      expect(emittedEvent.data).not.toBe(dummyData);
+      expect(emittedEvent.data).toEqual([selectedRow]);
+    });
+
+    it('should emit empty array when no rows are selected', () => {
+      const { component } = makeComponent();
+
+      const event: ActionMenuEvent<BaseModel> = {
+        menuItem: { label: 'Delete', action: 'delete' },
+        data: { id: 0 } as BaseModel
+      };
+
+      component.bulkAction(event);
+
+      expect(component['bulkActionClicked'].emit).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          data: []
+        })
+      );
+    });
+  });
+});

--- a/src/app/core/_components/tables/ht-table/ht-table.component.ts
+++ b/src/app/core/_components/tables/ht-table/ht-table.component.ts
@@ -416,7 +416,10 @@ export class HTTableComponent<T extends BaseModel> implements OnInit, AfterViewI
   }
 
   bulkAction(event: ActionMenuEvent<BaseModel>): void {
-    this.bulkActionClicked.emit(event as unknown as ActionMenuEvent<T[]>);
+    this.bulkActionClicked.emit({
+      ...event,
+      data: this.dataSource.selection.selected
+    } as ActionMenuEvent<T[]>);
   }
 
   exportAction(event: ActionMenuEvent<BaseModel>): void {

--- a/src/app/core/_datasources/tasks.datasource.spec.ts
+++ b/src/app/core/_datasources/tasks.datasource.spec.ts
@@ -1,0 +1,153 @@
+/// <reference types="jasmine" />
+import { of, throwError } from 'rxjs';
+
+import { ChangeDetectorRef, Injector } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { ResponseWrapper } from '@models/response.model';
+
+import { GlobalService } from '@services/main.service';
+import { UIConfigService } from '@services/shared/storage.service';
+import { AutoRefreshService } from '@services/shared/refresh/auto-refresh.service';
+import { HttpCacheService } from '@services/shared/http-cache.service';
+import { LocalStorageService } from '@services/storage/local-storage.service';
+
+import { TasksDataSource } from './tasks.datasource';
+import { mockResponse } from '@src/app/testing/mock-response';
+import { UIConfig } from '@models/config-ui.model';
+
+function buildMockResponse(taskWrappers: { id: number; attributes: Record<string, unknown> }[]): ResponseWrapper {
+  return mockResponse({
+    data: taskWrappers.map((t) => ({
+      id: t.id,
+      type: 'taskWrapperDisplay',
+      attributes: t.attributes
+    })),
+    meta: { page: { total_elements: taskWrappers.length } },
+    links: { self: '/test', next: null, prev: null }
+  });
+}
+
+describe('TasksDataSource', () => {
+  let dataSource: TasksDataSource;
+  let gsSpy: jasmine.SpyObj<GlobalService>;
+
+  beforeEach(() => {
+    gsSpy = jasmine.createSpyObj('GlobalService', ['getAll']);
+
+    const cdrSpy = jasmine.createSpyObj('ChangeDetectorRef', ['markForCheck', 'detectChanges']);
+    const uiServiceSpy = jasmine.createSpyObj('UIConfigService', ['getUISettings']);
+    uiServiceSpy.getUISettings.and.returnValue({});
+    const autoRefreshSpy = jasmine.createSpyObj('AutoRefreshService', ['toggleAutoRefresh', 'startAutoRefresh', 'stopAutoRefresh'], {
+      refresh$: of()
+    });
+    const cacheSpy = jasmine.createSpyObj('HttpCacheService', ['invalidate']);
+    const storageSpy = jasmine.createSpyObj('LocalStorageService', ['getItem', 'setItem']);
+    storageSpy.getItem.and.returnValue(null);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: GlobalService, useValue: gsSpy },
+        { provide: ChangeDetectorRef, useValue: cdrSpy },
+        { provide: UIConfigService, useValue: uiServiceSpy },
+        { provide: AutoRefreshService, useValue: autoRefreshSpy },
+        { provide: HttpCacheService, useValue: cacheSpy },
+        { provide: LocalStorageService, useValue: storageSpy }
+      ]
+    });
+
+    const injector = TestBed.inject(Injector);
+    dataSource = new TasksDataSource(injector);
+  });
+
+  describe('taskWrapperId mapping', () => {
+    it('should set taskWrapperId from id when API does not return taskWrapperId', () => {
+      const response = buildMockResponse([
+        { id: 5, attributes: { displayName: 'Task A', taskType: 1 } },
+        { id: 10, attributes: { displayName: 'Task B', taskType: 2 } }
+      ]);
+      gsSpy.getAll.and.returnValue(of(response));
+
+      dataSource.loadAll();
+
+      const data = dataSource.getOriginalData();
+      expect(data[0].taskWrapperId).toBe(5);
+      expect(data[1].taskWrapperId).toBe(10);
+    });
+
+    it('should keep existing taskWrapperId if API returns it', () => {
+      const response = buildMockResponse([
+        { id: 5, attributes: { displayName: 'Task A', taskWrapperId: 99 } }
+      ]);
+      gsSpy.getAll.and.returnValue(of(response));
+
+      dataSource.loadAll();
+
+      const data = dataSource.getOriginalData();
+      expect(data[0].taskWrapperId).toBe(99);
+    });
+
+    it('should preserve all other fields when mapping taskWrapperId', () => {
+      const response = buildMockResponse([
+        { id: 5, attributes: { displayName: 'Task A', taskType: 1, hashlistId: 3 } }
+      ]);
+      gsSpy.getAll.and.returnValue(of(response));
+
+      dataSource.loadAll();
+
+      const data = dataSource.getOriginalData();
+      expect(data[0].displayName).toBe('Task A');
+      expect(data[0].hashlistId).toBe(3);
+      expect(data[0].id).toBe(5);
+    });
+  });
+
+  describe('loadAll', () => {
+    it('should set loading to false after successful load', () => {
+      gsSpy.getAll.and.returnValue(of(buildMockResponse([])));
+      dataSource.loadAll();
+      expect(dataSource['loadingSubject'].getValue()).toBeFalse();
+    });
+
+    it('should set loading to false after failed load', () => {
+      gsSpy.getAll.and.returnValue(throwError(() => new Error('Network error')));
+      dataSource.loadAll();
+      expect(dataSource['loadingSubject'].getValue()).toBeFalse();
+    });
+
+    it('should set data from API response', () => {
+      const response = buildMockResponse([
+        { id: 1, attributes: { displayName: 'Task 1' } },
+        { id: 2, attributes: { displayName: 'Task 2' } }
+      ]);
+      gsSpy.getAll.and.returnValue(of(response));
+
+      dataSource.loadAll();
+
+      expect(dataSource.getOriginalData().length).toBe(2);
+    });
+
+    it('should call reload with filter when filterQuery is set', () => {
+      const filter = { field: 'name', operator: 'eq' as never, value: 'test' };
+      gsSpy.getAll.and.returnValue(of(buildMockResponse([])));
+
+      dataSource.setFilterQuery(filter);
+      dataSource.reload();
+
+      expect(gsSpy.getAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('setIsArchived', () => {
+    it('should reset pagination when isArchived changes', () => {
+      dataSource.pageAfter = 'someCursor';
+      dataSource.index = 5;
+
+      gsSpy.getAll.and.returnValue(of(buildMockResponse([])));
+      dataSource.setIsArchived(true);
+
+      expect(dataSource.pageAfter).toBeNull();
+      expect(dataSource.index).toBe(0);
+    });
+  });
+});

--- a/src/app/core/_datasources/tasks.datasource.ts
+++ b/src/app/core/_datasources/tasks.datasource.ts
@@ -63,7 +63,9 @@ export class TasksDataSource extends BaseDataSource<JTaskWrapperDisplay> {
         )
         .subscribe((response: ResponseWrapper) => {
           // Use JsonAPISerializer without Zod
-          const taskWrappers = new JsonAPISerializer().deserialize<JTaskWrapperDisplay[]>(response);
+          const taskWrappers = new JsonAPISerializer()
+            .deserialize<JTaskWrapperDisplay[]>(response)
+            .map((w) => ({ ...w, taskWrapperId: w.taskWrapperId ?? w.id }));
           const length = response.meta.page.total_elements;
           const nextLink = response.links.next;
           const prevLink = response.links.prev;


### PR DESCRIPTION
Fix bulk actions not working by passing selected rows to action handler

The bulk-action menu emitted a dummy data object instead of the actual
selected rows, causing .map() to crash. Fixed by replacing event.data
with dataSource.selection.selected in HTTableComponent. Also ensured
taskWrapperId is populated from id after deserialization in
TasksDataSource, as the display endpoint does not return it as an
attribute.

Add unit tests for bulk action fix and tasks datasource

Added spec files for HTTableComponent.bulkAction to verify selected rows replace the dummy data object, and for TasksDataSource to verify taskWrapperId is populated from id when missing from the API response.