### PR TITLE
Do not throw an error in the case that the schema doesnt validate

### DIFF
--- a/src/app/core/_services/api/serializer-service.spec.ts
+++ b/src/app/core/_services/api/serializer-service.spec.ts
@@ -100,11 +100,16 @@ describe('JsonAPISerializer', () => {
   });
 
   describe('schema mismatch detection', () => {
-    it('throws when user data is validated against access group schema', () => {
-      // Bug 2: using zAccessGroupListResponse for user data should fail validation
+    it('logs an error but does not throw when user data is validated against access group schema', () => {
+      // Validation is intentionally non-fatal: schema mismatches are reported via
+      // console.error (and an alert in dev mode), but deserialization still proceeds.
+      const consoleSpy = spyOn(console, 'error');
+
       expect(() => {
         serializer.deserialize(userListBody, zAccessGroupListResponse);
-      }).toThrow();
+      }).not.toThrow();
+
+      expect(consoleSpy).toHaveBeenCalledWith('API response validation failed', jasmine.anything());
     });
   });
 });

--- a/src/app/core/_services/api/serializer-service.ts
+++ b/src/app/core/_services/api/serializer-service.ts
@@ -110,7 +110,6 @@ export class JsonAPISerializer {
         // eslint-disable-next-line no-console
         console.log('Actual API response body:', JSON.stringify(body, null, 2));
         this.alertService?.showErrorMessage('API response validation failed: ' + parseResult.error.message);
-        throw parseResult.error;
       }
     }
   }

--- a/src/app/users/edit-groups/edit-groups.component.spec.ts
+++ b/src/app/users/edit-groups/edit-groups.component.spec.ts
@@ -93,13 +93,17 @@ describe('EditGroupsComponent deserialization', () => {
     serializer = new JsonAPISerializer();
   });
 
-  it('should throw when user data is deserialized with zAccessGroupListResponse (the bug)', () => {
-    // This is the current (buggy) code path:
-    //   const users: JAccessGroup[] = serializer.deserialize(response, zAccessGroupListResponse);
-    // It should throw because user-shaped data does not match access group schema.
+  it('logs an error when user data is deserialized with zAccessGroupListResponse (the bug)', () => {
+    // Validation against the wrong schema no longer throws — it reports the mismatch
+    // via console.error (and an alert in dev mode) so the UI stays responsive even when
+    // backend payloads drift from the expected shape.
+    const consoleSpy = spyOn(console, 'error');
+
     expect(() => {
       serializer.deserialize(userListBody, zAccessGroupListResponse);
-    }).toThrow();
+    }).not.toThrow();
+
+    expect(consoleSpy).toHaveBeenCalledWith('API response validation failed', jasmine.anything());
   });
 
   it('should correctly deserialize user data with zUserListResponse (the fix)', () => {

--- a/src/generated/api/zod/pre-task.ts
+++ b/src/generated/api/zod/pre-task.ts
@@ -70,7 +70,7 @@ export const zPreTaskResponse = z.object({
       maxAgents: z.int(),
       isMaskImport: z.boolean(),
       crackerBinaryTypeId: z.int(),
-      auxiliaryKeyspace: z.int().optional()
+      auxiliaryKeyspace: z.number().optional()
     })
   }),
   relationships: z
@@ -130,7 +130,7 @@ export const zPreTaskPostPatchResponse = z.object({
       maxAgents: z.int(),
       isMaskImport: z.boolean(),
       crackerBinaryTypeId: z.int(),
-      auxiliaryKeyspace: z.int().optional()
+      auxiliaryKeyspace: z.number().optional()
     })
   })
 });
@@ -166,7 +166,7 @@ export const zPreTaskListResponse = z.object({
         maxAgents: z.int(),
         isMaskImport: z.boolean(),
         crackerBinaryTypeId: z.int(),
-        auxiliaryKeyspace: z.int().optional()
+        auxiliaryKeyspace: z.number().optional()
       })
     })
   ),


### PR DESCRIPTION
Do not throw an error in development when we validate and a schema fails.
Important currently as the schemas are not completely accurate yet due to inaccuracies in the openapi json file.
Also regarding the 1.0 release better as we can distinguish real errors.

Issue: https://github.com/hashtopolis/server/issues/2108