### PR TITLE
fix: encode paste sourceData without mutating form in new hashlist

### DIFF
--- a/src/app/hashlists/new-hashlist/new-hashlist.component.spec.ts
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.spec.ts
@@ -258,7 +258,7 @@ describe('NewHashlistComponent', () => {
       expect(component.isCreatingLoading).toBe(false);
     }));
 
-    it('should submit form with "paste" sourceType', fakeAsync(() => {
+    it('should submit form with "paste" sourceType and base64-encode sourceData', fakeAsync(() => {
       gsSpy.create.and.returnValue(of(mockResponse()));
       component.form.patchValue({
         name: 'Test Hashlist',
@@ -271,7 +271,12 @@ describe('NewHashlistComponent', () => {
       component.onSubmit();
       tick();
 
-      expect(gsSpy.create).toHaveBeenCalled();
+      const expectedEncoded = btoa('some data');
+      expect(gsSpy.create).toHaveBeenCalledWith(
+        jasmine.anything(),
+        jasmine.objectContaining({ sourceData: expectedEncoded })
+      );
+      expect(component.form.controls.sourceData.value).toBe('some data');
       expect(alertSpy.showSuccessMessage).toHaveBeenCalledWith('New HashList created');
       expect(routerSpy.navigate).toHaveBeenCalledWith(['/hashlists/hashlist']);
     }));

--- a/src/app/hashlists/new-hashlist/new-hashlist.component.ts
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.ts
@@ -320,13 +320,14 @@ export class NewHashlistComponent implements OnInit, OnDestroy {
 
     // Proceed with existing logic now that input is validated
     if (sourceType === 'paste') {
-      this.form.patchValue({
-        sourceData: handleEncode(this.form.controls.sourceData.value)
-      });
       this.isCreatingLoading = true;
+      const payload = {
+        ...this.form.getRawValue(),
+        sourceData: handleEncode(this.form.controls.sourceData.value)
+      };
 
       try {
-        await firstValueFrom(this.gs.create(SERV.HASHLISTS, this.form.getRawValue()));
+        await firstValueFrom(this.gs.create(SERV.HASHLISTS, payload));
         this.alert.showSuccessMessage('New HashList created');
         this.router.navigate(['/hashlists/hashlist']);
       } catch (error) {


### PR DESCRIPTION
Build the base64 payload locally instead of patching the form control, preventing the encoded value from briefly appearing in the input field. Also strengthens the paste submission test to assert that the API receives encoded data and that the form value remains unchanged.