### PR TITLE
agent's status now depends on assigned tasks in order to be running/stopped

### DIFF
--- a/src/app/core/_components/tables/agents-status-table/agents-status-table.component.ts
+++ b/src/app/core/_components/tables/agents-status-table/agents-status-table.component.ts
@@ -375,7 +375,27 @@ export class AgentsStatusTableComponent extends BaseTableComponent implements On
    * @private
    */
   private renderActiveAgent(agent: JAgent): string {
-    return (agent.agentSpeed ?? 0) > 0 ? 'Running task' : 'Stopped task';
+    const isReportingProgress = agent.lastAct === 'sendProgress';
+    const hasAssignedTask = !!agent.taskId;
+    const hasRecentActivity = this.hasRecentActivity(agent.lastTime);
+
+    return agent.isActive && hasAssignedTask && isReportingProgress && hasRecentActivity
+      ? 'Running task'
+      : 'Stopped task';
+  }
+
+  // Determine if the last server interaction is recent enough to consider the agent online.
+  private hasRecentActivity(lastTime: number): boolean {
+    if (!lastTime) {
+      return false;
+    }
+
+    const nowInSeconds = Math.floor(Date.now() / 1000);
+    const elapsedSeconds = Math.max(0, nowInSeconds - lastTime);
+    const configuredTimeout = this.uiService.getUISettings()?.agenttimeout ?? 0;
+    const timeoutSeconds = configuredTimeout > 0 ? configuredTimeout : 120;
+
+    return elapsedSeconds <= timeoutSeconds;
   }
 
   /**


### PR DESCRIPTION
Wrong API call was being done, agentSpeed came unpopulated so as speed = 0, Status was always Stopped. Now, under this conditions: 

return agent.isActive && hasAssignedTask && isReportingProgress && hasRecentActivity

The frontend can determine wether to set status running or stopped.

Additionally, added a method to determine if an agent is still working on a taask depending on if any data is sent recently.