### PR TITLE
2173 bug wrong request to create new hashtype

### DIFF
--- a/src/app/core/_services/main.config.ts
+++ b/src/app/core/_services/main.config.ts
@@ -65,7 +65,7 @@ export class SERV {
   public static CONFIGS = { URL: '/ui/configs', RESOURCE: 'Configs' };
   public static CRACKERS = { URL: '/ui/crackers', RESOURCE: 'Crackers' };
   public static CRACKERS_TYPES = { URL: '/ui/crackertypes', RESOURCE: 'CrackerTypes' };
-  public static HASHTYPES = { URL: '/ui/hashtypes', RESOURCE: 'HashTypes' };
+  public static HASHTYPES = { URL: '/ui/hashtypes', RESOURCE: 'hashtype' };
   public static HEALTH_CHECKS = { URL: '/ui/healthchecks', RESOURCE: 'HealthCheck' };
   public static HEALTH_CHECKS_AGENTS = { URL: '/ui/healthcheckagents', RESOURCE: 'HealthCheckAgents' };
   public static LOGS = { URL: '/ui/logentries', RESOURCE: 'LogEntries' };

--- a/src/app/core/_services/metadata.service.ts
+++ b/src/app/core/_services/metadata.service.ts
@@ -627,7 +627,7 @@ export class MetadataService {
   //This variable defines the fields and properties required when creating a new Hashtype.
   newhashtype: MetadataFormField[] = [
     {
-      name: 'id',
+      name: 'hashTypeId',
       label: 'Hashtype',
       type: 'number',
       requiredasterisk: true,

--- a/src/app/core/_services/metadata.service.ts
+++ b/src/app/core/_services/metadata.service.ts
@@ -898,7 +898,7 @@ export class MetadataService {
     },
     {
       name: 'pagingSize',
-      label: 'Hashes size Page in Hash Vieww',
+      label: 'Hashes size Page in Hash View',
       type: 'number',
       tooltip: false
     },

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -556,7 +556,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
           {
             label: 'Write us an email',
             icon: 'faPaperplane',
-            routerLink: ['mailto:contact@hashtoplis.org'],
+            routerLink: ['mailto:contact@hashtopolis.org'],
             external: true
           },
           {


### PR DESCRIPTION
Wrong naming resource should be named 'hashtype' instead of 'HashTypes' also send field 'hashTypeId' not id.

Would be nice if the type system could prevent this or that we can prevent this with the openapi spec -> use zod request schemas.

Issue: https://github.com/hashtopolis/server/issues/2173

Also fix two typos:       https://github.com/hashtopolis/server/issues/1899, https://github.com/hashtopolis/server/issues/2171