### PR TITLE
feat(supertasks): add "skip completed pretasks" option to apply-hashlist form

### DIFF
--- a/src/app/tasks/supertasks/applyhashlist.component.html
+++ b/src/app/tasks/supertasks/applyhashlist.component.html
@@ -38,6 +38,11 @@
           ></input-select>
         </div>
       </div>
+      <input-check
+        title="Skip pretasks already completed"
+        tooltip="If an identical attack has already been fully run against this hashlist, skip creating a duplicate task for it."
+        formControlName="skipCompleted"
+      ></input-check>
       <grid-buttons>
         <button-submit name="Cancel" [disabled]="false" type="cancel"></button-submit>
         <button-submit [name]="'Create'" [loading]="isCreatingLoading"></button-submit>

--- a/src/app/tasks/supertasks/applyhashlist.component.ts
+++ b/src/app/tasks/supertasks/applyhashlist.component.ts
@@ -30,6 +30,17 @@ export interface ApplyHashlistForm {
   hashlistId: FormControl<HashlistId | null>;
   crackerBinaryId: FormControl<CrackerBinaryId | null>;
   crackerBinaryTypeId: FormControl<CrackerBinaryTypeId | null>;
+  skipCompleted: FormControl<boolean>;
+}
+
+interface SkippedPretask {
+  pretaskId: number;
+  matchingTaskId: number;
+}
+
+interface CreateSupertaskMeta {
+  taskWrapperId: number | null;
+  skippedPretasks?: SkippedPretask[];
 }
 
 /**
@@ -119,7 +130,8 @@ export class ApplyHashlistComponent implements OnInit, OnDestroy {
       supertaskTemplateId: new FormControl<number | null>(null),
       hashlistId: new FormControl<HashlistId | null>(null),
       crackerBinaryId: new FormControl<CrackerBinaryId | null>(null),
-      crackerBinaryTypeId: new FormControl<CrackerBinaryTypeId | null>(null)
+      crackerBinaryTypeId: new FormControl<CrackerBinaryTypeId | null>(null),
+      skipCompleted: new FormControl<boolean>(false, { nonNullable: true })
     });
   }
 
@@ -135,7 +147,8 @@ export class ApplyHashlistComponent implements OnInit, OnDestroy {
       supertaskTemplateId: new FormControl<number | null>(this.editedIndex),
       hashlistId: new FormControl<HashlistId | null>(null),
       crackerBinaryId: new FormControl<CrackerBinaryId | null>(1),
-      crackerBinaryTypeId: new FormControl<CrackerBinaryTypeId | null>(null)
+      crackerBinaryTypeId: new FormControl<CrackerBinaryTypeId | null>(null),
+      skipCompleted: new FormControl<boolean>(false, { nonNullable: true })
     });
 
     //subscribe to changes to handle select cracker binary
@@ -252,13 +265,30 @@ export class ApplyHashlistComponent implements OnInit, OnDestroy {
       const adaptedFormValue = {
         supertaskTemplateId: formValue.supertaskTemplateId,
         hashlistId: formValue.hashlistId,
-        crackerVersionId: formValue.crackerBinaryTypeId
+        crackerVersionId: formValue.crackerBinaryTypeId,
+        skipCompleted: formValue.skipCompleted
       };
-      const onSubmitSubscription$ = this.gs.chelper(SERV.HELPER, 'createSupertask', adaptedFormValue).subscribe(() => {
-        this.alert.showSuccessMessage('New SuperTask created');
-        this.router.navigate(['tasks/show-tasks']);
-        this.isCreatingLoading = false;
-      });
+      const onSubmitSubscription$ = this.gs
+        .chelper<ResponseWrapper<CreateSupertaskMeta>>(SERV.HELPER, 'createSupertask', adaptedFormValue)
+        .subscribe({
+          next: (response) => {
+            const skipped = response?.meta?.skippedPretasks ?? [];
+            const allSkipped = response?.meta?.taskWrapperId == null;
+            if (skipped.length) {
+              this.alert.showInfoMessage(`Skipped ${skipped.length} pretask(s) already completed for this hashlist.`);
+            }
+            this.alert.showSuccessMessage(
+              allSkipped ? 'All pretasks already completed - no new SuperTask created.' : 'New SuperTask created'
+            );
+            this.router.navigate(['tasks/show-tasks']);
+          },
+          error: () => {
+            this.isCreatingLoading = false;
+          },
+          complete: () => {
+            this.isCreatingLoading = false;
+          }
+        });
       this.unsubscribeService.add(onSubmitSubscription$);
     } else {
       this.form.markAllAsTouched();


### PR DESCRIPTION
## Summary

Adds the client-side control for the server-side supertask dedup feature (server PR hashtopolis/server#2177, feature request hashtopolis/server#2167).

A "Skip pretasks already completed" checkbox is added to the apply-supertask ("Use Supertask") form. When checked, it sends `skipCompleted: true` to the `createSupertask` helper and surfaces the server's `meta.skippedPretasks` response — an info toast listing the skipped pretasks, plus the all-skipped (`taskWrapperId == null`, no wrapper created) case. **Defaults off**, so existing behavior is unchanged.

## Depends on

- Server: **hashtopolis/server#2177** — adds the `skipCompleted` flag and the `meta.skippedPretasks` response. This UI is a no-op against a server without that change (the flag is simply ignored).

## Changes

- `applyhashlist.component.ts` — adds a `skipCompleted` FormControl (`buildForm()` + `initForm()`), sends it in the `createSupertask` body, types the call `ResponseWrapper<CreateSupertaskMeta>`, surfaces `meta.skippedPretasks` and the all-skipped case via `AlertService`, and uses the `{ next, error, complete }` subscribe form (resets `isCreatingLoading` on error/complete).
- `applyhashlist.component.html` — the checkbox + explanatory tooltip.

## Testing

- Compiles clean under `ng serve`.
- Verified end-to-end against the server branch with a live CPU agent through this UI: applying a supertask with the box checked skipped the already-exhausted pretask, and only the new pretask ran (and cracked the hash). Screenshots on hashtopolis/server#2167.

Refs hashtopolis/server#2167
