### PR TITLE
2130 always place sort arrow to the left of column labels

### DIFF
--- a/src/app/core/_components/tables/ht-table/ht-table.component.html
+++ b/src/app/core/_components/tables/ht-table/ht-table.component.html
@@ -208,7 +208,7 @@
             mat-header-cell
             *matHeaderCellDef
             [mat-sort-header]="tableColumn.id + ''"
-            [arrowPosition]="tableColumn.isNumeric ? 'before' : 'after'"
+            arrowPosition="before"
             (click)="onColumnHeaderClick(tableColumn)"
             [class.cell-numeric]="tableColumn.isNumeric"
           >


### PR DESCRIPTION
Pin arrow button to the left of the table column label.


Issue: https://github.com/hashtopolis/server/issues/2130