### PR TITLE
Remove fields in frontend config metadata that were removed by backen…

### DIFF
--- a/src/app/core/_components/forms/simple-forms/formconfig.component.spec.ts
+++ b/src/app/core/_components/forms/simple-forms/formconfig.component.spec.ts
@@ -305,6 +305,38 @@ describe('FormConfigComponent', () => {
     expect(alertService.showSuccessMessage).toHaveBeenCalledWith('Saved General Settings');
   });
 
+  it('should surface an error (not an undefined id) for changed fields with no backend id', () => {
+    component.title = 'Task/Chunk Settings';
+    // `ruleSplitAlways` is intentionally absent from both formValues and formIds,
+    // mirroring a metadata field the backend never returns. Without the guard its
+    // "changed" control (0 !== undefined) would PATCH /ui/configs/undefined.
+    component.formValues = {
+      chunktime: 700 as unknown as string | boolean
+    } as unknown as typeof component.formValues;
+    component.formIds = {
+      chunktime: 3
+    };
+
+    globalService.update.and.returnValue(of({} as object));
+
+    component.onFormSubmit({ chunktime: 800, ruleSplitAlways: 0 });
+
+    // The field with an id still saves...
+    expect(globalService.update).toHaveBeenCalledTimes(1);
+    expect(globalService.update).toHaveBeenCalledWith(SERV.CONFIGS, 3, { item: 'chunktime', value: '800' });
+    // ...the one without an id is never PATCHed with an undefined id...
+    expect(globalService.update).not.toHaveBeenCalledWith(
+      SERV.CONFIGS,
+      undefined as unknown as number,
+      jasmine.objectContaining({ item: 'ruleSplitAlways' })
+    );
+    // ...and the user is told it could not be saved.
+    expect(alertService.showErrorMessage).toHaveBeenCalledWith(
+      'Cannot save (no matching config on server): ruleSplitAlways'
+    );
+    expect(alertService.showSuccessMessage).toHaveBeenCalledWith('Saved Task/Chunk Settings');
+  });
+
   it('should do nothing when form values have not changed', () => {
     component.formValues = {
       serverLogLevel: 20 as unknown as string | boolean,

--- a/src/app/core/_components/forms/simple-forms/formconfig.component.ts
+++ b/src/app/core/_components/forms/simple-forms/formconfig.component.ts
@@ -190,8 +190,19 @@ export class FormConfigComponent implements OnInit, OnDestroy {
 
     if (Object.keys(changedFields).length === 0) return;
 
+    // Currently this form data can get out of sync with the backend implementation.
+    // If some fields are removed and not returned by backend show an error here when trying to update them.
+    // @IMPROVEMENT -> this should be fully typed instead of being dynamic
+    const updatableKeys = Object.keys(changedFields).filter((key) => this.formIds[key] !== undefined);
+    const skippedKeys = Object.keys(changedFields).filter((key) => this.formIds[key] === undefined);
+    if (skippedKeys.length) {
+      this.alert.showErrorMessage(`Cannot save (no matching config on server): ${skippedKeys.join(', ')}`);
+    }
+
+    if (updatableKeys.length === 0) return;
+
     // Prepare all update observables
-    const updateRequests = Object.keys(changedFields).map((key) => {
+    const updateRequests = updatableKeys.map((key) => {
       const id = this.formIds[key];
       const value = changedFields[key];
       return this.gs.update(SERV.CONFIGS, id, { item: key, value: String(value) });
@@ -201,7 +212,7 @@ export class FormConfigComponent implements OnInit, OnDestroy {
     this.mySubscription = forkJoin(updateRequests).subscribe({
       next: () => {
         // Mark all fields as updated
-        Object.keys(changedFields).forEach((key) =>
+        updatableKeys.forEach((key) =>
           this.uicService.onUpdatingCheck(key as Parameters<typeof this.uicService.onUpdatingCheck>[0])
         );
 

--- a/src/app/core/_services/metadata.service.ts
+++ b/src/app/core/_services/metadata.service.ts
@@ -856,25 +856,6 @@ export class MetadataService {
       label: 'Display Cracks per Minute for Active Tasks',
       type: 'checkbox',
       tooltip: false
-    },
-    { label: 'Rule splitting', isTitle: true },
-    {
-      name: 'ruleSplitSmallTasks',
-      label: 'Rule Splitting for Tasks: Always Create Small Tasks',
-      type: 'checkbox',
-      tooltip: false
-    },
-    {
-      name: 'ruleSplitAlways',
-      label: 'Rule Splitting with Benchmark Constraint: Allow Subtasks with a Single Rule',
-      type: 'checkbox',
-      tooltip: false
-    },
-    {
-      name: 'ruleSplitDisable',
-      label: 'Disable Automatic Task Splitting for Large Rule Files',
-      type: 'checkbox',
-      tooltip: false
     }
   ];
 

--- a/src/config/default/app/tooltip.ts
+++ b/src/config/default/app/tooltip.ts
@@ -74,10 +74,7 @@ export const DEFAULT_CONFIG_TOOLTIP = {
         hashlistAlias: 'Display hashlist aliases',
         blacklistChars: 'Characters to exclude from attacks',
         priority0Start: 'Start time for priority level 0 tasks',
-        showTaskPerformance: 'Display task performance metrics',
-        ruleSplitSmallTasks: 'Split small tasks with rules',
-        ruleSplitAlways: 'Always split tasks with rules',
-        ruleSplitDisable: 'Disable automatic rule splitting'
+        showTaskPerformance: 'Display task performance metrics'
       },
       hch: {
         maxHashlistSize: 'Maximum size limit for hashlist import',
@@ -137,10 +134,7 @@ export const DEFAULT_CONFIG_TOOLTIP = {
         hashlistAlias: 'When enabled, display human-readable aliases for hashlists if configured',
         blacklistChars: 'Characters to exclude from rule-based attacks to improve performance',
         priority0Start: 'Scheduled start time for high-priority tasks (format: HH:MM)',
-        showTaskPerformance: 'When enabled, display detailed performance metrics for running tasks',
-        ruleSplitSmallTasks: 'Automatically split small tasks when rules are applied',
-        ruleSplitAlways: 'Always split tasks when rules are applied',
-        ruleSplitDisable: 'Disable automatic task splitting when rules are applied'
+        showTaskPerformance: 'When enabled, display detailed performance metrics for running tasks'
       },
       hch: {
         maxHashlistSize: 'Maximum file size in MB allowed when importing a hashlist',
@@ -218,13 +212,7 @@ export const DEFAULT_CONFIG_TOOLTIP = {
         priority0Start:
           'Scheduled time (format HH:MM in 24-hour format) at which highest-priority tasks automatically start. Allows scheduling intensive tasks during off-peak hours.',
         showTaskPerformance:
-          'When enabled, displays detailed performance graphs and metrics for running tasks showing speed, progress, and estimated completion time.',
-        ruleSplitSmallTasks:
-          'Automatically splits small tasks when rules are applied to improve performance through parallelization across multiple agents.',
-        ruleSplitAlways:
-          'Always splits tasks when rules are applied, regardless of task size. Ensures maximum parallelization but may increase overhead.',
-        ruleSplitDisable:
-          'Completely disables automatic task splitting when rules are applied. Tasks remain as single units assigned to single agents.'
+          'When enabled, displays detailed performance graphs and metrics for running tasks showing speed, progress, and estimated completion time.'
       },
       hch: {
         maxHashlistSize:


### PR DESCRIPTION
Remove fields in frontend config metadata that were removed by backend which lead to update errors

ruleSplitSmallTasks, ruleSplitAlways, ruleSplitDisable do not exist anymore in the backend and have been removed

Improvement would be that these are all typed but currently these are dynamic forms. Maybe plan a refactoring after the 1.0 release to prevent a drift from the frontend/backend config values. 

Issue: https://github.com/hashtopolis/server/issues/2137