### PR TITLE
Only show running and completed status icon (no idling)

### DIFF
--- a/src/app/core/_components/tables/tasks-table/tasks-table.component.spec.ts
+++ b/src/app/core/_components/tables/tasks-table/tasks-table.component.spec.ts
@@ -997,7 +997,17 @@ describe('TasksTableComponent', () => {
       expect(icon.tooltip).toBe('In Progress');
     });
 
-    it('should return empty icon for non-RUNNING status', () => {
+    it('should return check icon for COMPLETED status', () => {
+      const wrapper = { status: TaskStatus.COMPLETED } as JTaskWrapperDisplay;
+
+      const icon = component.renderStatusIcons(wrapper);
+
+      expect(icon.name).toBe('check_circle');
+      expect(icon.cls).toBe('text-ok');
+      expect(icon.tooltip).toBe('Completed');
+    });
+
+    it('should return empty icon for IDLE status', () => {
       const wrapper = { status: TaskStatus.IDLE } as JTaskWrapperDisplay;
 
       const icon = component.renderStatusIcons(wrapper);

--- a/src/app/core/_components/tables/tasks-table/tasks-table.component.ts
+++ b/src/app/core/_components/tables/tasks-table/tasks-table.component.ts
@@ -511,14 +511,25 @@ export class TasksTableComponent extends BaseTableComponent implements OnInit, O
 
   // --- Render functions ---
   renderStatusIcons(wrapper: JTaskWrapperDisplay): HTTableIcon {
-    if (wrapper.status === TaskStatus.RUNNING) {
-      return { name: 'radio_button_checked', cls: 'pulsing-progress', tooltip: 'In Progress' };
+    switch (wrapper.status) {
+      case TaskStatus.RUNNING:
+        return { name: 'radio_button_checked', cls: 'pulsing-progress', tooltip: 'In Progress' };
+      case TaskStatus.COMPLETED:
+        return { name: 'check_circle', cls: 'text-ok', tooltip: 'Completed' };
+      default:
+        return { name: '' };
     }
-    return { name: '' };
   }
 
   private getTaskStatusLabel(wrapper: JTaskWrapperDisplay): string {
-    return wrapper.status === TaskStatus.RUNNING ? 'Running' : '';
+    switch (wrapper.status) {
+      case TaskStatus.RUNNING:
+        return 'Running';
+      case TaskStatus.COMPLETED:
+        return 'Completed';
+      default:
+        return '';
+    }
   }
 
   private renderIsSmallIcon(wrapper: JTaskWrapperDisplay): HTTableIcon {


### PR DESCRIPTION
Show running and completed status icons and no idling.

Issue: https://github.com/hashtopolis/server/issues/2153