### PR TITLE
When clicking on the cracked hashes in chunk it should link to cracks…

### DIFF
--- a/src/app/core/_components/tables/base-table/base-table.component.spec.ts
+++ b/src/app/core/_components/tables/base-table/base-table.component.spec.ts
@@ -106,10 +106,10 @@ describe('BaseTableComponent', () => {
   });
 
   it('should render cracked link from chunk', (done) => {
-    const mockChunk = { taskId: 1, cracked: 100 } as JChunk;
+    const mockChunk = { id: 1, taskId: 2, cracked: 100 } as JChunk;
     component.renderCrackedLinkFromChunk(mockChunk).subscribe((links) => {
       expect(links.length).toBe(1);
-      expect(links[0].routerLink).toEqual(['/hashlists', 'hashes', 'tasks', 1]);
+      expect(links[0].routerLink).toEqual(['/hashlists', 'hashes', 'chunks', 1]);
       expect(links[0].label).toBe('100');
       done();
     });

--- a/src/app/core/_components/tables/base-table/base-table.component.ts
+++ b/src/app/core/_components/tables/base-table/base-table.component.ts
@@ -173,7 +173,7 @@ export class BaseTableComponent {
     const links: HTTableRouterLink[] = [];
     if (chunk) {
       links.push({
-        routerLink: ['/hashlists', 'hashes', 'tasks', chunk.taskId],
+        routerLink: ['/hashlists', 'hashes', 'chunks', chunk.id],
         label: chunk.cracked.toLocaleString()
       });
     }

--- a/src/app/core/_components/tables/chunks-table/chunks-table.component.spec.ts
+++ b/src/app/core/_components/tables/chunks-table/chunks-table.component.spec.ts
@@ -295,11 +295,11 @@ describe('ChunksTableComponent', () => {
     it('should render CRACKED column routerLink with correct path and label', (done) => {
       const columns = component.getColumns();
       const crackedColumn = columns.find((col) => col.id === ChunksTableCol.CRACKED);
-      const chunk = { taskId: 5, cracked: 100 } as JChunk;
+      const chunk = { id: 9, taskId: 5, cracked: 100 } as JChunk;
 
       crackedColumn?.routerLink!(chunk).subscribe((links) => {
         expect(links.length).toBe(1);
-        expect(links[0].routerLink).toEqual(['/hashlists', 'hashes', 'tasks', 5]);
+        expect(links[0].routerLink).toEqual(['/hashlists', 'hashes', 'chunks', 9]);
         expect(links[0].label).toBe('100');
         done();
       });


### PR DESCRIPTION
Modify links to link to cracks of specific chunk and not the full task

Issue: https://github.com/hashtopolis/server/issues/2190