### PR TITLE
correct name in the Agent settings PATCH

### DIFF
--- a/src/app/core/_services/metadata.service.ts
+++ b/src/app/core/_services/metadata.service.ts
@@ -724,7 +724,7 @@ export class MetadataService {
       tooltip: false
     },
     {
-      name: 'benchtime',
+      name: 'chunktimeout',
       label: 'Inactivity Timeout for Issued Chunks',
       type: 'number',
       tooltip: false


### PR DESCRIPTION
The API key "benchtime" used to read/write the value for Inactivity Timeout for Issued Chunks was not correct. This key was sending the PATCH to config/2 instead of config/4 when updating Agent settings, so the server was not really being updated on this part. The correct API key is "chunktimeout"

To test: 
1- curl the configs/4 endpoint and look at the value attribute on the data
2- Change the Inactivity Timeout for Issued Chunks value through the frontend and send the PATCh by clicking on Update
3- Repeat the first step, the value should have changed.