### PR TITLE
Pretasks created by mask importer are not directly visible

### DIFF
--- a/src/app/account/settings/acc-settings/acc-settings.component.spec.ts
+++ b/src/app/account/settings/acc-settings/acc-settings.component.spec.ts
@@ -1,6 +1,5 @@
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { of } from 'rxjs';
-import { uiDatePipe } from 'src/app/core/_pipes/date.pipe';
 import { SERV } from 'src/app/core/_services/main.config';
 import { GlobalService } from 'src/app/core/_services/main.service';
 import { ComponentsModule } from 'src/app/shared/components.module';
@@ -98,7 +97,6 @@ describe('AccountSettingsComponent', () => {
     alertSpy = jasmine.createSpyObj('AlertService', ['showSuccessMessage', 'showErrorMessage']);
 
     spyOn(JsonAPISerializer.prototype, 'deserialize').and.returnValue(mockUser);
-    spyOn(uiDatePipe.prototype, 'transform').and.returnValue('07/04/2025 12:00:00');
 
     await TestBed.configureTestingModule({
       declarations: [AccountSettingsComponent],

--- a/src/app/account/settings/acc-settings/acc-settings.component.spec.ts
+++ b/src/app/account/settings/acc-settings/acc-settings.component.spec.ts
@@ -1,5 +1,6 @@
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { of } from 'rxjs';
+import { uiDatePipe } from 'src/app/core/_pipes/date.pipe';
 import { SERV } from 'src/app/core/_services/main.config';
 import { GlobalService } from 'src/app/core/_services/main.service';
 import { ComponentsModule } from 'src/app/shared/components.module';
@@ -93,12 +94,13 @@ describe('AccountSettingsComponent', () => {
     otp4: userResponse.attributes.otp4
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     alertSpy = jasmine.createSpyObj('AlertService', ['showSuccessMessage', 'showErrorMessage']);
 
     spyOn(JsonAPISerializer.prototype, 'deserialize').and.returnValue(mockUser);
+    spyOn(uiDatePipe.prototype, 'transform').and.returnValue('07/04/2025 12:00:00');
 
-    TestBed.configureTestingModule({
+    await TestBed.configureTestingModule({
       declarations: [AccountSettingsComponent],
       imports: [
         CommonModule,

--- a/src/app/core/_datasources/preconfigured-tasks.datasource.ts
+++ b/src/app/core/_datasources/preconfigured-tasks.datasource.ts
@@ -54,6 +54,9 @@ export class PreTasksDataSource extends BaseDataSource<JPretask> {
     try {
       if (this._superTaskId === 0) {
         let params: IParamBuilder = new RequestParamBuilder().addInitial(this).addInclude('pretaskFiles');
+        if (this.uiService.getUISettings()?.hideImportMasks === '1') {
+          params = params.addFilter({ field: 'isMaskImport', operator: FilterType.EQUAL, value: false });
+        }
         params = this.applyFilterWithPaginationReset(params, activeFilter, query);
         const pretasks = await this.loadPretasks(params.create());
         this.setData(pretasks);

--- a/src/app/core/_datasources/preconfigured-tasks.datasource.ts
+++ b/src/app/core/_datasources/preconfigured-tasks.datasource.ts
@@ -54,7 +54,7 @@ export class PreTasksDataSource extends BaseDataSource<JPretask> {
     try {
       if (this._superTaskId === 0) {
         let params: IParamBuilder = new RequestParamBuilder().addInitial(this).addInclude('pretaskFiles');
-        if (this.uiService.getUISettings()?.hideImportMasks === '1') {
+        if (this.uiService.getUISettings()?.hideImportMasks === 1) {
           params = params.addFilter({ field: 'isMaskImport', operator: FilterType.EQUAL, value: false });
         }
         params = this.applyFilterWithPaginationReset(params, activeFilter, query);

--- a/src/app/core/_datasources/specs/preconfigured-tasks.datasource.spec.ts
+++ b/src/app/core/_datasources/specs/preconfigured-tasks.datasource.spec.ts
@@ -213,8 +213,8 @@ describe('PreTasksDataSource', () => {
       );
     });
 
-    it('should add isMaskImport=false filter when hideImportMasks is "1"', async () => {
-      uiServiceSpy.getUISettings.and.returnValue({ hideImportMasks: '1' } as unknown as UiSettings);
+    it('should add isMaskImport=false filter when hideImportMasks is 1', async () => {
+      uiServiceSpy.getUISettings.and.returnValue({ hideImportMasks: 1 } as unknown as UiSettings);
       await dataSource.loadAll();
       const [, params] = gsSpy.getAll.calls.mostRecent().args;
       expect((params as RequestParams).filter).toContain(
@@ -222,8 +222,8 @@ describe('PreTasksDataSource', () => {
       );
     });
 
-    it('should NOT add isMaskImport filter when hideImportMasks is "0"', async () => {
-      uiServiceSpy.getUISettings.and.returnValue({ hideImportMasks: '0' } as unknown as UiSettings);
+    it('should NOT add isMaskImport filter when hideImportMasks is 0', async () => {
+      uiServiceSpy.getUISettings.and.returnValue({ hideImportMasks: 0 } as unknown as UiSettings);
       await dataSource.loadAll();
       const [, params] = gsSpy.getAll.calls.mostRecent().args;
       const filter: Filter[] = (params as RequestParams).filter ?? [];
@@ -302,8 +302,8 @@ describe('PreTasksDataSource', () => {
       expect(dataSource['loadingSubject'].getValue()).toBeFalse();
     });
 
-    it('should NOT add isMaskImport filter even when hideImportMasks is "1"', async () => {
-      uiServiceSpy.getUISettings.and.returnValue({ hideImportMasks: '1' } as unknown as UiSettings);
+    it('should NOT add isMaskImport filter even when hideImportMasks is 1', async () => {
+      uiServiceSpy.getUISettings.and.returnValue({ hideImportMasks: 1 } as unknown as UiSettings);
       await dataSource.loadAll();
       const [, params] = gsSpy.getAll.calls.mostRecent().args;
       const filter: Filter[] = (params as RequestParams).filter ?? [];

--- a/src/app/core/_datasources/specs/preconfigured-tasks.datasource.spec.ts
+++ b/src/app/core/_datasources/specs/preconfigured-tasks.datasource.spec.ts
@@ -5,6 +5,7 @@ import { of, throwError } from 'rxjs';
 import { ChangeDetectorRef, Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
+import { UiSettings } from '@models/config-ui.schema';
 import { JFile } from '@models/file.model';
 import { JPretask } from '@models/pretask.model';
 import { Filter, FilterType, RequestParams } from '@models/request-params.model';
@@ -71,14 +72,15 @@ const MOCK_SUPERTASK_NO_PRETASKS: JSuperTask = {
 describe('PreTasksDataSource', () => {
   let dataSource: PreTasksDataSource;
   let gsSpy: jasmine.SpyObj<GlobalService>;
+  let uiServiceSpy: jasmine.SpyObj<UIConfigService>;
   let deserializeSpy: jasmine.Spy;
 
   beforeEach(() => {
     gsSpy = jasmine.createSpyObj('GlobalService', ['get', 'getAll']);
 
     const cdrSpy = jasmine.createSpyObj('ChangeDetectorRef', ['markForCheck', 'detectChanges']);
-    const uiServiceSpy = jasmine.createSpyObj('UIConfigService', ['getUISettings']);
-    uiServiceSpy.getUISettings.and.returnValue({});
+    uiServiceSpy = jasmine.createSpyObj('UIConfigService', ['getUISettings']);
+    uiServiceSpy.getUISettings.and.returnValue(null);
     const autoRefreshSpy = jasmine.createSpyObj(
       'AutoRefreshService',
       ['toggleAutoRefresh', 'startAutoRefresh', 'stopAutoRefresh'],
@@ -211,6 +213,31 @@ describe('PreTasksDataSource', () => {
       );
     });
 
+    it('should add isMaskImport=false filter when hideImportMasks is "1"', async () => {
+      uiServiceSpy.getUISettings.and.returnValue({ hideImportMasks: '1' } as unknown as UiSettings);
+      await dataSource.loadAll();
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      expect((params as RequestParams).filter).toContain(
+        jasmine.objectContaining({ field: 'isMaskImport', operator: FilterType.EQUAL, value: false })
+      );
+    });
+
+    it('should NOT add isMaskImport filter when hideImportMasks is "0"', async () => {
+      uiServiceSpy.getUISettings.and.returnValue({ hideImportMasks: '0' } as unknown as UiSettings);
+      await dataSource.loadAll();
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      const filter: Filter[] = (params as RequestParams).filter ?? [];
+      expect(filter.some((f) => f.field === 'isMaskImport')).toBeFalse();
+    });
+
+    it('should NOT add isMaskImport filter when hideImportMasks is absent', async () => {
+      uiServiceSpy.getUISettings.and.returnValue(null);
+      await dataSource.loadAll();
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      const filter: Filter[] = (params as RequestParams).filter ?? [];
+      expect(filter.some((f) => f.field === 'isMaskImport')).toBeFalse();
+    });
+
     it('should set loading to false after a successful response', async () => {
       await dataSource.loadAll();
       expect(dataSource['loadingSubject'].getValue()).toBeFalse();
@@ -273,6 +300,14 @@ describe('PreTasksDataSource', () => {
     it('should set loading to false after response', async () => {
       await dataSource.loadAll();
       expect(dataSource['loadingSubject'].getValue()).toBeFalse();
+    });
+
+    it('should NOT add isMaskImport filter even when hideImportMasks is "1"', async () => {
+      uiServiceSpy.getUISettings.and.returnValue({ hideImportMasks: '1' } as unknown as UiSettings);
+      await dataSource.loadAll();
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      const filter: Filter[] = (params as RequestParams).filter ?? [];
+      expect(filter.some((f) => f.field === 'isMaskImport')).toBeFalse();
     });
   });
 

--- a/src/app/core/_models/config-ui.schema.ts
+++ b/src/app/core/_models/config-ui.schema.ts
@@ -65,7 +65,7 @@ export const uisSettingsSchema = z.preprocess(
     agenttimeout: z.coerce.number().default(0),
     maxSessionLength: z.coerce.number().default(0),
     hashcatBrainEnable: z.coerce.number().default(0),
-    hideImportMasks: z.coerce.string().default('1'),
+    hideImportMasks: z.coerce.number().default(1),
     // String (already strings from API)
     hashlistAlias: z.coerce.string().default('#HL#'),
     blacklistChars: z.coerce.string().default(''),

--- a/src/app/core/_models/config-ui.schema.ts
+++ b/src/app/core/_models/config-ui.schema.ts
@@ -18,7 +18,8 @@ export const uisCacheNames = [
   'agentUtilThreshold2',
   'statustimer',
   'agenttimeout',
-  'maxSessionLength'
+  'maxSessionLength',
+  'hideImportMasks'
 ] as const;
 
 export type UisCacheName = (typeof uisCacheNames)[number];
@@ -64,6 +65,7 @@ export const uisSettingsSchema = z.preprocess(
     agenttimeout: z.coerce.number().default(0),
     maxSessionLength: z.coerce.number().default(0),
     hashcatBrainEnable: z.coerce.number().default(0),
+    hideImportMasks: z.coerce.string().default('1'),
     // String (already strings from API)
     hashlistAlias: z.coerce.string().default('#HL#'),
     blacklistChars: z.coerce.string().default(''),

--- a/src/app/core/_services/metadata.service.ts
+++ b/src/app/core/_services/metadata.service.ts
@@ -1087,6 +1087,13 @@ export class MetadataService {
       type: 'select',
       selectOptions: serverlog,
       tooltip: false
+    },
+    {
+      name: 'hideImportMasks',
+      label: 'Hide Preconfigured Tasks Created by Mask Importer',
+      type: 'checkbox',
+      tooltip: false,
+      fullWidth: true
     }
   ];
 

--- a/src/app/core/_services/shared/storage.service.spec.ts
+++ b/src/app/core/_services/shared/storage.service.spec.ts
@@ -28,6 +28,7 @@ function makeUiSettings(overrides: Partial<UiSettings> = {}): UiSettings {
     hashcatBrainEnable: 0,
     hashlistAlias: '#HL#',
     blacklistChars: '',
+    hideImportMasks: '1',
     _timestamp: Date.now(),
     _expiresin: 72 * 60 * 60 * 1000,
     ...overrides

--- a/src/app/core/_services/shared/storage.service.spec.ts
+++ b/src/app/core/_services/shared/storage.service.spec.ts
@@ -28,7 +28,7 @@ function makeUiSettings(overrides: Partial<UiSettings> = {}): UiSettings {
     hashcatBrainEnable: 0,
     hashlistAlias: '#HL#',
     blacklistChars: '',
-    hideImportMasks: '1',
+    hideImportMasks: 1,
     _timestamp: Date.now(),
     _expiresin: 72 * 60 * 60 * 1000,
     ...overrides


### PR DESCRIPTION
I added hideImportMasks as a required field to the UI settings schema, which also required adding it to the storage service spec to maintain coherence.

The pretasks datasource now reads that config value and, when it is 1, adds false boolean value to the API request so that pretasks created by the mask importer are hidden from the standard preconfigured tasks list. New spec cases cover the hide/show behaviour.

In the config-general tab, The hide option can be enabled/disabled via checkbox. 

The fix can be tested by seeing that every pretask is shown in "tasks/preconfigured-tasks" when the unmarking the checkbox and updating settings. Same otherwise, marking the checkbox and updating settings will make the pretasks created via mask disappear from that tab, only accessible from their corresponding supertask.

Also closes https://github.com/hashtopolis/server/issues/2188