### PR TITLE
The 'benchtime' setting was absent from the Task/Chunk Settings page …

### DIFF
--- a/src/app/core/_services/metadata.service.ts
+++ b/src/app/core/_services/metadata.service.ts
@@ -809,6 +809,12 @@ export class MetadataService {
   servertaskchunk: MetadataFormField[] = [
     { label: 'Benchmark / Chunk', isTitle: true },
     {
+      name: 'benchtime',
+      label: 'Time in Seconds an Agent Should Benchmark a Task',
+      type: 'number',
+      tooltip: false
+    },
+    {
       name: 'chunktime',
       label: 'Expected Chunk Duration',
       type: 'number',


### PR DESCRIPTION
…despite being a valid backend config key. Added it under the

Benchmark/Chunk section in metadata.service.ts.