### PR TITLE
Hide isMaskImport pretasks in supertask detail 

### DIFF
--- a/src/app/core/_datasources/preconfigured-tasks.datasource.ts
+++ b/src/app/core/_datasources/preconfigured-tasks.datasource.ts
@@ -54,9 +54,7 @@ export class PreTasksDataSource extends BaseDataSource<JPretask> {
     try {
       if (this._superTaskId === 0) {
         let params: IParamBuilder = new RequestParamBuilder().addInitial(this).addInclude('pretaskFiles');
-        if (this.uiService.getUISettings()?.hideImportMasks === 1) {
-          params = params.addFilter({ field: 'isMaskImport', operator: FilterType.EQUAL, value: false });
-        }
+        params = this.applyMaskImportFilter(params);
         params = this.applyFilterWithPaginationReset(params, activeFilter, query);
         const pretasks = await this.loadPretasks(params.create());
         this.setData(pretasks);
@@ -73,6 +71,7 @@ export class PreTasksDataSource extends BaseDataSource<JPretask> {
           // If reverseQuery (NOTIN) is requested then NOTIN empty set === all pretasks.
           if (this._reverseQuery) {
             let paramsAll: IParamBuilder = new RequestParamBuilder().addInitial(this).addInclude('pretaskFiles');
+            paramsAll = this.applyMaskImportFilter(paramsAll);
             paramsAll = this.applyFilterWithPaginationReset(paramsAll, activeFilter, query);
             const pretasks = await this.loadPretasks(paramsAll.create());
             this.setData(pretasks);
@@ -87,6 +86,18 @@ export class PreTasksDataSource extends BaseDataSource<JPretask> {
     } finally {
       this.loading = false;
     }
+  }
+
+  /**
+   * Exclude mask-importer pretasks (isMaskImport=true) when the hideImportMasks UI setting is on.
+   * @param params
+   * @private
+   */
+  private applyMaskImportFilter(params: IParamBuilder): IParamBuilder {
+    if (this.uiService.getUISettings()?.hideImportMasks === 1) {
+      return params.addFilter({ field: 'isMaskImport', operator: FilterType.EQUAL, value: false });
+    }
+    return params;
   }
 
   /**
@@ -155,6 +166,9 @@ export class PreTasksDataSource extends BaseDataSource<JPretask> {
         .addInitial(this)
         .addInclude('pretaskFiles')
         .addFilter({ field: 'pretaskId', operator: filterOperator, value: pretaskIds });
+      if (this._reverseQuery) {
+        paramsBuilder = this.applyMaskImportFilter(paramsBuilder);
+      }
       paramsBuilder = this.applyFilterWithPaginationReset(paramsBuilder, activeFilter, query);
       const paramsPretaskFiles = paramsBuilder.create();
       const httpOptions = { headers: new HttpHeaders({ 'X-Skip-Error-Dialog': 'true' }) };

--- a/src/app/core/_datasources/specs/preconfigured-tasks.datasource.spec.ts
+++ b/src/app/core/_datasources/specs/preconfigured-tasks.datasource.spec.ts
@@ -326,6 +326,31 @@ describe('PreTasksDataSource', () => {
         jasmine.objectContaining({ field: 'pretaskId', operator: FilterType.NOTIN, value: [MOCK_PRETASK.id] })
       );
     });
+
+    it('should add isMaskImport=false filter when hideImportMasks is 1', async () => {
+      uiServiceSpy.getUISettings.and.returnValue({ hideImportMasks: 1 } as unknown as UiSettings);
+      await dataSource.loadAll();
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      expect((params as RequestParams).filter).toContain(
+        jasmine.objectContaining({ field: 'isMaskImport', operator: FilterType.EQUAL, value: false })
+      );
+    });
+
+    it('should NOT add isMaskImport filter when hideImportMasks is 0', async () => {
+      uiServiceSpy.getUISettings.and.returnValue({ hideImportMasks: 0 } as unknown as UiSettings);
+      await dataSource.loadAll();
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      const filter: Filter[] = (params as RequestParams).filter ?? [];
+      expect(filter.some((f) => f.field === 'isMaskImport')).toBeFalse();
+    });
+
+    it('should NOT add isMaskImport filter when hideImportMasks is absent', async () => {
+      uiServiceSpy.getUISettings.and.returnValue(null);
+      await dataSource.loadAll();
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      const filter: Filter[] = (params as RequestParams).filter ?? [];
+      expect(filter.some((f) => f.field === 'isMaskImport')).toBeFalse();
+    });
   });
 
   // loadAll() — supertask mode, NO pretasks assigned, reverseQuery=false
@@ -381,6 +406,15 @@ describe('PreTasksDataSource', () => {
       await dataSource.loadAll();
       expect(dataSource.getOriginalData().length).toBe(1);
       expect(dataSource.getOriginalData()[0].taskName).toBe(MOCK_PRETASK.taskName);
+    });
+
+    it('should add isMaskImport=false filter when hideImportMasks is 1', async () => {
+      uiServiceSpy.getUISettings.and.returnValue({ hideImportMasks: 1 } as unknown as UiSettings);
+      await dataSource.loadAll();
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      expect((params as RequestParams).filter).toContain(
+        jasmine.objectContaining({ field: 'isMaskImport', operator: FilterType.EQUAL, value: false })
+      );
     });
   });
 


### PR DESCRIPTION
There is a config value called 'hideImportMasks' that should hide pretasks that were created in Supertask Builder using the insert mask field (import mask).

These pretasks can be hidden in the pretask table. This pr also hides them in the supertasks detail page within the pretasks not part of this supertask table.

Issue: https://github.com/hashtopolis/server/issues/2194