### PR TITLE
supertasks can now be archived

### DIFF
--- a/src/app/core/_components/tables/tasks-table/tasks-table.component.spec.ts
+++ b/src/app/core/_components/tables/tasks-table/tasks-table.component.spec.ts
@@ -10,6 +10,7 @@ import { Router } from '@angular/router';
 import { JTaskWrapperDisplay, TaskStatus, TaskType } from '@models/task.model';
 
 import { ExportService } from '@services/export/export.service';
+import { SERV } from '@services/main.config';
 import { GlobalService } from '@services/main.service';
 import { TasksRoleService } from '@services/roles/tasks/tasks-role.service';
 import { AlertService } from '@services/shared/alert.service';
@@ -695,6 +696,36 @@ describe('TasksTableComponent', () => {
       expect(updateIsArchivedSpy).toHaveBeenCalledWith(123, false);
     });
 
+    it('should call updateTaskWrapperIsArchived for ARCHIVE action on SUPERTASK', () => {
+      const event = {
+        menuItem: { label: 'Archive', action: RowActionMenuAction.ARCHIVE },
+        data: { taskType: TaskType.SUPERTASK, taskWrapperId: 456 } as JTaskWrapperDisplay
+      };
+      const updateTaskWrapperIsArchivedSpy = spyOn(
+        component as unknown as { updateTaskWrapperIsArchived: jasmine.Spy },
+        'updateTaskWrapperIsArchived'
+      );
+
+      component.rowActionClicked(event);
+
+      expect(updateTaskWrapperIsArchivedSpy).toHaveBeenCalledWith(456, true);
+    });
+
+    it('should call updateTaskWrapperIsArchived for UNARCHIVE action on SUPERTASK', () => {
+      const event = {
+        menuItem: { label: 'Unarchive', action: RowActionMenuAction.UNARCHIVE },
+        data: { taskType: TaskType.SUPERTASK, taskWrapperId: 456 } as JTaskWrapperDisplay
+      };
+      const updateTaskWrapperIsArchivedSpy = spyOn(
+        component as unknown as { updateTaskWrapperIsArchived: jasmine.Spy },
+        'updateTaskWrapperIsArchived'
+      );
+
+      component.rowActionClicked(event);
+
+      expect(updateTaskWrapperIsArchivedSpy).toHaveBeenCalledWith(456, false);
+    });
+
     it('should open delete dialog for DELETE action', () => {
       const event = {
         menuItem: { label: 'Delete', action: RowActionMenuAction.DELETE },
@@ -856,6 +887,27 @@ describe('TasksTableComponent', () => {
       expect(mockAlertService.showSuccessMessage).toHaveBeenCalledWith('Successfully archived tasks!');
     });
 
+    it('should call gs.bulkUpdate for TASKS_WRAPPER when archiving a SUPERTASK', () => {
+      mockDialog.open.and.returnValue({
+        afterClosed: () =>
+          of({
+            action: BulkActionMenuAction.ARCHIVE,
+            data: [{ taskType: TaskType.SUPERTASK, taskWrapperId: 10 }]
+          })
+      } as unknown as ReturnType<typeof mockDialog.open>);
+
+      component.openDialog({
+        rows: [{ taskType: TaskType.SUPERTASK, taskWrapperId: 10 }] as JTaskWrapperDisplay[],
+        title: 'Archive',
+        action: BulkActionMenuAction.ARCHIVE
+      });
+
+      expect(mockGlobalService.bulkUpdate).toHaveBeenCalledWith(SERV.TASKS_WRAPPER, jasmine.any(Array), {
+        isArchived: true
+      });
+      expect(mockAlertService.showSuccessMessage).toHaveBeenCalledWith('Successfully archived tasks!');
+    });
+
     it('should call bulkActionDelete for bulk DELETE action', () => {
       mockDialog.open.and.returnValue({
         afterClosed: () =>
@@ -887,6 +939,40 @@ describe('TasksTableComponent', () => {
       });
 
       expect(mockGlobalService.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateTaskWrapperIsArchived', () => {
+    it('should call gs.update with TASKS_WRAPPER endpoint when archiving', () => {
+      (
+        component as unknown as { updateTaskWrapperIsArchived: (id: number, b: boolean) => void }
+      ).updateTaskWrapperIsArchived(456, true);
+
+      expect(mockGlobalService.update).toHaveBeenCalledWith(SERV.TASKS_WRAPPER, 456, { isArchived: true });
+    });
+
+    it('should call gs.update with TASKS_WRAPPER endpoint when unarchiving', () => {
+      (
+        component as unknown as { updateTaskWrapperIsArchived: (id: number, b: boolean) => void }
+      ).updateTaskWrapperIsArchived(456, false);
+
+      expect(mockGlobalService.update).toHaveBeenCalledWith(SERV.TASKS_WRAPPER, 456, { isArchived: false });
+    });
+
+    it('should show "Successfully archived supertask!" on archive success', () => {
+      (
+        component as unknown as { updateTaskWrapperIsArchived: (id: number, b: boolean) => void }
+      ).updateTaskWrapperIsArchived(456, true);
+
+      expect(mockAlertService.showSuccessMessage).toHaveBeenCalledWith('Successfully archived supertask!');
+    });
+
+    it('should show "Successfully unarchived supertask!" on unarchive success', () => {
+      (
+        component as unknown as { updateTaskWrapperIsArchived: (id: number, b: boolean) => void }
+      ).updateTaskWrapperIsArchived(456, false);
+
+      expect(mockAlertService.showSuccessMessage).toHaveBeenCalledWith('Successfully unarchived supertask!');
     });
   });
 

--- a/src/app/core/_components/tables/tasks-table/tasks-table.component.ts
+++ b/src/app/core/_components/tables/tasks-table/tasks-table.component.ts
@@ -1,4 +1,4 @@
-import { Observable, catchError, of } from 'rxjs';
+import { Observable, catchError, forkJoin, of } from 'rxjs';
 
 import { AfterViewInit, Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { SafeHtml } from '@angular/platform-browser';
@@ -612,14 +612,29 @@ export class TasksTableComponent extends BaseTableComponent implements OnInit, O
   private bulkActionArchive(wrappers: JTaskWrapperDisplay[], isArchived: boolean): void {
     const action = isArchived ? 'archived' : 'unarchived';
     const tasks: { id: number }[] = [];
+    const supertaskWrappers: { id: number }[] = [];
     for (const wrapper of wrappers) {
       if (wrapper.taskType === TaskType.TASK && wrapper.taskId !== undefined) {
         tasks.push({ id: wrapper.taskId });
+      } else if (wrapper.taskType === TaskType.SUPERTASK && wrapper.taskWrapperId !== undefined) {
+        supertaskWrappers.push({ id: wrapper.taskWrapperId });
       }
     }
 
+    const requests = [];
+    if (tasks.length > 0) {
+      requests.push(this.gs.bulkUpdate(SERV.TASKS, tasks, { isArchived: isArchived }));
+    }
+    if (supertaskWrappers.length > 0) {
+      requests.push(this.gs.bulkUpdate(SERV.TASKS_WRAPPER, supertaskWrappers, { isArchived: isArchived }));
+    }
+
+    if (requests.length === 0) {
+      return;
+    }
+
     this.subscriptions.push(
-      this.gs.bulkUpdate(SERV.TASKS, tasks, { isArchived: isArchived }).subscribe(() => {
+      forkJoin(requests).subscribe(() => {
         this.alertService.showSuccessMessage(`Successfully ${action} tasks!`);
         this.reload();
       })
@@ -675,12 +690,16 @@ export class TasksTableComponent extends BaseTableComponent implements OnInit, O
   private rowActionArchive(wrapper: JTaskWrapperDisplay): void {
     if (wrapper.taskType === TaskType.TASK && wrapper.taskId) {
       this.updateIsArchived(wrapper.taskId, true);
+    } else if (wrapper.taskType === TaskType.SUPERTASK && wrapper.taskWrapperId) {
+      this.updateTaskWrapperIsArchived(wrapper.taskWrapperId, true);
     }
   }
 
   private rowActionUnarchive(wrapper: JTaskWrapperDisplay): void {
     if (wrapper.taskType === TaskType.TASK && wrapper.taskId) {
       this.updateIsArchived(wrapper.taskId, false);
+    } else if (wrapper.taskType === TaskType.SUPERTASK && wrapper.taskWrapperId) {
+      this.updateTaskWrapperIsArchived(wrapper.taskWrapperId, false);
     }
   }
 
@@ -689,6 +708,16 @@ export class TasksTableComponent extends BaseTableComponent implements OnInit, O
     this.subscriptions.push(
       this.gs.update(SERV.TASKS, taskId, { isArchived: isArchived }).subscribe(() => {
         this.alertService.showSuccessMessage(`Successfully ${strArchived} task!`);
+        this.reload();
+      })
+    );
+  }
+
+  private updateTaskWrapperIsArchived(taskWrapperId: number, isArchived: boolean): void {
+    const strArchived = isArchived ? 'archived' : 'unarchived';
+    this.subscriptions.push(
+      this.gs.update(SERV.TASKS_WRAPPER, taskWrapperId, { isArchived: isArchived }).subscribe(() => {
+        this.alertService.showSuccessMessage(`Successfully ${strArchived} supertask!`);
         this.reload();
       })
     );


### PR DESCRIPTION
For me the issue happened not only for running supertasks, but also for stopped ones. I think it had nothing to do with the running status. This condition if (wrapper.taskType === TaskType.TASK && wrapper.taskId) was blocking the request to be sent for supertasks as they were not being considered. The exact same issue was happening to other methods (rowActionUnarchive and bulkActionArchive) and also fixed them.

Added unit tests for these archive/unarchive actions.