### PR TITLE
2212 enhancement reorder UI fields in some detail pages

### DIFF
--- a/src/app/agents/edit-agent/edit-agent.component.html
+++ b/src/app/agents/edit-agent/edit-agent.component.html
@@ -64,6 +64,7 @@
                   title="Graphic cards"
                   [value]="renderDevices(showagent['devices'])"
                   [minRows]="1"
+                  [rowAligned]="true"
                   [readonly]="true"
                 ></input-text-area>
               }

--- a/src/app/agents/edit-agent/edit-agent.component.html
+++ b/src/app/agents/edit-agent/edit-agent.component.html
@@ -1,72 +1,93 @@
 @if (!isLoading) {
-  <app-page title="Agent Details">
-    <grid-main>
-      <form [formGroup]="updateForm" (ngSubmit)="onSubmit()">
-        @if (showagent) {
-          <app-form-row>
-            <input-text title="Agent ID" value="{{ showagent['id'] }}" [readonly]="true"></input-text>
-            <input-text
-              title="Machine Name"
-              formControlName="agentName"
-              icon="computer"
-              [isRequired]="agentRoleService.hasRole('update')"
-            ></input-text>
-          </app-form-row>
-
-          <app-form-row>
-            <input-select title="Owner" formControlName="userId" [items]="selectUsers"></input-select>
-            <div [formGroup]="updateAssignForm" (ngSubmit)="onSubmit()">
-              <input-select
-                title="Assignment"
-                formControlName="taskId"
-                [items]="assignTasks"
-                [isBlankOptionDisabled]="assignNew"
-                [blankOptionText]="'Unassign'"
-              ></input-select>
-            </div>
-          </app-form-row>
-
-          <app-form-row>
-            <input-select
-              title="Cracker errors"
-              formControlName="ignoreErrors"
-              [items]="selectIgnorerrors"
-            ></input-select>
-            <input-text title="Extra parameters" formControlName="cmdPars"></input-text>
-          </app-form-row>
-
-          <app-form-row align="left">
-            <input-check title="CPU only" formControlName="cpuOnly"></input-check>
-            <input-check title="Trust" formControlName="isTrusted" tooltip="Trust agent with secret data"></input-check>
-            <input-check title="Active" formControlName="isActive"></input-check>
-          </app-form-row>
-        }
-        <mat-accordion>
-          <mat-expansion-panel>
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                <span><strong>Detailed Information</strong></span>
-              </mat-panel-title>
-            </mat-expansion-panel-header>
+  <app-page [title]="pageTitle">
+    <div class="grid grid-cols-12 gap-4">
+      <div class="col-span-12 md:col-span-6">
+        <grid-main class="h-full">
+          <form [formGroup]="updateForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-3">
             @if (showagent) {
-              <div class="grid grid-cols-3 gap-3 items-start">
+              <app-form-row [columns]="2">
+                <input-text title="ID" value="{{ showagent['id'] }}" [readonly]="true"></input-text>
+                <input-select title="Owner" formControlName="userId" [items]="selectUsers"></input-select>
+              </app-form-row>
+
+              <input-text
+                title="Name"
+                formControlName="agentName"
+                icon="computer"
+                [isRequired]="agentRoleService.hasRole('update')"
+              ></input-text>
+
+              <div [formGroup]="updateAssignForm">
+                <input-select
+                  title="Assignment"
+                  formControlName="taskId"
+                  [items]="assignTasks"
+                  [isBlankOptionDisabled]="assignNew"
+                  [blankOptionText]="'Unassign'"
+                ></input-select>
+              </div>
+
+              <input-text title="Extra parameters" formControlName="cmdPars"></input-text>
+
+              <input-select
+                title="Cracker errors"
+                formControlName="ignoreErrors"
+                [items]="selectIgnorerrors"
+              ></input-select>
+
+              <app-form-row align="left">
+                <input-check title="CPU only" formControlName="cpuOnly"></input-check>
+                <input-check
+                  title="Trust"
+                  formControlName="isTrusted"
+                  tooltip="Trust agent with secret data"
+                ></input-check>
+                <input-check title="Active" formControlName="isActive"></input-check>
+              </app-form-row>
+            }
+
+            @if (agentRoleService.hasRole('update')) {
+              <grid-buttons>
+                <button-submit [name]="'Update'" [loading]="isUpdatingLoading"></button-submit>
+              </grid-buttons>
+            }
+          </form>
+        </grid-main>
+      </div>
+
+      <div class="col-span-12 md:col-span-6">
+        <grid-main class="h-full">
+          @if (showagent) {
+            <div class="flex flex-col gap-3">
+              @if (showagent['devices']) {
+                <input-text-area
+                  title="Graphic cards"
+                  [value]="renderDevices(showagent['devices'])"
+                  [minRows]="1"
+                  [readonly]="true"
+                ></input-text-area>
+              }
+
+              <app-form-row [columns]="2">
+                <input-text title="Machine ID" [value]="showagent['uid']" [readonly]="true"></input-text>
+                <input-text title="O.S." [value]="getOsMessage(showagent['os'])" [readonly]="true"></input-text>
+              </app-form-row>
+
+              <app-form-row [columns]="2">
                 <input-text
                   title="Last activity"
                   [value]="showagent['lastTime'] | uiDate"
                   [readonly]="true"
                 ></input-text>
                 <input-text title="Last Action" [value]="showagent['lastAct']" [readonly]="true"></input-text>
-                <input-text title="IP" [value]="showagent['lastIp']" [readonly]="true"></input-text>
-                <input-text title="Machine ID" [value]="showagent['uid']" [readonly]="true"></input-text>
+              </app-form-row>
+
+              <app-form-row [columns]="2">
                 <input-text title="Access token" [value]="showagent['token']" [readonly]="true"></input-text>
-                <input-text title="O.S." [value]="getOsMessage(showagent['os'])" [readonly]="true"></input-text>
-                @if (showagent['devices']) {
-                  <input-text
-                    title="Graphic cards"
-                    [value]="this.renderDevices(showagent['devices'])"
-                    [readonly]="true"
-                  ></input-text>
-                }
+                <input-text title="IP" [value]="showagent['lastIp']" [readonly]="true"></input-text>
+              </app-form-row>
+
+              <app-form-row [columns]="2">
                 @if (agentRoleService.hasRole('readAccessGroup')) {
                   <input-multiselect
                     label="Member of access groups"
@@ -75,21 +96,19 @@
                     [readonly]="true"
                   ></input-multiselect>
                 }
-              </div>
-            }
-            @if (timespent) {
-              <input-text title="Time spent cracking" [value]="timespent | sectotime" [readonly]="true"></input-text>
-            }
-          </mat-expansion-panel>
-        </mat-accordion>
-
-        @if (agentRoleService.hasRole('update')) {
-          <grid-buttons>
-            <button-submit [name]="'Update'" [loading]="isUpdatingLoading"></button-submit>
-          </grid-buttons>
-        }
-      </form>
-    </grid-main>
+                @if (timespent) {
+                  <input-text
+                    title="Time spent cracking"
+                    [value]="timespent | sectotime"
+                    [readonly]="true"
+                  ></input-text>
+                }
+              </app-form-row>
+            </div>
+          }
+        </grid-main>
+      </div>
+    </div>
 
     @if (showagent && agentRoleService.hasRole('readStat')) {
       <app-table>

--- a/src/app/agents/edit-agent/edit-agent.component.ts
+++ b/src/app/agents/edit-agent/edit-agent.component.ts
@@ -70,7 +70,6 @@ export class EditAgentComponent implements OnInit, OnDestroy {
   editedAgentIndex: number;
   showagent: JAgentWith<'agentStats' | 'accessGroups' | 'assignments'>;
 
-  /** Page heading: "Agent <machine name>". */
   pageTitle = 'Agent';
 
   // Calculations

--- a/src/app/agents/edit-agent/edit-agent.component.ts
+++ b/src/app/agents/edit-agent/edit-agent.component.ts
@@ -70,6 +70,9 @@ export class EditAgentComponent implements OnInit, OnDestroy {
   editedAgentIndex: number;
   showagent: JAgentWith<'agentStats' | 'accessGroups' | 'assignments'>;
 
+  /** Page heading: "Agent <machine name>". */
+  pageTitle = 'Agent';
+
   // Calculations
   timespent = 0;
   getchunks: JChunk[] = [];
@@ -267,6 +270,8 @@ export class EditAgentComponent implements OnInit, OnDestroy {
       return;
     }
 
+    this.pageTitle = 'Agent ' + (this.showagent.agentName ?? '');
+
     this.updateForm.setValue({
       isActive: this.showagent.isActive,
       userId: this.showagent.userId ?? null,
@@ -386,9 +391,14 @@ export class EditAgentComponent implements OnInit, OnDestroy {
     }
   }
 
-  // Render devices using count by device type
+  // Render devices using count by device type, one entry per line.
+  // Accepts either real newlines or HTML <br> as the incoming separator.
   renderDevices(devices: string): string {
-    const deviceList = devices.split('\n').filter((d) => !!d.trim());
+    const deviceList = devices
+      .replace(/<br\s*\/?>/gi, '\n')
+      .split('\n')
+      .map((d) => d.trim())
+      .filter((d) => !!d);
     const deviceCountMap: Record<string, number> = {};
 
     deviceList.forEach((device) => {
@@ -397,7 +407,7 @@ export class EditAgentComponent implements OnInit, OnDestroy {
 
     return Object.keys(deviceCountMap)
       .map((device) => `${deviceCountMap[device]} x ${device}`)
-      .join('<br>');
+      .join('\n');
   }
 
   getOsLabel(os: AgentOS): string {

--- a/src/app/config/engine/preprocessors/new_edit-preprocessor/new_edit-preprocessor.component.ts
+++ b/src/app/config/engine/preprocessors/new_edit-preprocessor/new_edit-preprocessor.component.ts
@@ -115,6 +115,8 @@ export class NewEditPreprocessorComponent implements OnInit {
 
     const preprocessor = new JsonAPISerializer().deserialize(response, zPreprocessorResponse);
 
+    this.pageTitle = 'Preprocessor ' + (preprocessor.name ?? '');
+
     this.newEditPreprocessorForm.patchValue({
       name: preprocessor.name,
       binaryName: preprocessor.binaryName,

--- a/src/app/config/health-checks/view-health-check/view-health-checks.component.html
+++ b/src/app/config/health-checks/view-health-check/view-health-checks.component.html
@@ -1,4 +1,4 @@
-<app-page title="Health Check">
+<app-page [title]="healthc ? 'Health Check ' + healthc.id : 'Health Check'">
   <grid-main>
     <div class="flex flex-wrap items-center gap-2">
       <input-text

--- a/src/app/core/_components/forms/simple-forms/form.component.ts
+++ b/src/app/core/_components/forms/simple-forms/form.component.ts
@@ -197,18 +197,25 @@ export class FormComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * In edit mode, when the metadata declares `titlePrefix`/`titleField`, build
-   * the page title as "<Entity> <Name>" from the loaded entity (e.g.
-   * "Wordlist rockyou.txt"). Falls back to just the prefix when the name is blank.
+   * In edit mode, when the metadata declares `titleField`, build the page title
+   * from the loaded entity. `titleField` may name several fields, whose values
+   * are joined with spaces (e.g. "hashcat 6.2.6"). An optional `titlePrefix` is
+   * prepended as a static entity word (e.g. "Wordlist rockyou.txt"). Keeps the
+   * static title when neither prefix nor field yields anything.
    */
   private applyDynamicTitle(): void {
     const { titlePrefix, titleField } = this.globalMetadata;
-    if (!titlePrefix || !titleField) {
+    if (!titleField) {
       return;
     }
-    const name = this.formValues[titleField];
-    this.title = name !== undefined && name !== null && name !== '' ? `${titlePrefix} ${name}` : titlePrefix;
-    this.titleService.set([this.title]);
+    const fields = Array.isArray(titleField) ? titleField : [titleField];
+    const parts = [titlePrefix, ...fields.map((field) => this.formValues[field])].filter(
+      (value) => value !== undefined && value !== null && value !== ''
+    );
+    if (parts.length) {
+      this.title = parts.join(' ');
+      this.titleService.set([this.title]);
+    }
   }
 
   /**

--- a/src/app/core/_components/forms/simple-forms/form.component.ts
+++ b/src/app/core/_components/forms/simple-forms/form.component.ts
@@ -170,6 +170,7 @@ export class FormComponent implements OnInit, OnDestroy {
         this.formValues = this.responseSchema
           ? (new JsonAPISerializer().deserialize(response, this.responseSchema) as Record<string, unknown>)
           : new JsonAPISerializer().deserialize<Record<string, unknown>>(response);
+        this.applyDynamicTitle();
         this.isloaded = true; // Data is loaded and ready for form rendering
       },
       error: (err: unknown) => {
@@ -193,6 +194,21 @@ export class FormComponent implements OnInit, OnDestroy {
     });
 
     this.unsubscribeService.add(editSubscription);
+  }
+
+  /**
+   * In edit mode, when the metadata declares `titlePrefix`/`titleField`, build
+   * the page title as "<Entity> <Name>" from the loaded entity (e.g.
+   * "Wordlist rockyou.txt"). Falls back to just the prefix when the name is blank.
+   */
+  private applyDynamicTitle(): void {
+    const { titlePrefix, titleField } = this.globalMetadata;
+    if (!titlePrefix || !titleField) {
+      return;
+    }
+    const name = this.formValues[titleField];
+    this.title = name !== undefined && name !== null && name !== '' ? `${titlePrefix} ${name}` : titlePrefix;
+    this.titleService.set([this.title]);
   }
 
   /**

--- a/src/app/core/_components/tables/crackers-table/crackers-table.component.ts
+++ b/src/app/core/_components/tables/crackers-table/crackers-table.component.ts
@@ -94,7 +94,7 @@ export class CrackersTableComponent extends BaseTableComponent implements OnInit
         routerLink: (cracker: JCrackerBinaryType) => this.renderVersions(cracker),
         isSortable: false,
         export: async (cracker: JCrackerBinaryType) =>
-          cracker.crackerVersions.map((bin: JCrackerBinary) => bin.version).join(', ')
+          cracker.crackerVersions.map((bin: JCrackerBinary) => `${bin.binaryName} ${bin.version}`).join(', ')
       }
     ];
   }
@@ -221,7 +221,7 @@ export class CrackersTableComponent extends BaseTableComponent implements OnInit
     if (cracker) {
       cracker.crackerVersions.forEach((entry) => {
         links.push({
-          label: entry.version,
+          label: `${entry.binaryName} ${entry.version}`,
           routerLink: ['/config', 'engine', 'crackers', entry.id, 'edit']
         });
       });

--- a/src/app/core/_datasources/hashes.datasource.ts
+++ b/src/app/core/_datasources/hashes.datasource.ts
@@ -1,5 +1,6 @@
 import { zHashListResponse } from '@generated/api/zod';
 import { EMPTY, catchError, finalize } from 'rxjs';
+import { z } from 'zod';
 
 import { JHash } from '@models/hash.model';
 import { Filter, FilterType } from '@models/request-params.model';
@@ -9,6 +10,8 @@ import { SERV } from '@services/main.config';
 import { RequestParamBuilder } from '@services/params/builder-implementation.service';
 
 import { BaseDataSource } from '@datasources/base.datasource';
+
+const crackedFilterSchema = z.enum(['cracked', 'uncracked']);
 
 export class HashesDataSource extends BaseDataSource<JHash> {
   private _id = 0;
@@ -55,8 +58,13 @@ export class HashesDataSource extends BaseDataSource<JHash> {
       } else if (this._dataType === 'hashlists') {
         params.addFilter({ field: 'hashlistId', operator: FilterType.EQUAL, value: this._id });
 
-        if (this._filterparam) {
-          params.addFilter({ field: 'isCracked', operator: FilterType.EQUAL, value: true });
+        const crackedFilter = crackedFilterSchema.safeParse(this._filterparam);
+        if (crackedFilter.success) {
+          params.addFilter({
+            field: 'isCracked',
+            operator: FilterType.EQUAL,
+            value: crackedFilter.data === 'cracked'
+          });
         }
       }
 

--- a/src/app/core/_services/metadata.service.ts
+++ b/src/app/core/_services/metadata.service.ts
@@ -42,9 +42,13 @@ export interface InfoMetadataForm {
   delsubmitok?: string;
   delsubmitokredirect?: string;
   delsubmitcancel?: string;
-  /** In edit mode, build the page title as `${titlePrefix} ${formValues[titleField]}`. */
+  /**
+   * In edit mode, build the page title as `${titlePrefix} ${formValues[titleField]}`.
+   * `titleField` may list several fields (e.g. `['filename', 'version']`), whose
+   * values are joined with spaces — yielding titles like "Agent Binary foo.bin 1.0".
+   */
   titlePrefix?: string;
-  titleField?: string;
+  titleField?: string | string[];
 }
 
 /**
@@ -250,7 +254,7 @@ export class MetadataService {
   editotherInfo = [
     {
       title: 'Edit Other File',
-      titlePrefix: 'Other',
+      titlePrefix: 'Other File',
       titleField: 'filename',
       customform: false,
       subtitle: false,
@@ -364,6 +368,8 @@ export class MetadataService {
   editagentbinaryInfo = [
     {
       title: 'Edit Agent Binary',
+      titlePrefix: 'Agent Binary',
+      titleField: ['filename', 'version'],
       customform: false,
       subtitle: false,
       submitok: 'Agent Binary saved!',
@@ -442,8 +448,7 @@ export class MetadataService {
   editcrackerversionInfo = [
     {
       title: 'Edit Binary Version',
-      titlePrefix: 'Binary Version',
-      titleField: 'version',
+      titleField: ['binaryName', 'version'],
       customform: false,
       subtitle: false,
       submitok: 'Cracker saved!',

--- a/src/app/core/_services/metadata.service.ts
+++ b/src/app/core/_services/metadata.service.ts
@@ -42,6 +42,9 @@ export interface InfoMetadataForm {
   delsubmitok?: string;
   delsubmitokredirect?: string;
   delsubmitcancel?: string;
+  /** In edit mode, build the page title as `${titlePrefix} ${formValues[titleField]}`. */
+  titlePrefix?: string;
+  titleField?: string;
 }
 
 /**
@@ -207,6 +210,8 @@ export class MetadataService {
   editwordlistInfo = [
     {
       title: 'Edit Wordlist File',
+      titlePrefix: 'Wordlist',
+      titleField: 'filename',
       customform: false,
       subtitle: false,
       submitok: 'Saved!',
@@ -225,6 +230,8 @@ export class MetadataService {
   editruleInfo = [
     {
       title: 'Edit Rule File',
+      titlePrefix: 'Rule',
+      titleField: 'filename',
       customform: false,
       subtitle: false,
       submitok: 'Saved!',
@@ -243,6 +250,8 @@ export class MetadataService {
   editotherInfo = [
     {
       title: 'Edit Other File',
+      titlePrefix: 'Other',
+      titleField: 'filename',
       customform: false,
       subtitle: false,
       submitok: 'Saved!',
@@ -261,23 +270,25 @@ export class MetadataService {
   editfile: MetadataFormField[] = [
     { name: 'id', label: 'ID', type: 'number', disabled: true },
     {
-      name: 'filename',
-      label: 'Name',
-      type: 'text',
-      requiredasterisk: true,
-      validators: [Validators.required]
-    },
-    {
       name: 'fileType',
       label: 'File Type',
       type: 'select',
       selectOptions: fileFormat
     },
     {
+      name: 'filename',
+      label: 'Name',
+      type: 'text',
+      requiredasterisk: true,
+      fullWidth: true,
+      validators: [Validators.required]
+    },
+    {
       name: 'accessGroupId',
       label: 'Access group',
       type: 'asyncSelect',
       requiredasterisk: true,
+      fullWidth: true,
       selectEndpoint$: () => this.gs.getRelationships(SERV.USERS, this.gs.userId!, RelationshipType.ACCESSGROUPS),
       selectSchema: zAccessGroupListResponse,
       selectOptions$: [],
@@ -431,6 +442,8 @@ export class MetadataService {
   editcrackerversionInfo = [
     {
       title: 'Edit Binary Version',
+      titlePrefix: 'Binary Version',
+      titleField: 'version',
       customform: false,
       subtitle: false,
       submitok: 'Cracker saved!',
@@ -494,6 +507,7 @@ export class MetadataService {
       label: 'Binary Version',
       type: 'text',
       requiredasterisk: true,
+      fullWidth: true,
       tooltip: false,
       validators: [Validators.required]
     },
@@ -613,6 +627,8 @@ export class MetadataService {
   edithashtypeInfo = [
     {
       title: 'Edit Hashtype',
+      titlePrefix: 'Hashtype',
+      titleField: 'description',
       customform: false,
       subtitle: false,
       submitok: 'Hashtype saved!',
@@ -669,6 +685,7 @@ export class MetadataService {
       label: 'Hashtype',
       type: 'number',
       requiredasterisk: true,
+      fullWidth: true,
       tooltip: 'ie. Hashcat -m',
       validators: [Validators.required, Validators.pattern('^[0-9]*$'), Validators.minLength(1), this.numberValidator],
       disabled: true
@@ -678,6 +695,7 @@ export class MetadataService {
       label: 'Description',
       type: 'text',
       requiredasterisk: true,
+      fullWidth: true,
       tooltip: false,
       validators: [Validators.required, Validators.minLength(1)]
     },

--- a/src/app/hashlists/edit-hashlist/edit-hashlist.component.html
+++ b/src/app/hashlists/edit-hashlist/edit-hashlist.component.html
@@ -1,98 +1,131 @@
 @if (!isLoading) {
-  <app-page [title]="type === 3 ? 'Edit SuperHashlist' : 'Edit Hashlist'">
-    <grid-main [narrow]="true">
-      <form [formGroup]="updateForm" (ngSubmit)="onSubmit()">
-        <input-text title="ID" formControlName="hashlistId"></input-text>
+  <app-page [title]="(type === 3 ? 'SuperHashlist ' : 'Hashlist ') + (editedHashlist?.name ?? '')">
+    <div class="grid grid-cols-12 gap-4">
+      <div class="col-span-12 md:col-span-6">
+        <grid-main>
+          <form [formGroup]="updateForm" (ngSubmit)="onSubmit()">
+            <app-form-row [columns]="2">
+              <input-text title="ID" formControlName="hashlistId"></input-text>
+              <input-text title="Format" formControlName="format"></input-text>
+            </app-form-row>
 
-        <div formGroupName="updateData" class="flex flex-col gap-3">
-          <input-text [isRequired]="true" title="Name" formControlName="name"></input-text>
-          <input-text-area title="Notes" formControlName="notes"></input-text-area>
-          @if (roleService.hasRole('groups')) {
-            <input-select title="Access group" formControlName="accessGroupId" [items]="selectAccessgroup">
-            </input-select>
-          }
-          <input-check title="Secret Data" formControlName="isSecret"></input-check>
-        </div>
+            <div formGroupName="updateData" class="flex flex-col gap-3">
+              <input-text [isRequired]="true" title="Name" formControlName="name"></input-text>
+              <input-text-area title="Notes" formControlName="notes"></input-text-area>
+              @if (roleService.hasRole('groups')) {
+                <input-select title="Access group" formControlName="accessGroupId" [items]="selectAccessgroup">
+                </input-select>
+              }
+            </div>
 
-        <app-form-row [columns]="3">
-          <input-text
-            title="Hash Type"
-            [value]="hashtype?.id + ' - ' + hashtype?.description"
-            [readonly]="true"
-          ></input-text>
-          <input-text
-            title="Using hashcat brain"
-            [value]="editedHashlist?.useBrain ? 'Yes' : 'No'"
-            [readonly]="true"
-          ></input-text>
-          <input-text title="Format" formControlName="format"></input-text>
-          <input-text title="Hashes" formControlName="hashCount"></input-text>
-          <input-text title="Cracked" formControlName="cracked"></input-text>
-          <input-text title="Remaining" formControlName="remaining"></input-text>
-        </app-form-row>
+            <app-form-row [columns]="2">
+              <input-text
+                title="Hash Type"
+                [value]="hashtype?.id + ' - ' + hashtype?.description"
+                [readonly]="true"
+              ></input-text>
+              <input-text
+                title="Using hashcat brain"
+                [value]="editedHashlist?.useBrain ? 'Yes' : 'No'"
+                [readonly]="true"
+              ></input-text>
+              <input-text
+                title="Hashes"
+                formControlName="hashCount"
+                [linkTo]="['/hashlists', 'hashes', 'hashlists', editedHashlistIndex]"
+                [linkIcon]="true"
+                [readonly]="true"
+              ></input-text>
+              <input-text
+                title="Cracked"
+                formControlName="cracked"
+                [linkTo]="['/hashlists', 'hashes', 'hashlists', editedHashlistIndex]"
+                [linkIcon]="true"
+                [readonly]="true"
+              ></input-text>
+            </app-form-row>
 
-        <grid-buttons>
-          <button-submit [name]="'Update'" [disabled]="!roleService.hasRole('update')"></button-submit>
-        </grid-buttons>
-      </form>
+            <app-form-row [columns]="2">
+              <input-text
+                title="Remaining"
+                formControlName="remaining"
+                [linkTo]="['/hashlists', 'hashes', 'hashlists', editedHashlistIndex]"
+                [linkIcon]="true"
+                [readonly]="true"
+              ></input-text>
+            </app-form-row>
 
-      <!-- If its cracked or partially cracked then show additional actions -->
-      <app-page-subtitle subtitle="Actions"></app-page-subtitle>
+            <app-form-row align="left">
+              <div formGroupName="updateData">
+                <input-check title="Secret Data" formControlName="isSecret"></input-check>
+              </div>
+            </app-form-row>
 
-      <div class="flex flex-wrap items-center gap-3">
-        <button-submit
-          [name]="'Import pre-cracked hashes'"
-          (click)="importCrackedHashes()"
-          [disabled]="!roleService.hasRole('update')"
-        >
-        </button-submit>
-
-        @if ((editedHashlist?.cracked ?? 0) > 0) {
-          <button-submit
-            [name]="'Export hashes for pre-crack'"
-            (click)="exortPreCrackedHashes()"
-            [disabled]="!roleService.hasRole('read')"
-          >
-          </button-submit>
-        }
-
-        <button-submit [name]="'Show Hashes'" (click)="goToHashes()" [disabled]="!roleService.hasRole('read')">
-        </button-submit>
-
-        @if ((editedHashlist?.cracked ?? 0) > 0) {
-          <button-submit
-            [name]="'Generate Wordlist'"
-            (click)="exportWordlist()"
-            [disabled]="!roleService.hasRole('wordlist')"
-          >
-          </button-submit>
-        }
-
-        @if ((editedHashlist?.cracked ?? 0) > 0) {
-          <button-submit
-            [name]="'Export Left Hashes'"
-            (click)="exportLeftHashes()"
-            [disabled]="!roleService.hasRole('wordlist')"
-          >
-          </button-submit>
-        }
+            <grid-buttons>
+              <button-submit [name]="'Update'" [disabled]="!roleService.hasRole('update')"></button-submit>
+            </grid-buttons>
+          </form>
+        </grid-main>
       </div>
 
-      @if ((editedHashlist?.cracked ?? 0) > 0 && roleService.hasRole('tasks')) {
-        <br />
-        <mat-accordion>
-          <mat-expansion-panel>
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                <span><strong>Report Builder</strong></span>
-              </mat-panel-title>
-            </mat-expansion-panel-header>
+      <!-- If its cracked or partially cracked then show additional actions -->
+      <div class="col-span-12 md:col-span-6">
+        <grid-main>
+          <app-page-subtitle subtitle="Actions"></app-page-subtitle>
 
-            <hashlist-report [hashlistId]="editedHashlistIndex"></hashlist-report>
-          </mat-expansion-panel>
-        </mat-accordion>
-      }
-    </grid-main>
+          <div class="flex flex-wrap items-center gap-3">
+            <button-submit
+              [name]="'Import pre-cracked hashes'"
+              (click)="importCrackedHashes()"
+              [disabled]="!roleService.hasRole('update')"
+            >
+            </button-submit>
+
+            @if ((editedHashlist?.cracked ?? 0) > 0) {
+              <button-submit
+                [name]="'Export cracked hashes'"
+                (click)="exortPreCrackedHashes()"
+                [disabled]="!roleService.hasRole('read')"
+              >
+              </button-submit>
+            }
+
+            @if ((editedHashlist?.cracked ?? 0) > 0) {
+              <button-submit
+                [name]="'Generate Wordlist'"
+                (click)="exportWordlist()"
+                [disabled]="!roleService.hasRole('wordlist')"
+              >
+              </button-submit>
+            }
+
+            @if ((editedHashlist?.cracked ?? 0) > 0) {
+              <button-submit
+                [name]="'Export Left Hashes'"
+                (click)="exportLeftHashes()"
+                [disabled]="!roleService.hasRole('wordlist')"
+              >
+              </button-submit>
+            }
+          </div>
+
+          @if ((editedHashlist?.cracked ?? 0) > 0 && roleService.hasRole('tasks')) {
+            <br />
+            <mat-accordion>
+              <mat-expansion-panel>
+                <mat-expansion-panel-header>
+                  <mat-panel-title>
+                    <span><strong>Report Builder</strong></span>
+                  </mat-panel-title>
+                </mat-expansion-panel-header>
+
+                <hashlist-report [hashlistId]="editedHashlistIndex"></hashlist-report>
+              </mat-expansion-panel>
+            </mat-accordion>
+          }
+        </grid-main>
+      </div>
+    </div>
 
     @if (type === 3) {
       <app-table>

--- a/src/app/hashlists/edit-hashlist/edit-hashlist.component.html
+++ b/src/app/hashlists/edit-hashlist/edit-hashlist.component.html
@@ -38,7 +38,7 @@
               <input-text
                 title="Cracked"
                 formControlName="cracked"
-                [linkTo]="['/hashlists', 'hashes', 'hashlists', editedHashlistIndex]"
+                [linkTo]="['/hashlists', 'hashes', 'hashlists', editedHashlistIndex + '?cracked']"
                 [readonly]="true"
               ></input-text>
             </app-form-row>
@@ -47,7 +47,7 @@
               <input-text
                 title="Remaining"
                 formControlName="remaining"
-                [linkTo]="['/hashlists', 'hashes', 'hashlists', editedHashlistIndex]"
+                [linkTo]="['/hashlists', 'hashes', 'hashlists', editedHashlistIndex + '?uncracked']"
                 [readonly]="true"
               ></input-text>
             </app-form-row>

--- a/src/app/hashlists/edit-hashlist/edit-hashlist.component.html
+++ b/src/app/hashlists/edit-hashlist/edit-hashlist.component.html
@@ -33,14 +33,12 @@
                 title="Hashes"
                 formControlName="hashCount"
                 [linkTo]="['/hashlists', 'hashes', 'hashlists', editedHashlistIndex]"
-                [linkIcon]="true"
                 [readonly]="true"
               ></input-text>
               <input-text
                 title="Cracked"
                 formControlName="cracked"
                 [linkTo]="['/hashlists', 'hashes', 'hashlists', editedHashlistIndex]"
-                [linkIcon]="true"
                 [readonly]="true"
               ></input-text>
             </app-form-row>
@@ -50,7 +48,6 @@
                 title="Remaining"
                 formControlName="remaining"
                 [linkTo]="['/hashlists', 'hashes', 'hashlists', editedHashlistIndex]"
-                [linkIcon]="true"
                 [readonly]="true"
               ></input-text>
             </app-form-row>

--- a/src/app/hashlists/edit-hashlist/edit-hashlist.component.html
+++ b/src/app/hashlists/edit-hashlist/edit-hashlist.component.html
@@ -50,10 +50,7 @@
                 [linkTo]="['/hashlists', 'hashes', 'hashlists', editedHashlistIndex + '?uncracked']"
                 [readonly]="true"
               ></input-text>
-            </app-form-row>
-
-            <app-form-row align="left">
-              <div formGroupName="updateData">
+              <div formGroupName="updateData" class="self-end">
                 <input-check title="Secret Data" formControlName="isSecret"></input-check>
               </div>
             </app-form-row>
@@ -70,7 +67,7 @@
         <grid-main>
           <app-page-subtitle subtitle="Actions"></app-page-subtitle>
 
-          <div class="flex flex-wrap items-center gap-3">
+          <div class="flex flex-col items-start gap-3">
             <button-submit
               [name]="'Import pre-cracked hashes'"
               (click)="importCrackedHashes()"

--- a/src/app/hashlists/edit-hashlist/edit-hashlist.component.spec.ts
+++ b/src/app/hashlists/edit-hashlist/edit-hashlist.component.spec.ts
@@ -1,11 +1,13 @@
 import { of } from 'rxjs';
 
+import { provideLocationMocks } from '@angular/common/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { By } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { ResponseWrapper } from '@models/response.model';
@@ -21,6 +23,7 @@ import { UnsubscribeService } from '@services/unsubscribe.service';
 
 import { StaticArrayPipe } from '@src/app/core/_pipes/static-array.pipe';
 import { EditHashlistComponent } from '@src/app/hashlists/edit-hashlist/edit-hashlist.component';
+import { InputTextComponent } from '@src/app/shared/input/text/text.component';
 import { ButtonsModule } from '@src/app/shared/buttons/buttons.module';
 import { ComponentsModule } from '@src/app/shared/components.module';
 import { InputModule } from '@src/app/shared/input/input.module';
@@ -128,7 +131,9 @@ describe('EditHashlistComponent', () => {
     alertSpy = jasmine.createSpyObj('AlertService', ['showSuccessMessage', 'showErrorMessage']);
     titleSpy = jasmine.createSpyObj('AutoTitleService', ['set']);
     unsubSpy = jasmine.createSpyObj('UnsubscribeService', ['add', 'unsubscribeAll']);
-    routerSpy = jasmine.createSpyObj('Router', ['navigate', 'navigateByUrl']);
+    routerSpy = jasmine.createSpyObj('Router', ['navigate', 'navigateByUrl', 'createUrlTree', 'serializeUrl'], {
+      events: of()
+    });
     configSpy = jasmine.createSpyObj('ConfigService', ['getEndpoint']);
     unsavedChangesSpy = jasmine.createSpyObj('UnsavedChangesService', ['setUnsavedChanges']);
     roleServiceSpy = jasmine.createSpyObj('HashListRoleService', ['hasRole']);
@@ -160,7 +165,8 @@ describe('EditHashlistComponent', () => {
         {
           provide: ActivatedRoute,
           useValue: { params: of({ id: '1' }) }
-        }
+        },
+        provideLocationMocks()
       ]
     }).compileComponents();
 
@@ -438,15 +444,29 @@ describe('EditHashlistComponent', () => {
   });
 
   describe('goToHashes', () => {
-    it('should navigate to hashes page', () => {
+    it('should link the Hashes, Cracked and Remaining fields to the hashes page', fakeAsync(() => {
+      // Suppress the role-gated tasks table and report-builder panel so the form
+      // renders without their extra data requests; the link fields are not gated.
+      roleServiceSpy.hasRole.and.returnValue(false);
+      // RouterLink computes an href via the mocked Router; give serializeUrl a
+      // string so MockLocationStrategy doesn't choke while rendering the anchors.
+      routerSpy.serializeUrl.and.returnValue('/');
       initComponent();
       respondToHashlistRequest(mockHashlistResponse());
       component.editedHashlistIndex = 42;
+      tick();
+      fixture.detectChanges();
 
-      component.goToHashes();
+      const linkedFields = fixture.debugElement
+        .queryAll(By.directive(InputTextComponent))
+        .map((de) => de.componentInstance as InputTextComponent)
+        .filter((input) => ['Hashes', 'Cracked', 'Remaining'].includes(input.title));
 
-      expect(routerSpy.navigate).toHaveBeenCalledWith(['/hashlists', 'hashes', 'hashlists', 42]);
-    });
+      expect(linkedFields.map((input) => input.title)).toEqual(['Hashes', 'Cracked', 'Remaining']);
+      for (const input of linkedFields) {
+        expect(input.linkTo).toEqual(['/hashlists', 'hashes', 'hashlists', 42]);
+      }
+    }));
   });
 
   describe('canDeactivate', () => {

--- a/src/app/hashlists/edit-hashlist/edit-hashlist.component.spec.ts
+++ b/src/app/hashlists/edit-hashlist/edit-hashlist.component.spec.ts
@@ -1,7 +1,7 @@
 import { of } from 'rxjs';
 
-import { provideLocationMocks } from '@angular/common/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideLocationMocks } from '@angular/common/testing';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatExpansionModule } from '@angular/material/expansion';
@@ -23,10 +23,10 @@ import { UnsubscribeService } from '@services/unsubscribe.service';
 
 import { StaticArrayPipe } from '@src/app/core/_pipes/static-array.pipe';
 import { EditHashlistComponent } from '@src/app/hashlists/edit-hashlist/edit-hashlist.component';
-import { InputTextComponent } from '@src/app/shared/input/text/text.component';
 import { ButtonsModule } from '@src/app/shared/buttons/buttons.module';
 import { ComponentsModule } from '@src/app/shared/components.module';
 import { InputModule } from '@src/app/shared/input/input.module';
+import { InputTextComponent } from '@src/app/shared/input/text/text.component';
 import { PageSubTitleComponent } from '@src/app/shared/page-headers/page-subtitle/page-subtitle.component';
 import { mockResponse } from '@src/app/testing/mock-response';
 

--- a/src/app/hashlists/edit-hashlist/edit-hashlist.component.spec.ts
+++ b/src/app/hashlists/edit-hashlist/edit-hashlist.component.spec.ts
@@ -457,15 +457,20 @@ describe('EditHashlistComponent', () => {
       tick();
       fixture.detectChanges();
 
-      const linkedFields = fixture.debugElement
-        .queryAll(By.directive(InputTextComponent))
-        .map((de) => de.componentInstance as InputTextComponent)
-        .filter((input) => ['Hashes', 'Cracked', 'Remaining'].includes(input.title));
+      const linkByTitle = new Map(
+        fixture.debugElement
+          .queryAll(By.directive(InputTextComponent))
+          .map((de) => de.componentInstance as InputTextComponent)
+          .filter((input) => ['Hashes', 'Cracked', 'Remaining'].includes(input.title))
+          .map((input) => [input.title, input.linkTo])
+      );
 
-      expect(linkedFields.map((input) => input.title)).toEqual(['Hashes', 'Cracked', 'Remaining']);
-      for (const input of linkedFields) {
-        expect(input.linkTo).toEqual(['/hashlists', 'hashes', 'hashlists', 42]);
-      }
+      expect([...linkByTitle.keys()]).toEqual(['Hashes', 'Cracked', 'Remaining']);
+      // Hashes links to the unfiltered list; Cracked/Remaining pack the filter into
+      // the :id segment (split on '?' in hashes.component.ts) for cracked/uncracked views.
+      expect(linkByTitle.get('Hashes')).toEqual(['/hashlists', 'hashes', 'hashlists', 42]);
+      expect(linkByTitle.get('Cracked')).toEqual(['/hashlists', 'hashes', 'hashlists', '42?cracked']);
+      expect(linkByTitle.get('Remaining')).toEqual(['/hashlists', 'hashes', 'hashlists', '42?uncracked']);
     }));
   });
 

--- a/src/app/hashlists/edit-hashlist/edit-hashlist.component.ts
+++ b/src/app/hashlists/edit-hashlist/edit-hashlist.component.ts
@@ -259,13 +259,6 @@ export class EditHashlistComponent implements OnInit, OnDestroy, CanComponentDea
     this.unsubscribeService.add(helperExportedWordlistSubscription$);
   }
 
-  /**
-   * Navigate to the hashes view for this hashlist.
-   */
-  goToHashes(): void {
-    this.router.navigate(['/hashlists', 'hashes', 'hashlists', this.editedHashlistIndex]);
-  }
-
   canDeactivate(): boolean {
     const hasUnsavedChanges = this.updateForm.dirty;
 

--- a/src/app/shared/grid-containers/grid-main.scss
+++ b/src/app/shared/grid-containers/grid-main.scss
@@ -2,6 +2,12 @@
   display: block;
 }
 
+/* When the host is told to fill its container (e.g. `h-full` in an equal-height
+   grid row), stretch the inner card so its border matches the row height. */
+:host(.h-full) .grid-main {
+  height: 100%;
+}
+
 :host(.grid-main--narrow) {
   @media (min-width: 768px) {
     max-width: calc(50% - var(--space-xs));

--- a/src/app/shared/input/color/color.component.scss
+++ b/src/app/shared/input/color/color.component.scss
@@ -14,9 +14,17 @@ input-color {
     flex: 1;
   }
 
+  // Swatch height drives the field box, so drop the infix's own padding.
+  .field-stack__field.mat-mdc-form-field .mat-mdc-form-field-infix {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
   input[type='color'] {
     width: 100%;
-    min-height: 28px;
+    // Match a text-field row, minus the ~2px form-field chrome (as _material.scss:71).
+    min-height: calc(var(--input-row-height) - 2px);
+    box-sizing: border-box;
     padding: 0;
     background: none;
     border: 1px solid var(--border);

--- a/src/app/shared/input/text-area/text-area.component.html
+++ b/src/app/shared/input/text-area/text-area.component.html
@@ -1,4 +1,9 @@
-<div class="field-stack" [class.is-invalid]="hasError && isTouched && !readonly" [class.input--readonly]="readonly">
+<div
+  class="field-stack"
+  [class.is-invalid]="hasError && isTouched && !readonly"
+  [class.input--readonly]="readonly"
+  [class.field-stack--row-aligned]="rowAligned"
+>
   <label class="field-stack__label" [attr.for]="inputId">
     @if (linkTo) {
       <a [routerLink]="linkTo">{{ title }}</a>

--- a/src/app/shared/input/text-area/text-area.component.ts
+++ b/src/app/shared/input/text-area/text-area.component.ts
@@ -33,6 +33,8 @@ import { AbstractInputComponent } from '@src/app/shared/input/abstract-input';
 export class InputTextAreaComponent extends AbstractInputComponent<string> {
   @Input() minRows = 3;
   @Input() maxRows = 12;
+  /** Snap each line to one input-row height so the field grows in whole rows. */
+  @Input() rowAligned = false;
 
   onValueChange(event: Event): void {
     const target = event.target as HTMLTextAreaElement;

--- a/src/app/shared/input/text/text.component.html
+++ b/src/app/shared/input/text/text.component.html
@@ -1,16 +1,14 @@
 <div class="field-stack" [class.is-invalid]="hasError && isTouched && !readonly" [class.input--readonly]="readonly">
   <label class="field-stack__label" [attr.for]="inputId">
-    @if (linkTo && !linkIcon) {
-      <a [routerLink]="linkTo">{{ title }}</a>
+    @if (linkTo) {
+      <a [routerLink]="linkTo" class="field-stack__label-link" [attr.aria-label]="'Open ' + title">
+        {{ title }}
+        <mat-icon aria-hidden="true">open_in_new</mat-icon>
+      </a>
     } @else {
       <span class="field-stack__label-text">
         {{ title }}
       </span>
-      @if (linkTo && linkIcon) {
-        <a [routerLink]="linkTo" class="field-stack__label-link" [attr.aria-label]="'Open ' + title">
-          <mat-icon>open_in_new</mat-icon>
-        </a>
-      }
     }
     @if (isRequired && !readonly) {
       <span class="field-stack__required" aria-hidden="true">*</span>

--- a/src/app/shared/input/text/text.component.html
+++ b/src/app/shared/input/text/text.component.html
@@ -1,11 +1,16 @@
 <div class="field-stack" [class.is-invalid]="hasError && isTouched && !readonly" [class.input--readonly]="readonly">
   <label class="field-stack__label" [attr.for]="inputId">
-    @if (linkTo) {
+    @if (linkTo && !linkIcon) {
       <a [routerLink]="linkTo">{{ title }}</a>
     } @else {
       <span class="field-stack__label-text">
         {{ title }}
       </span>
+      @if (linkTo && linkIcon) {
+        <a [routerLink]="linkTo" class="field-stack__label-link" [attr.aria-label]="'Open ' + title">
+          <mat-icon>open_in_new</mat-icon>
+        </a>
+      }
     }
     @if (isRequired && !readonly) {
       <span class="field-stack__required" aria-hidden="true">*</span>

--- a/src/app/shared/input/text/text.component.ts
+++ b/src/app/shared/input/text/text.component.ts
@@ -34,8 +34,6 @@ export class InputTextComponent extends AbstractInputComponent<string> {
   @Input() pattern: string | RegExp;
   @Input() inputType: 'text' | 'password' | 'email' | 'url' = 'text';
   @Input() icon: string;
-  /** When true and `linkTo` is set, the label keeps plain text and shows a clickable link icon next to it. */
-  @Input() linkIcon = false;
   @Input() minLength?: number;
   @Input() maxLength?: number;
   @Input() showPasswordToggle: boolean = false;

--- a/src/app/shared/input/text/text.component.ts
+++ b/src/app/shared/input/text/text.component.ts
@@ -34,6 +34,8 @@ export class InputTextComponent extends AbstractInputComponent<string> {
   @Input() pattern: string | RegExp;
   @Input() inputType: 'text' | 'password' | 'email' | 'url' = 'text';
   @Input() icon: string;
+  /** When true and `linkTo` is set, the label keeps plain text and shows a clickable link icon next to it. */
+  @Input() linkIcon = false;
   @Input() minLength?: number;
   @Input() maxLength?: number;
   @Input() showPasswordToggle: boolean = false;

--- a/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.html
+++ b/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.html
@@ -28,6 +28,12 @@
                   formControlName="chunkTime"
                 ></input-number>
                 <input-select
+                  title="Benchmark Type"
+                  formControlName="useNewBench"
+                  [items]="selectBenchmarktype"
+                  [readonly]="true"
+                ></input-select>
+                <input-select
                   title="CPU only"
                   tooltip="The task will work only with CPU agents assigned"
                   formControlName="isCpuTask"
@@ -39,15 +45,6 @@
                   tooltip="Measured in seconds"
                   formControlName="statusTimer"
                 ></input-number>
-              </app-form-row>
-
-              <app-form-row [columns]="2">
-                <input-select
-                  title="Benchmark Type"
-                  formControlName="useNewBench"
-                  [items]="selectBenchmarktype"
-                  [readonly]="true"
-                ></input-select>
               </app-form-row>
             </div>
 

--- a/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.html
+++ b/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.html
@@ -4,11 +4,14 @@
       <div class="col-span-12 md:col-span-6">
         <grid-main>
           <form [formGroup]="updateForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-3">
-            <input-text title="ID" formControlName="pretaskId"></input-text>
+            <app-form-row [columns]="2">
+              <input-text title="ID" formControlName="pretaskId"></input-text>
+              <ng-container formGroupName="updateData">
+                <input-color title="Color" formControlName="color"></input-color>
+              </ng-container>
+            </app-form-row>
 
             <div formGroupName="updateData" class="flex flex-col gap-3">
-              <input-color title="Color" formControlName="color"></input-color>
-
               <input-text title="Name" formControlName="taskName" [isRequired]="!isReadOnly"></input-text>
               <input-text-area
                 title="Attack command"

--- a/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.html
+++ b/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.html
@@ -1,52 +1,57 @@
 @if (!isLoading) {
-  <app-page title="Edit Preconfigured Tasks">
-    <grid-main [narrow]="true">
-      <form [formGroup]="updateForm" (ngSubmit)="onSubmit()">
-        <input-text title="ID" formControlName="pretaskId"></input-text>
+  <app-page [title]="'Preconfigured Task ' + pretaskName">
+    <div class="grid grid-cols-12 gap-4">
+      <div class="col-span-12 md:col-span-6">
+        <grid-main>
+          <form [formGroup]="updateForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-3">
+            <input-text title="ID" formControlName="pretaskId"></input-text>
 
-        <div formGroupName="updateData" class="flex flex-col gap-3">
-          <input-text title="Name" formControlName="taskName" [isRequired]="!isReadOnly"></input-text>
-          <input-color title="Color" formControlName="color"></input-color>
-          <input-text-area
-            title="Attack command"
-            formControlName="attackCmd"
-            [isRequired]="!isReadOnly"
-          ></input-text-area>
-        </div>
+            <div formGroupName="updateData" class="flex flex-col gap-3">
+              <input-color title="Color" formControlName="color"></input-color>
 
-        <app-form-row formGroupName="updateData" [columns]="3">
-          <input-number title="Priority" formControlName="priority"></input-number>
-          <input-number title="Max agents" formControlName="maxAgents"></input-number>
-          <input-number title="Chunk time" tooltip="Measured in seconds" formControlName="chunkTime"></input-number>
-          <input-select
-            title="CPU only"
-            tooltip="The task will work only with CPU agents assigned"
-            formControlName="isCpuTask"
-            [items]="selectYesno"
-          ></input-select>
-          <input-select title="Small task" formControlName="isSmall" [items]="selectYesno"></input-select>
-        </app-form-row>
+              <input-text title="Name" formControlName="taskName" [isRequired]="!isReadOnly"></input-text>
+              <input-text-area
+                title="Attack command"
+                formControlName="attackCmd"
+                [isRequired]="!isReadOnly"
+              ></input-text-area>
 
-        <app-form-row>
-          <input-text title="Benchmark Type" formControlName="useNewBench"></input-text>
-          <input-text title="Status timer" formControlName="statusTimer"></input-text>
-        </app-form-row>
+              <app-form-row [columns]="2">
+                <input-number title="Priority" formControlName="priority"></input-number>
+                <input-number title="Max agents" formControlName="maxAgents"></input-number>
+                <input-number
+                  title="Chunk time"
+                  tooltip="Measured in seconds"
+                  formControlName="chunkTime"
+                ></input-number>
+                <input-select
+                  title="Benchmark Type"
+                  formControlName="useNewBench"
+                  [items]="selectBenchmarktype"
+                ></input-select>
+                <input-select
+                  title="CPU only"
+                  tooltip="The task will work only with CPU agents assigned"
+                  formControlName="isCpuTask"
+                  [items]="selectYesno"
+                ></input-select>
+                <input-select title="Small task" formControlName="isSmall" [items]="selectYesno"></input-select>
+                <input-text title="Status timer" formControlName="statusTimer"></input-text>
+              </app-form-row>
+            </div>
 
-        @if (roleService.hasRole('edit')) {
-          <grid-buttons>
-            <button-submit [name]="'Update'" [loading]="isUpdatingLoading"></button-submit>
-          </grid-buttons>
-        }
-      </form>
+            @if (roleService.hasRole('edit')) {
+              <grid-buttons>
+                <button-submit [name]="'Update'" [loading]="isUpdatingLoading"></button-submit>
+              </grid-buttons>
+            }
+          </form>
+        </grid-main>
+      </div>
 
-      <mat-accordion>
-        <mat-expansion-panel>
-          <mat-expansion-panel-header>
-            <mat-panel-title>
-              <span><strong>Files</strong></span>
-            </mat-panel-title>
-          </mat-expansion-panel-header>
-
+      <div class="col-span-12 md:col-span-6">
+        <grid-main>
+          <app-page-subtitle subtitle="Files"></app-page-subtitle>
           <app-files-table
             #table
             name="filesTableInPreTasks"
@@ -60,8 +65,8 @@
             [editIndex]="editedPretaskIndex"
             [editType]="1"
           ></app-files-table>
-        </mat-expansion-panel>
-      </mat-accordion>
-    </grid-main>
+        </grid-main>
+      </div>
+    </div>
   </app-page>
 }

--- a/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.html
+++ b/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.html
@@ -25,18 +25,26 @@
                   formControlName="chunkTime"
                 ></input-number>
                 <input-select
-                  title="Benchmark Type"
-                  formControlName="useNewBench"
-                  [items]="selectBenchmarktype"
-                ></input-select>
-                <input-select
                   title="CPU only"
                   tooltip="The task will work only with CPU agents assigned"
                   formControlName="isCpuTask"
                   [items]="selectYesno"
                 ></input-select>
                 <input-select title="Small task" formControlName="isSmall" [items]="selectYesno"></input-select>
-                <input-text title="Status timer" formControlName="statusTimer"></input-text>
+                <input-number
+                  title="Status timer"
+                  tooltip="Measured in seconds"
+                  formControlName="statusTimer"
+                ></input-number>
+              </app-form-row>
+
+              <app-form-row [columns]="2">
+                <input-select
+                  title="Benchmark Type"
+                  formControlName="useNewBench"
+                  [items]="selectBenchmarktype"
+                  [readonly]="true"
+                ></input-select>
               </app-form-row>
             </div>
 

--- a/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.ts
+++ b/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.ts
@@ -49,7 +49,6 @@ export class EditPreconfiguredTasksComponent implements OnInit, OnDestroy {
   // Edit Options
   editedPretaskIndex: number;
 
-  /** Name of the loaded pretask, used for the page title. */
   pretaskName = '';
 
   /** Read-only mode based on roles */

--- a/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.ts
+++ b/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.ts
@@ -20,8 +20,8 @@ import { AutoTitleService } from '@services/shared/autotitle.service';
 import { ConfigService } from '@services/shared/config.service';
 import { UnsubscribeService } from '@services/unsubscribe.service';
 
-import { benchmarkType } from '@src/app/core/_constants/tasks.config';
 import { yesNo } from '@src/app/core/_constants/general.config';
+import { benchmarkType } from '@src/app/core/_constants/tasks.config';
 import { attackCommandWithAliasValidator } from '@src/app/core/_validators/attack-command.validator';
 
 /**

--- a/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.ts
+++ b/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.ts
@@ -20,6 +20,7 @@ import { AutoTitleService } from '@services/shared/autotitle.service';
 import { ConfigService } from '@services/shared/config.service';
 import { UnsubscribeService } from '@services/unsubscribe.service';
 
+import { benchmarkType } from '@src/app/core/_constants/tasks.config';
 import { yesNo } from '@src/app/core/_constants/general.config';
 import { attackCommandWithAliasValidator } from '@src/app/core/_validators/attack-command.validator';
 
@@ -43,9 +44,13 @@ export class EditPreconfiguredTasksComponent implements OnInit, OnDestroy {
 
   /** Select Options. */
   selectYesno = yesNo;
+  selectBenchmarktype = benchmarkType;
 
   // Edit Options
   editedPretaskIndex: number;
+
+  /** Name of the loaded pretask, used for the page title. */
+  pretaskName = '';
 
   /** Read-only mode based on roles */
   isReadOnly = false;
@@ -122,8 +127,6 @@ export class EditPreconfiguredTasksComponent implements OnInit, OnDestroy {
   buildForm(): void {
     this.updateForm = new FormGroup({
       pretaskId: new FormControl({ value: '', disabled: true }),
-      statusTimer: new FormControl({ value: '', disabled: true }),
-      useNewBench: new FormControl({ value: '', disabled: true }),
       updateData: new FormGroup({
         taskName: new FormControl(
           { value: '', disabled: this.isReadOnly },
@@ -138,7 +141,9 @@ export class EditPreconfiguredTasksComponent implements OnInit, OnDestroy {
         priority: new FormControl({ value: '', disabled: this.isReadOnly }),
         maxAgents: new FormControl({ value: '', disabled: this.isReadOnly }),
         isCpuTask: new FormControl({ value: '', disabled: this.isReadOnly }),
-        isSmall: new FormControl({ value: '', disabled: this.isReadOnly })
+        isSmall: new FormControl({ value: '', disabled: this.isReadOnly }),
+        statusTimer: new FormControl({ value: '', disabled: this.isReadOnly }),
+        useNewBench: new FormControl({ value: '', disabled: this.isReadOnly })
       })
     });
   }
@@ -150,17 +155,11 @@ export class EditPreconfiguredTasksComponent implements OnInit, OnDestroy {
 
     const pretask: JPretask = this.serializer.deserialize(response, zPreTaskResponse);
 
+    this.pretaskName = pretask.taskName ?? '';
+
     this.updateForm = new FormGroup({
       pretaskId: new FormControl({
         value: pretask.id,
-        disabled: true
-      }),
-      statusTimer: new FormControl({
-        value: pretask.statusTimer,
-        disabled: true
-      }),
-      useNewBench: new FormControl({
-        value: pretask.useNewBench,
         disabled: true
       }),
       updateData: new FormGroup({
@@ -174,7 +173,9 @@ export class EditPreconfiguredTasksComponent implements OnInit, OnDestroy {
         priority: new FormControl(pretask.priority),
         maxAgents: new FormControl(pretask.maxAgents),
         isCpuTask: new FormControl(pretask.isCpuTask, this.isReadOnly ? [] : [Validators.required]),
-        isSmall: new FormControl(pretask.isSmall, this.isReadOnly ? [] : [Validators.required])
+        isSmall: new FormControl(pretask.isSmall, this.isReadOnly ? [] : [Validators.required]),
+        statusTimer: new FormControl({ value: pretask.statusTimer, disabled: this.isReadOnly }),
+        useNewBench: new FormControl({ value: pretask.useNewBench, disabled: this.isReadOnly })
       })
     });
   }

--- a/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.ts
+++ b/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.ts
@@ -143,7 +143,7 @@ export class EditPreconfiguredTasksComponent implements OnInit, OnDestroy {
         isCpuTask: new FormControl({ value: '', disabled: this.isReadOnly }),
         isSmall: new FormControl({ value: '', disabled: this.isReadOnly }),
         statusTimer: new FormControl({ value: '', disabled: this.isReadOnly }),
-        useNewBench: new FormControl({ value: '', disabled: this.isReadOnly })
+        useNewBench: new FormControl({ value: '', disabled: true })
       })
     });
   }
@@ -175,7 +175,7 @@ export class EditPreconfiguredTasksComponent implements OnInit, OnDestroy {
         isCpuTask: new FormControl(pretask.isCpuTask, this.isReadOnly ? [] : [Validators.required]),
         isSmall: new FormControl(pretask.isSmall, this.isReadOnly ? [] : [Validators.required]),
         statusTimer: new FormControl({ value: pretask.statusTimer, disabled: this.isReadOnly }),
-        useNewBench: new FormControl({ value: pretask.useNewBench, disabled: this.isReadOnly })
+        useNewBench: new FormControl({ value: pretask.useNewBench, disabled: true })
       })
     });
   }

--- a/src/app/tasks/edit-supertasks/edit-supertasks.component.html
+++ b/src/app/tasks/edit-supertasks/edit-supertasks.component.html
@@ -1,4 +1,4 @@
-<app-page title="Supertask Details">
+<app-page [title]="'Supertask ' + editName">
   <grid-main [narrow]="true">
     <form [formGroup]="viewForm">
       <app-form-row>

--- a/src/app/tasks/edit-supertasks/edit-supertasks.component.ts
+++ b/src/app/tasks/edit-supertasks/edit-supertasks.component.ts
@@ -58,7 +58,7 @@ export class EditSupertasksComponent implements OnInit, OnDestroy {
     }
   }
 
-  editName: string;
+  editName = '';
 
   @ViewChild('superTasksPretasksTable') superTasksPretasksTable: PretasksTableComponent;
   @ViewChild('superTasksPretaskNotContainedTable') superTasksPretasksNotContainedTable: PretasksTableComponent;

--- a/src/app/tasks/edit-tasks/edit-tasks.component.html
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.html
@@ -4,10 +4,14 @@
       <div class="col-span-12 md:col-span-6">
         <grid-main>
           <form [formGroup]="updateForm" class="flex flex-col gap-3">
-            <input-text title="ID" formControlName="taskId"></input-text>
+            <app-form-row [columns]="2">
+              <input-text title="ID" formControlName="taskId"></input-text>
+              <ng-container formGroupName="updateData">
+                <input-color title="Color" formControlName="color"></input-color>
+              </ng-container>
+            </app-form-row>
 
             <div formGroupName="updateData" class="flex flex-col gap-3">
-              <input-color title="Color" formControlName="color"></input-color>
               <input-text title="Name" formControlName="taskName" [isRequired]="!isReadOnly"></input-text>
               <input-text-area
                 title="Attack command"

--- a/src/app/tasks/edit-tasks/edit-tasks.component.html
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.html
@@ -1,95 +1,47 @@
 @if (!isLoading) {
-  <app-page title="Edit Task">
-    <grid-main [narrow]="true">
-      <form [formGroup]="updateForm">
-        <input-text title="ID" formControlName="taskId"></input-text>
-
-        <app-form-row formGroupName="updateData" [columns]="1">
-          <input-text title="Name" formControlName="taskName" [isRequired]="!isReadOnly"></input-text>
-          <input-color title="Color" formControlName="color"></input-color>
-        </app-form-row>
-
-        <div formGroupName="updateData" class="flex flex-col gap-3">
-          <input-text-area
-            title="Attack command"
-            formControlName="attackCmd"
-            [isRequired]="!isReadOnly"
-          ></input-text-area>
-          <input-text-area title="Notes" formControlName="notes"></input-text-area>
-        </div>
-
-        <div formGroupName="updateData" class="flex flex-col gap-3">
-          <app-form-row [columns]="4">
-            <input-number title="Priority" formControlName="priority"></input-number>
-            <input-number title="Status timer" formControlName="statusTimer"></input-number>
-            <input-number title="Max agents" formControlName="maxAgents"></input-number>
-            <input-number title="Chunk size" formControlName="chunkTime"></input-number>
-          </app-form-row>
-          <app-form-row align="left">
-            <input-check title="CPU only" formControlName="isCpuTask"></input-check>
-            <input-check title="Small task" formControlName="isSmall"></input-check>
-          </app-form-row>
-        </div>
-
-        @if (roleService.hasRole('edit')) {
-          <grid-buttons>
-            <button-submit name="Purge" type="delete" (click)="purgeTask()"></button-submit>
-            <button-submit name="Update" (click)="onSubmit()" [loading]="isUpdatingLoading"></button-submit>
-          </grid-buttons>
-        }
-      </form>
-
-      <!-- Task Information -->
-      <mat-accordion class="block mt-md">
-        <mat-expansion-panel>
-          <mat-expansion-panel-header>
-            <mat-panel-title>
-              <span><strong>Task Information</strong></span>
-            </mat-panel-title>
-          </mat-expansion-panel-header>
-
+  <app-page [title]="pageTitle">
+    <div class="grid grid-cols-12 gap-4">
+      <div class="col-span-12 md:col-span-6">
+        <grid-main>
           <form [formGroup]="updateForm" class="flex flex-col gap-3">
-            <div class="flex flex-row flex-wrap items-center gap-2">
-              <input-text title="No. of Chunks" formControlName="totalNumberOfChunks"></input-text>
-              <input-text title="Enforce Piping" formControlName="forcePipe"></input-text>
-              <input-text title="Use static chunking" formControlName="staticChunks" class="w-60"></input-text>
-              <input-text title="Skipping keyspace" formControlName="skipKeyspace"></input-text>
-              <input-text title="Keyspace size" formControlName="keyspace"></input-text>
-              <input-text title="Keyspace dispatched" formControlName="keyspaceProgress"></input-text>
+            <input-text title="ID" formControlName="taskId"></input-text>
+
+            <div formGroupName="updateData" class="flex flex-col gap-3">
+              <input-color title="Color" formControlName="color"></input-color>
+              <input-text title="Name" formControlName="taskName" [isRequired]="!isReadOnly"></input-text>
+              <input-text-area
+                title="Attack command"
+                formControlName="attackCmd"
+                [isRequired]="!isReadOnly"
+              ></input-text-area>
+              <input-text-area title="Notes" formControlName="notes"></input-text-area>
+
+              <app-form-row [columns]="4">
+                <input-number title="Priority" formControlName="priority"></input-number>
+                <input-number title="Status timer" formControlName="statusTimer"></input-number>
+                <input-number title="Max agents" formControlName="maxAgents"></input-number>
+                <input-number title="Chunk size" formControlName="chunkTime"></input-number>
+              </app-form-row>
+              <app-form-row align="left">
+                <input-check title="CPU only" formControlName="isCpuTask"></input-check>
+                <input-check title="Small task" formControlName="isSmall"></input-check>
+              </app-form-row>
             </div>
 
-            <app-form-row [columns]="2">
-              @if (tkeyspace > 0 || (tusepreprocessor && cprogress > 0)) {
-                <input-text title="Keyspace Searched" [value]="searched + '%'" [readonly]="true"></input-text>
-              } @else {
-                <input-text title="Keyspace Searched" value="N/A" [readonly]="true"></input-text>
-              }
-
-              @if (roleService.hasRole('editTaskChunks')) {
-                @if (ctimespent) {
-                  <input-text title="Time spent" [value]="ctimespent | sectotime" [readonly]="true"></input-text>
-                } @else {
-                  <input-text title="Time spent" value="---" [readonly]="true"></input-text>
-                }
-              }
-            </app-form-row>
-
-            @if (roleService.hasRole('editTaskChunks')) {
-              <app-form-row [columns]="2">
-                @if (estimatedTime !== 0) {
-                  <input-text title="E.T." [value]="estimatedTime | sectotime" [readonly]="true"></input-text>
-                } @else {
-                  <input-text title="E.T." value="---" [readonly]="true"></input-text>
-                }
-
-                @if (currenspeed !== 0) {
-                  <input-text title="Speed" value="{{ currenspeed | hashRate }}" [readonly]="true"></input-text>
-                } @else {
-                  <input-text title="Speed" value="---" [readonly]="true"></input-text>
-                }
-              </app-form-row>
+            @if (roleService.hasRole('edit')) {
+              <grid-buttons>
+                <button-submit name="Purge" type="delete" (click)="purgeTask()"></button-submit>
+                <button-submit name="Update" (click)="onSubmit()" [loading]="isUpdatingLoading"></button-submit>
+              </grid-buttons>
             }
+          </form>
+        </grid-main>
+      </div>
 
+      <!-- Task Information -->
+      <div class="col-span-12 md:col-span-6">
+        <grid-main>
+          <div [formGroup]="updateForm" class="flex flex-col gap-3">
             <app-form-row [columns]="2">
               @if (roleService.hasRole('editTaskInfoHashlist')) {
                 @if (hashlistinform) {
@@ -123,17 +75,57 @@
                 }
               }
             </app-form-row>
-          </form>
-        </mat-expansion-panel>
 
-        @if (roleService.hasRole('editTaskFiles')) {
-          <mat-expansion-panel>
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                <span><strong>Files</strong></span>
-              </mat-panel-title>
-            </mat-expansion-panel-header>
+            <app-form-row [columns]="2">
+              <input-text title="Keyspace size" formControlName="keyspace"></input-text>
+              <input-text title="Keyspace dispatched" formControlName="keyspaceProgress"></input-text>
+            </app-form-row>
 
+            <app-form-row [columns]="2">
+              @if (roleService.hasRole('editTaskChunks')) {
+                @if (currenspeed !== 0) {
+                  <input-text title="Speed" value="{{ currenspeed | hashRate }}" [readonly]="true"></input-text>
+                } @else {
+                  <input-text title="Speed" value="---" [readonly]="true"></input-text>
+                }
+              }
+
+              @if (tkeyspace > 0 || (tusepreprocessor && cprogress > 0)) {
+                <input-text title="Keyspace Searched" [value]="searched + '%'" [readonly]="true"></input-text>
+              } @else {
+                <input-text title="Keyspace Searched" value="N/A" [readonly]="true"></input-text>
+              }
+            </app-form-row>
+
+            @if (roleService.hasRole('editTaskChunks')) {
+              <app-form-row [columns]="2">
+                @if (ctimespent) {
+                  <input-text title="Time spent" [value]="ctimespent | sectotime" [readonly]="true"></input-text>
+                } @else {
+                  <input-text title="Time spent" value="---" [readonly]="true"></input-text>
+                }
+
+                @if (estimatedTime !== 0) {
+                  <input-text title="E.T." [value]="estimatedTime | sectotime" [readonly]="true"></input-text>
+                } @else {
+                  <input-text title="E.T." value="---" [readonly]="true"></input-text>
+                }
+              </app-form-row>
+            }
+
+            <app-form-row [columns]="2">
+              <input-text title="No. of Chunks" formControlName="totalNumberOfChunks"></input-text>
+              <input-text title="Skipping keyspace" formControlName="skipKeyspace"></input-text>
+            </app-form-row>
+
+            <app-form-row [columns]="2">
+              <input-text title="Use static chunking" formControlName="staticChunks"></input-text>
+              <input-text title="Enforce Piping" formControlName="forcePipe"></input-text>
+            </app-form-row>
+          </div>
+
+          @if (roleService.hasRole('editTaskFiles')) {
+            <app-page-subtitle subtitle="Files" class="block mt-md"></app-page-subtitle>
             <app-files-table
               #table
               name="filesTable"
@@ -147,10 +139,10 @@
               [editType]="0"
             >
             </app-files-table>
-          </mat-expansion-panel>
-        }
-      </mat-accordion>
-    </grid-main>
+          }
+        </grid-main>
+      </div>
+    </div>
 
     <!-- Graph Visual  -->
     @if (tkeyspace > 0) {

--- a/src/app/tasks/edit-tasks/edit-tasks.component.ts
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.ts
@@ -56,6 +56,9 @@ export class EditTasksComponent implements OnInit, OnDestroy {
   taskWrapperId: number;
   originalValue: JTask;
 
+  /** Page heading: "Task <name>". */
+  pageTitle = 'Task';
+
   updateForm: FormGroup;
   createForm: FormGroup<{ agentId: FormControl<number | null> }>; // Assign Agent
   /** On form update show a spinner loading */
@@ -125,6 +128,7 @@ export class EditTasksComponent implements OnInit, OnDestroy {
       const task = await this.loadTask();
 
       this.originalValue = task;
+      this.pageTitle = 'Task ' + (task.taskName ?? '');
       this.searched = task.searched ?? '';
       this.color = task.color ?? '';
       this.crackerinfo = task.crackerBinary;

--- a/src/app/tasks/edit-tasks/edit-tasks.component.ts
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.ts
@@ -56,7 +56,6 @@ export class EditTasksComponent implements OnInit, OnDestroy {
   taskWrapperId: number;
   originalValue: JTask;
 
-  /** Page heading: "Task <name>". */
   pageTitle = 'Task';
 
   updateForm: FormGroup;

--- a/src/app/tasks/new-preconfigured-tasks/new-preconfigured-tasks.component.html
+++ b/src/app/tasks/new-preconfigured-tasks/new-preconfigured-tasks.component.html
@@ -12,8 +12,10 @@
     <div class="col-span-12 md:col-span-6">
       <grid-main>
         <form [formGroup]="createForm" (ngSubmit)="onSubmit()">
-          <input-text title="Name" formControlName="taskName" [isRequired]="true"></input-text>
-          <input-color title="Color" formControlName="color"></input-color>
+          <app-form-row>
+            <input-text title="Name" formControlName="taskName" [isRequired]="true"></input-text>
+            <input-color title="Color" formControlName="color"></input-color>
+          </app-form-row>
 
           <input-text-area title="Command line" formControlName="attackCmd" [isRequired]="true"></input-text-area>
           <blacklist-attack [value]="createForm.controls.attackCmd.value"></blacklist-attack>

--- a/src/app/tasks/new-tasks/new-tasks.component.html
+++ b/src/app/tasks/new-tasks/new-tasks.component.html
@@ -7,8 +7,10 @@
             <mat-card-content>
               <h2 class="text-sm font-medium text-muted-foreground uppercase tracking-wide">Task Configuration</h2>
               <div class="form-layout">
-                <input-text title="Name" formControlName="taskName" [isRequired]="true"></input-text>
-                <input-color title="Color" formControlName="color"></input-color>
+                <app-form-row>
+                  <input-text title="Name" formControlName="taskName" [isRequired]="true"></input-text>
+                  <input-color title="Color" formControlName="color"></input-color>
+                </app-form-row>
 
                 @if (!isLoading) {
                   <input-multiselect

--- a/src/app/users/edit-groups/edit-groups.component.html
+++ b/src/app/users/edit-groups/edit-groups.component.html
@@ -1,4 +1,4 @@
-<app-page title="Edit Access Group">
+<app-page [title]="'Access Group ' + editName">
   <grid-main [narrow]="true">
     <form [formGroup]="updateForm" (ngSubmit)="onSubmit()">
       <input-text title="Name" formControlName="groupName" [isRequired]="true"></input-text>

--- a/src/app/users/edit-groups/edit-groups.component.ts
+++ b/src/app/users/edit-groups/edit-groups.component.ts
@@ -45,7 +45,7 @@ export class EditGroupsComponent implements OnInit, OnDestroy {
   addAgentsForm: FormGroup<AddAgentsForm>; // Form group for adding agents to group
   addUsersForm: FormGroup<AddUserForm>; // Form group for adding users to group
 
-  editName: string; // Name of the access group being edited
+  editName = ''; // Name of the access group being edited
   editedAccessGroupIndex: number; // Index of the access group being edited
 
   isAgentsLoading: boolean = true; // Show a spinner while loading agents for multiselect

--- a/src/app/users/edit-users/edit-users.component.html
+++ b/src/app/users/edit-users/edit-users.component.html
@@ -1,4 +1,4 @@
-<app-page title="User Profile">
+<app-page [title]="'User ' + editedUserName">
   <grid-main [narrow]="true">
     <form [formGroup]="updateForm" (ngSubmit)="onSubmit()">
       <app-form-row>

--- a/src/app/users/edit-users/edit-users.component.ts
+++ b/src/app/users/edit-users/edit-users.component.ts
@@ -56,7 +56,7 @@ export class EditUsersComponent implements OnInit, OnDestroy {
 
   // Edit Configuration
   editedUserIndex: number;
-  editedUserName: string;
+  editedUserName = '';
 
   private unsubscribeService = inject(UnsubscribeService);
   private changeDetectorRef = inject(ChangeDetectorRef);

--- a/src/app/users/globalpermissionsgroups/edit-globalpermissionsgroups/edit-globalpermissionsgroups.component.html
+++ b/src/app/users/globalpermissionsgroups/edit-globalpermissionsgroups/edit-globalpermissionsgroups.component.html
@@ -1,4 +1,4 @@
-<app-page title="Global Permission Group">
+<app-page [title]="'Global Permission Group ' + (editedGPG?.name ?? '')">
   <grid-main>
     <app-page-subtitle [subtitle]="'Authorization Matrix'"></app-page-subtitle>
     <form [formGroup]="updateForm" (ngSubmit)="onSubmit()">

--- a/src/styles/base/_tokens.scss
+++ b/src/styles/base/_tokens.scss
@@ -49,6 +49,7 @@
   --space-xl: 32px;
 
   --form-gap: var(--space-sm);
+  --input-row-height: 36px; // rendered height of a Material text-field row
 
   --background: #0f0f0f;
   --muted: #1c1c1c;

--- a/src/styles/components/_form.scss
+++ b/src/styles/components/_form.scss
@@ -128,6 +128,13 @@ app-form-row {
       min-height: auto;
     }
   }
+
+  // Row-aligned textareas fold the row padding into line-height (see
+  // _material.scss), so the infix must not add its own vertical padding.
+  &--row-aligned &__field.mat-mdc-form-field .mat-mdc-form-field-infix {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 }
 
 input-check,

--- a/src/styles/components/_form.scss
+++ b/src/styles/components/_form.scss
@@ -88,6 +88,7 @@ app-form-row {
   &__label-link {
     display: inline-flex;
     align-items: center;
+    gap: 4px;
     color: var(--primary);
 
     mat-icon {

--- a/src/styles/components/_form.scss
+++ b/src/styles/components/_form.scss
@@ -85,6 +85,21 @@ app-form-row {
     }
   }
 
+  &__label-link {
+    display: inline-flex;
+    align-items: center;
+    color: var(--primary);
+
+    mat-icon {
+      color: var(--primary);
+      cursor: pointer;
+    }
+
+    &:hover mat-icon {
+      color: var(--primary-hover, var(--primary));
+    }
+  }
+
   &__required {
     color: var(--primary);
     margin-left: 2px;

--- a/src/styles/components/_material.scss
+++ b/src/styles/components/_material.scss
@@ -59,16 +59,25 @@
 
 textarea.mat-mdc-input-element.custom-textarea {
   resize: none;
+  // Material's container-text token re-applies 16px to textareas; pin it back to
+  // the input size so a textarea reads identically to a plain input alongside it.
+  font-size: var(--text-md);
   line-height: 1.5;
   padding: 0;
   box-sizing: border-box;
 }
-// Row-aligned variant: each line occupies one text-field row, so the field
-// grows in whole-row steps. Infix padding is zeroed (_form.scss), so the line
-// height carries the row height minus the ~2px form-field chrome — a single
-// line then matches a plain input.
+// Row-aligned variant: each line occupies one full input-row, so a multi-line
+// field stacks to the same height as that many single-line inputs (5 GPU rows
+// == three left-column fields, bottom-aligned). Infix padding is zeroed
+// (_form.scss) and the 1px border is drawn as an inset shadow so it adds no
+// box height — keeping each line exactly --input-row-height and a single line
+// identical to a plain input.
 .field-stack--row-aligned textarea.mat-mdc-input-element.custom-textarea {
-  line-height: calc(var(--input-row-height) - 2px);
+  line-height: var(--input-row-height);
+}
+.field-stack--row-aligned.input--readonly .mat-mdc-form-field .mdc-text-field--filled {
+  border: 0;
+  box-shadow: inset 0 0 0 1px var(--border-faint);
 }
 .mat-mdc-form-field:has(textarea.custom-textarea) .mat-mdc-form-field-infix {
   display: flex;

--- a/src/styles/components/_material.scss
+++ b/src/styles/components/_material.scss
@@ -63,6 +63,13 @@ textarea.mat-mdc-input-element.custom-textarea {
   padding: 0;
   box-sizing: border-box;
 }
+// Row-aligned variant: each line occupies one text-field row, so the field
+// grows in whole-row steps. Infix padding is zeroed (_form.scss), so the line
+// height carries the row height minus the ~2px form-field chrome — a single
+// line then matches a plain input.
+.field-stack--row-aligned textarea.mat-mdc-input-element.custom-textarea {
+  line-height: calc(var(--input-row-height) - 2px);
+}
 .mat-mdc-form-field:has(textarea.custom-textarea) .mat-mdc-form-field-infix {
   display: flex;
   align-items: stretch;


### PR DESCRIPTION
- Reorder some fields (see screenshots) mostly readonly fields that were below have been moved to the second column

- Add dynamic titles instead of "Edit Task" name the title of the page "Task 'Name'" or "Agent 'Name'", if no name is present use other defining field or as fallback id

- Do the dynamic title also for dynamic forms. This requires a small config (as the dynamic forms are completely config derived) where we specify the fields that should be rendered in the title for the given object

- Make color input size same height as other inputs as otherwise some fields in the right column are not aligned with fields on the left one if the color input is present

- Also modify multiline input for graphics card display in agent so that it aligns with the columns (if multiline still align with rows on the left side for example so that the right column is still aligned properly)

- add link from certain label (add link icon there as well) to subpages

Ui change was mainly moving content below into the second column either some readonly content or files table.

<img width="2674" height="1760" alt="image" src="https://github.com/user-attachments/assets/180edf2d-839a-45fc-87b5-97c34e028fe3" />

<img width="2690" height="1788" alt="image" src="https://github.com/user-attachments/assets/1ac0b891-5343-4951-9cbe-07a5726914e8" />

<img width="2668" height="1768" alt="image" src="https://github.com/user-attachments/assets/bc205995-814f-4071-968e-b4935e82034f" />

<img width="2650" height="1778" alt="image" src="https://github.com/user-attachments/assets/089a6d4f-5469-4758-94df-c28ae5e5459a" />



Issue: https://github.com/hashtopolis/server/issues/2212