### PR TITLE
Let global HTTP interceptor surface login errors instead of AlertService

### DIFF
--- a/src/app/auth/auth.component.spec.ts
+++ b/src/app/auth/auth.component.spec.ts
@@ -11,7 +11,6 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { By } from '@angular/platform-browser';
 
 import { AuthService } from '@services/access/auth.service';
-import { AlertService } from '@services/shared/alert.service';
 import { ConfigService } from '@services/shared/config.service';
 import { UnsubscribeService } from '@services/unsubscribe.service';
 
@@ -26,13 +25,11 @@ describe('AuthComponent', () => {
 
   // Mocks
   let mockAuthService: jasmine.SpyObj<AuthService>;
-  let mockAlertService: jasmine.SpyObj<AlertService>;
   let mockUnsubscribeService: jasmine.SpyObj<UnsubscribeService>;
   let mockConfigService: jasmine.SpyObj<ConfigService>;
 
   beforeEach(async () => {
     mockAuthService = jasmine.createSpyObj('AuthService', ['logIn']);
-    mockAlertService = jasmine.createSpyObj('AlertService', ['showErrorMessage']);
     mockUnsubscribeService = jasmine.createSpyObj('UnsubscribeService', ['add', 'unsubscribeAll']);
     mockConfigService = jasmine.createSpyObj('ConfigService', ['getEndpoint']);
 
@@ -52,7 +49,6 @@ describe('AuthComponent', () => {
       declarations: [AuthComponent],
       providers: [
         { provide: AuthService, useValue: mockAuthService },
-        { provide: AlertService, useValue: mockAlertService },
         { provide: UnsubscribeService, useValue: mockUnsubscribeService },
         { provide: ConfigService, useValue: mockConfigService }
       ]
@@ -94,7 +90,7 @@ describe('AuthComponent', () => {
     expect(mockUnsubscribeService.add).toHaveBeenCalled();
   }));
 
-  it('should show error message when login fails on submit button click', fakeAsync(() => {
+  it('should stop loading when login fails on submit button click', fakeAsync(() => {
     const errorResponse = throwError(() => new Error('Login failed')).pipe(observeOn(asyncScheduler));
     mockAuthService.logIn.and.returnValue(errorResponse);
 
@@ -111,7 +107,7 @@ describe('AuthComponent', () => {
     expect(component.isLoading).toBeFalse();
   }));
 
-  it('should show default error message when login fails without specific error message', fakeAsync(() => {
+  it('should stop loading when login fails without a specific error message', fakeAsync(() => {
     const errorResponse = throwError(() => ({})).pipe(observeOn(asyncScheduler));
     mockAuthService.logIn.and.returnValue(errorResponse);
 

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -7,7 +7,6 @@ import { Validators } from '@angular/forms';
 import { UIConfig } from '@models/config-ui.model';
 
 import { AuthService } from '@services/access/auth.service';
-import { AlertService } from '@services/shared/alert.service';
 import { ConfigService } from '@services/shared/config.service';
 import { LocalStorageService } from '@services/storage/local-storage.service';
 import { UnsubscribeService } from '@services/unsubscribe.service';
@@ -32,13 +31,10 @@ export class AuthComponent implements OnInit, OnDestroy, AfterViewInit {
   private storage = inject<LocalStorageService<UIConfig>>(LocalStorageService);
   private configService = inject(ConfigService);
   private authService = inject(AuthService);
-  private alertService = inject(AlertService);
   private host = inject(ElementRef);
 
   /** Form group for the new SuperHashlist. */
   loginForm: FormGroup<LoginForm>;
-
-  errorRes: string | null;
 
   protected uiSettings: UISettingsUtilityClass;
   public isVisible = true;
@@ -119,10 +115,10 @@ export class AuthComponent implements OnInit, OnDestroy, AfterViewInit {
       next: () => {
         this.loginForm.reset();
       },
-      error: (error: string) => {
+      error: () => {
+        // The global HTTP response interceptor already surfaces the error to the
+        // user (modal dialog), so we only need to stop the loading spinner here.
         this.isLoading = false;
-        const errorMessage = error || 'An error occurred. Please try again later.';
-        this.handleError(errorMessage);
       },
       complete: () => {
         this.isLoading = false; // Hide spinner after attempting to log in
@@ -130,15 +126,5 @@ export class AuthComponent implements OnInit, OnDestroy, AfterViewInit {
     });
 
     this.unsubscribeService.add(authSubscription$);
-  }
-
-  /**
-   * Show and log specified error message
-   * @param errorMessage Message to log/display
-   * @private
-   */
-  private handleError(errorMessage: string): void {
-    this.errorRes = errorMessage;
-    this.alertService.showErrorMessage(errorMessage);
   }
 }


### PR DESCRIPTION
Error message was shown twice, once from the global interceptor and another time manually.
Fix this and only show the error from the interceptor.
Issue: https://github.com/hashtopolis/server/issues/2228