### PR TITLE
Fix Zod validation error for notifications not tied to an object (#2224)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -20970,7 +20970,7 @@
               "type": { "type": "string", "const": "notificationSetting" },
               "attributes": {
                 "type": "object",
-                "required": ["action", "objectId", "notification", "userId", "receiver", "isActive"],
+                "required": ["action", "notification", "userId", "receiver", "isActive"],
                 "properties": {
                   "action": {
                     "oneOf": [
@@ -20979,7 +20979,7 @@
                       { "const": "deleteNotification", "title": "Delete notification", "type": "string" }
                     ]
                   },
-                  "objectId": { "type": "integer" },
+                  "objectId": { "type": ["integer", "null"] },
                   "notification": {
                     "oneOf": [
                       { "const": "taskComplete", "title": "Task completed", "type": "string" },
@@ -21108,7 +21108,7 @@
               "type": { "type": "string", "const": "notificationSetting" },
               "attributes": {
                 "type": "object",
-                "required": ["action", "objectId", "notification", "userId", "receiver", "isActive"],
+                "required": ["action", "notification", "userId", "receiver", "isActive"],
                 "properties": {
                   "action": {
                     "oneOf": [
@@ -21117,7 +21117,7 @@
                       { "const": "deleteNotification", "title": "Delete notification", "type": "string" }
                     ]
                   },
-                  "objectId": { "type": "integer" },
+                  "objectId": { "type": ["integer", "null"] },
                   "notification": {
                     "oneOf": [
                       { "const": "taskComplete", "title": "Task completed", "type": "string" },
@@ -21191,7 +21191,7 @@
                 "type": { "type": "string", "const": "notificationSetting" },
                 "attributes": {
                   "type": "object",
-                  "required": ["action", "objectId", "notification", "userId", "receiver", "isActive"],
+                  "required": ["action", "notification", "userId", "receiver", "isActive"],
                   "properties": {
                     "action": {
                       "oneOf": [
@@ -21200,7 +21200,7 @@
                         { "const": "deleteNotification", "title": "Delete notification", "type": "string" }
                       ]
                     },
-                    "objectId": { "type": "integer" },
+                    "objectId": { "type": ["integer", "null"] },
                     "notification": {
                       "oneOf": [
                         { "const": "taskComplete", "title": "Task completed", "type": "string" },

--- a/src/app/core/_datasources/notifications.datasource.ts
+++ b/src/app/core/_datasources/notifications.datasource.ts
@@ -41,10 +41,10 @@ export class NotificationsDataSource extends BaseDataSource<JNotification> {
           finalize(() => (this.loading = false))
         )
         .subscribe((response: ResponseWrapper) => {
-          const notifications = this.serializer.deserialize(
+          const notifications: JNotification[] = this.serializer.deserialize(
             response,
             zNotificationSettingListResponse
-          ) as JNotification[];
+          );
 
           const length = response.meta.page.total_elements;
           const nextLink = response.links.next;

--- a/src/app/core/_datasources/notifications.datasource.ts
+++ b/src/app/core/_datasources/notifications.datasource.ts
@@ -41,10 +41,10 @@ export class NotificationsDataSource extends BaseDataSource<JNotification> {
           finalize(() => (this.loading = false))
         )
         .subscribe((response: ResponseWrapper) => {
-          const notifications: JNotification[] = this.serializer.deserialize(
+          const notifications = this.serializer.deserialize(
             response,
             zNotificationSettingListResponse
-          );
+          ) as JNotification[];
 
           const length = response.meta.page.total_elements;
           const nextLink = response.links.next;

--- a/src/app/core/_datasources/specs/notifications.datasource.spec.ts
+++ b/src/app/core/_datasources/specs/notifications.datasource.spec.ts
@@ -245,3 +245,42 @@ describe('NotificationsDataSource', () => {
     });
   });
 });
+
+// Schema-level regression for bug #2224: notifications not tied to an object (e.g. a global
+// agentError/logError) carry no objectId. The list-response schema must accept a null or absent
+// objectId, otherwise the serializer's validateBody() logs a large ZodError to the console.
+describe('zNotificationSettingListResponse objectId nullability', () => {
+  const bodyWith = (attrs: Record<string, unknown>) => ({
+    jsonapi: { version: '1.1' },
+    data: [
+      {
+        id: 1,
+        type: 'notificationSetting',
+        attributes: {
+          action: 'createNotification',
+          notification: 'agentError',
+          userId: 1,
+          receiver: 'user@example.org',
+          isActive: true,
+          ...attrs
+        }
+      }
+    ]
+  });
+
+  it('accepts a numeric objectId', () => {
+    expect(zNotificationSettingListResponse.safeParse(bodyWith({ objectId: 42 })).success).toBeTrue();
+  });
+
+  it('accepts a null objectId (notification not tied to an object)', () => {
+    expect(zNotificationSettingListResponse.safeParse(bodyWith({ objectId: null })).success).toBeTrue();
+  });
+
+  it('accepts an absent objectId', () => {
+    expect(zNotificationSettingListResponse.safeParse(bodyWith({})).success).toBeTrue();
+  });
+
+  it('still rejects a non-integer objectId', () => {
+    expect(zNotificationSettingListResponse.safeParse(bodyWith({ objectId: 'not-a-number' })).success).toBeFalse();
+  });
+});

--- a/src/app/core/_models/notification.model.ts
+++ b/src/app/core/_models/notification.model.ts
@@ -34,5 +34,5 @@ export interface JNotification extends BaseModel {
   notification: NotificationEvent;
   receiver: string;
   userId: UserId;
-  objectId?: number | null;
+  objectId?: number | null | undefined;
 }

--- a/src/app/core/_models/notification.model.ts
+++ b/src/app/core/_models/notification.model.ts
@@ -34,5 +34,5 @@ export interface JNotification extends BaseModel {
   notification: NotificationEvent;
   receiver: string;
   userId: UserId;
-  objectId?: number;
+  objectId?: number | null;
 }

--- a/src/generated/api/types/notification-setting.ts
+++ b/src/generated/api/types/notification-setting.ts
@@ -75,7 +75,7 @@ export type NotificationSettingResponse = {
     type: 'notificationSetting';
     attributes: {
       action: 'createNotification' | 'setActive' | 'deleteNotification';
-      objectId: number;
+      objectId?: number | null;
       notification:
         | 'taskComplete'
         | 'agentError'
@@ -142,7 +142,7 @@ export type NotificationSettingPostPatchResponse = {
     type: 'notificationSetting';
     attributes: {
       action: 'createNotification' | 'setActive' | 'deleteNotification';
-      objectId: number;
+      objectId?: number | null;
       notification:
         | 'taskComplete'
         | 'agentError'
@@ -185,7 +185,7 @@ export type NotificationSettingListResponse = {
     type: 'notificationSetting';
     attributes: {
       action: 'createNotification' | 'setActive' | 'deleteNotification';
-      objectId: number;
+      objectId?: number | null;
       notification:
         | 'taskComplete'
         | 'agentError'

--- a/src/generated/api/zod/notification-setting.ts
+++ b/src/generated/api/zod/notification-setting.ts
@@ -83,7 +83,7 @@ export const zNotificationSettingResponse = z.object({
     type: z.literal('notificationSetting'),
     attributes: z.object({
       action: z.union([z.literal('createNotification'), z.literal('setActive'), z.literal('deleteNotification')]),
-      objectId: z.int(),
+      objectId: z.int().nullish(),
       notification: z.union([
         z.literal('taskComplete'),
         z.literal('agentError'),
@@ -159,7 +159,7 @@ export const zNotificationSettingPostPatchResponse = z.object({
     type: z.literal('notificationSetting'),
     attributes: z.object({
       action: z.union([z.literal('createNotification'), z.literal('setActive'), z.literal('deleteNotification')]),
-      objectId: z.int(),
+      objectId: z.int().nullish(),
       notification: z.union([
         z.literal('taskComplete'),
         z.literal('agentError'),
@@ -206,7 +206,7 @@ export const zNotificationSettingListResponse = z.object({
       type: z.literal('notificationSetting'),
       attributes: z.object({
         action: z.union([z.literal('createNotification'), z.literal('setActive'), z.literal('deleteNotification')]),
-        objectId: z.int(),
+        objectId: z.int().nullish(),
         notification: z.union([
           z.literal('taskComplete'),
           z.literal('agentError'),


### PR DESCRIPTION
Some notifications are not tied to an object, fix typing and relax zod vallidation schemas in this case

Issue: https://github.com/hashtopolis/server/issues/2224