### PR TITLE
Remove misleading overall hashlist progress from task tooltip

### DIFF
--- a/src/app/core/_components/tables/ht-table/type/link/ht-table-type-link.component.html
+++ b/src/app/core/_components/tables/ht-table/type/link/ht-table-type-link.component.html
@@ -33,16 +33,6 @@
                   class="graph-preview-image"
                 />
 
-                <div class="overall-progress">
-                  <div class="overall-progress-label">
-                    Overall hashlist progress: {{ link.visualGraph!.overallProgress }}%
-                    <span class="overall-progress-meta">({{ link.visualGraph!.overallProgressLabel }})</span>
-                  </div>
-                  <div class="overall-progress-track">
-                    <div class="overall-progress-fill" [style.width.%]="link.visualGraph!.overallProgress"></div>
-                  </div>
-                </div>
-
                 <div class="graph-preview-legend">
                   <div class="legend-item">
                     <span class="legend-color not-processed"></span>
@@ -99,16 +89,6 @@
                   (error)="onVisualGraphImageError(link)"
                   class="graph-preview-image"
                 />
-
-                <div class="overall-progress">
-                  <div class="overall-progress-label">
-                    Overall hashlist progress: {{ link.visualGraph!.overallProgress }}%
-                    <span class="overall-progress-meta">({{ link.visualGraph!.overallProgressLabel }})</span>
-                  </div>
-                  <div class="overall-progress-track">
-                    <div class="overall-progress-fill" [style.width.%]="link.visualGraph!.overallProgress"></div>
-                  </div>
-                </div>
 
                 <div class="graph-preview-legend">
                   <div class="legend-item">


### PR DESCRIPTION
The progress showed per-task cracked count against the full hashlist total, giving an incorrect percentage.