### PR TITLE
Fix missing delete button on cracker binary version edit page

### DIFF
--- a/src/app/core/_components/forms/simple-forms/form.component.ts
+++ b/src/app/core/_components/forms/simple-forms/form.component.ts
@@ -42,7 +42,7 @@ export class FormComponent implements OnInit, OnDestroy {
 
   responseSchema: FormRouteData['responseSchema'];
 
-  showDeleteButton: boolean;
+  showDeleteButton: boolean = true;
 
   /**
    * Indicates the mode of the form: either 'create' or 'edit'.


### PR DESCRIPTION
showDeleteButton was never initialized, defaulting to undefined/falsy which hid the button.