### PR TITLE
In the permission matrix only show permissions that exist server side…

### DIFF
--- a/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.ts
+++ b/src/app/core/_components/tables/access-permission-groups-user-table/access-permission-groups-user-table.component.ts
@@ -29,12 +29,7 @@ import { HTTableColumn, HTTableEditable } from '@components/tables/ht-table/ht-t
 import { AccessPermissionGroupsExpandDataSource } from '@datasources/access-permission-groups-expand.datasource';
 
 import { PermissionValues } from '@src/app/core/_constants/userpermissions.config';
-import {
-  CrudVerb,
-  PERMISSION_DENIED_TOOLTIP,
-  PERMISSION_NOT_APPLICABLE_TOOLTIP,
-  PermissionMatrixRow
-} from '@src/app/shared/utils/permission-matrix';
+import { CrudVerb, PERMISSION_DENIED_TOOLTIP, PermissionMatrixRow } from '@src/app/shared/utils/permission-matrix';
 
 export const PermissionTableMode = {
   EDIT: 'edit',
@@ -171,13 +166,13 @@ export class AccessPermissionGroupsUserTableComponent
   }
 
   /**
-   * Build a single CRUD column descriptor. The descriptor's `checkbox` callback
-   * shape changes between modes:
+   * Build a single CRUD column descriptor. When the backend has no key for this
+   * row × verb the cell renders empty in every mode (see {@link cellCheckbox}).
+   * Otherwise the `checkbox` callback shape changes between modes:
    *   - edit: returns `value = row.<verb>`, no disabled/tooltip — the cell flip
    *     drives a PATCH.
    *   - form: returns `value = selection.has(row.keys[verb])`, with `disabled`
-   *     and `tooltip` honoring whether the user holds the permission and
-   *     whether the permission exists for this resource at all.
+   *     and `tooltip` honoring whether the user holds the permission.
    */
   private crudColumn(verb: CrudVerb): HTTableColumn {
     const colId = VERB_TO_COL[verb];
@@ -193,23 +188,22 @@ export class AccessPermissionGroupsUserTableComponent
   }
 
   private cellCheckbox(row: PermissionMatrixRow, verb: CrudVerb, action: string): HTTableEditable<UserPermissions> {
+    const key = row.keys?.[verb];
+    if (!key) {
+      // No backend permission exists for this row × verb — render an empty cell.
+      // The editable-checkbox template hides cells whose value is 'undefined'.
+      return {
+        data: row,
+        value: 'undefined',
+        action
+      };
+    }
+
     if (this.mode === PermissionTableMode.EDIT) {
       return {
         data: row,
         value: row[verb] + '',
         action
-      };
-    }
-
-    const key = row.keys?.[verb];
-    if (!key) {
-      // No backend permission exists for this row × verb.
-      return {
-        data: row,
-        value: 'false',
-        action,
-        disabled: true,
-        tooltip: PERMISSION_NOT_APPLICABLE_TOOLTIP
       };
     }
 

--- a/src/app/shared/utils/permission-matrix.ts
+++ b/src/app/shared/utils/permission-matrix.ts
@@ -104,4 +104,3 @@ function humanizeResourceName(operation: string): string {
 }
 
 export const PERMISSION_DENIED_TOOLTIP = 'You can only grant permissions you hold yourself.';
-export const PERMISSION_NOT_APPLICABLE_TOOLTIP = 'This action does not exist for this resource.';

--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -252,6 +252,13 @@ table.hashtopolis-table {
         display: block;
         flex: 1 1 auto;
         min-width: 0;
+
+        // A column without an `editable` callback renders nothing here. Don't let
+        // the empty host keep its flex-grow and push sibling content (e.g. a
+        // checkbox column's checkbox) off-axis from its header label.
+        &:empty {
+          flex: 0 0 auto;
+        }
       }
     }
 


### PR DESCRIPTION
Disable checkbox and show tooltip why disabled in permission matrix:

<img width="1538" height="1015" alt="image" src="https://github.com/user-attachments/assets/df47e4d8-d351-4c9c-b194-e99bf16b4c45" />

Issue: https://github.com/hashtopolis/server/issues/2222