### PR TITLE
Reroute to table list view after server import of a file (wordlist, rules,other)

### DIFF
--- a/src/app/files/new-files/new-files.component.spec.ts
+++ b/src/app/files/new-files/new-files.component.spec.ts
@@ -207,6 +207,23 @@ describe('NewFilesComponent', () => {
     });
   });
 
+  cases.forEach(({ kind, expectedRedirect }) => {
+    it(`should navigate to the files list after a successful server import for kind="${kind}"`, async () => {
+      setup(kind);
+
+      // Select a server file to import
+      component.selectedServerFiles.add('rockyou.txt');
+
+      const alert = TestBed.inject(AlertService) as unknown as MockAlertService;
+      const router = TestBed.inject(Router) as unknown as MockRouter;
+
+      await component['onSubmitServerImport']();
+
+      expect(alert.showSuccessMessage).toHaveBeenCalledWith('Server files imported successfully!');
+      expect(router.navigate).toHaveBeenCalledWith(['/files', expectedRedirect]);
+    });
+  });
+
   it('should unsubscribe on destroy', () => {
     const comp = setup('wordlist-new');
     const unsubscribe = fixture.debugElement.injector.get(UnsubscribeService) as unknown as MockUnsubscribeService;

--- a/src/app/files/new-files/new-files.component.ts
+++ b/src/app/files/new-files/new-files.component.ts
@@ -406,9 +406,8 @@ export class NewFilesComponent implements OnInit, OnDestroy {
       await Promise.all(requests);
 
       this.alert.showSuccessMessage('Server files imported successfully!');
-      // Reload server files
-      await this.loadServerFiles();
       this.selectedServerFiles.clear();
+      void this.router.navigate(['/files', this.redirect]);
     } catch (error) {
       console.error('Error importing server files:', error);
       this.alert.showErrorMessage('Could not import selected files.');


### PR DESCRIPTION
Reroute to the respective table list view (wordlist, rules, other) when files has been imported via server import.

Issue: https://github.com/hashtopolis/server/issues/2216