### PR TITLE
Open subtask dialog when clicking on supertask name

### DIFF
--- a/src/app/core/_components/tables/ht-table/ht-table.models.ts
+++ b/src/app/core/_components/tables/ht-table/ht-table.models.ts
@@ -55,6 +55,8 @@ export interface HTTableRouterLink {
   routerLink: Array<string | number> | null;
   tooltip?: string | undefined;
   icon?: { faIcon?: IconDefinition | undefined; tooltip?: string | undefined };
+  // Click handler for cells that trigger an action (e.g. open a dialog) instead of navigating. Used when routerLink is null.
+  onClick?: () => void;
   visualGraph?: {
     enabled: boolean;
     taskId: number;

--- a/src/app/core/_components/tables/ht-table/ht-table.models.ts
+++ b/src/app/core/_components/tables/ht-table/ht-table.models.ts
@@ -55,7 +55,7 @@ export interface HTTableRouterLink {
   routerLink: Array<string | number> | null;
   tooltip?: string | undefined;
   icon?: { faIcon?: IconDefinition | undefined; tooltip?: string | undefined };
-  // Click handler for cells that trigger an action (e.g. open a dialog) instead of navigating. Used when routerLink is null.
+  // click handler for cells that trigger an action
   onClick?: () => void;
   visualGraph?: {
     enabled: boolean;

--- a/src/app/core/_components/tables/ht-table/type/link/ht-table-type-link.component.html
+++ b/src/app/core/_components/tables/ht-table/type/link/ht-table-type-link.component.html
@@ -60,7 +60,7 @@
           }
         </span>
       } @else if (link.onClick) {
-        <!-- No routerLink but an action handler: render a clickable link that triggers it -->
+        <!-- action handler instead of router link -->
         <span class="link-wrapper">
           <a
             class="link"

--- a/src/app/core/_components/tables/ht-table/type/link/ht-table-type-link.component.html
+++ b/src/app/core/_components/tables/ht-table/type/link/ht-table-type-link.component.html
@@ -1,6 +1,6 @@
 @if (tableColumn.routerLink) {
   @for (link of tableColumn.routerLink(element) | async; track trackByFn($index, link)) {
-    @if (link.label || link.routerLink) {
+    @if (link.label || link.routerLink || link.onClick) {
       <!-- If routerLink is set, render as link <a> -->
       @if (link.routerLink) {
         <span
@@ -58,6 +58,29 @@
               }
             </div>
           }
+        </span>
+      } @else if (link.onClick) {
+        <!-- No routerLink but an action handler: render a clickable link that triggers it -->
+        <span class="link-wrapper">
+          <a
+            class="link"
+            role="button"
+            tabindex="0"
+            [title]="link.tooltip ?? ''"
+            (click)="onActionClicked(link)"
+            (keydown.enter)="onActionClicked(link)"
+          >
+            <span class="link-label">
+              @if (link.label) {
+                {{ link.label }}
+              } @else {
+                {{ $any(element)[tableColumn.dataKey!] }}
+              }
+            </span>
+            @if (link.icon?.faIcon; as faIcon) {
+              <fa-icon [icon]="faIcon" [title]="link.icon?.tooltip ?? ''"></fa-icon>
+            }
+          </a>
         </span>
       } @else {
         <span

--- a/src/app/core/_components/tables/ht-table/type/link/ht-table-type-link.component.scss
+++ b/src/app/core/_components/tables/ht-table/type/link/ht-table-type-link.component.scss
@@ -8,6 +8,11 @@
   overflow: visible;
 }
 
+// Action links (onClick, no href) need an explicit pointer cursor.
+a.link[role='button'] {
+  cursor: pointer;
+}
+
 a.link:has(fa-icon) {
   display: inline-flex;
   align-items: center;

--- a/src/app/core/_components/tables/ht-table/type/link/ht-table-type-link.component.ts
+++ b/src/app/core/_components/tables/ht-table/type/link/ht-table-type-link.component.ts
@@ -39,6 +39,11 @@ export class HTTableTypeLinkComponent implements OnDestroy {
     this.linkClicked.emit();
   }
 
+  onActionClicked(link: HTTableRouterLink) {
+    link.onClick?.();
+    this.linkClicked.emit();
+  }
+
   ngOnDestroy(): void {
     for (const objectUrl of this.objectUrls) {
       URL.revokeObjectURL(objectUrl);

--- a/src/app/core/_components/tables/tasks-table/tasks-table.component.spec.ts
+++ b/src/app/core/_components/tables/tasks-table/tasks-table.component.spec.ts
@@ -233,17 +233,31 @@ describe('TasksTableComponent', () => {
       });
     });
 
-    it('should render NAME column routerLink with null link for SUPERTASK', (done) => {
+    it('should render NAME column for SUPERTASK with an onClick that opens the subtasks dialog', (done) => {
       const columns = component.getColumns();
       const nameColumn = columns.find((col) => col.id === TaskTableCol.NAME);
       const taskWrapper = {
+        id: 42,
         taskType: TaskType.SUPERTASK,
         displayName: 'Test Supertask'
       } as JTaskWrapperDisplay;
 
+      mockDialog.open.and.returnValue({
+        afterClosed: () => of(undefined)
+      } as unknown as ReturnType<typeof mockDialog.open>);
+
       nameColumn?.routerLink!(taskWrapper).subscribe((links) => {
         expect(links[0].label).toBe('Test Supertask');
         expect(links[0].routerLink).toBeNull();
+        expect(links[0].onClick).toBeDefined();
+
+        links[0].onClick!();
+        expect(mockDialog.open).toHaveBeenCalledWith(
+          jasmine.anything(),
+          jasmine.objectContaining({
+            data: { supertaskId: 42, supertaskName: 'Test Supertask' }
+          })
+        );
         done();
       });
     });

--- a/src/app/core/_components/tables/tasks-table/tasks-table.component.ts
+++ b/src/app/core/_components/tables/tasks-table/tasks-table.component.ts
@@ -851,12 +851,13 @@ export class TasksTableComponent extends BaseTableComponent implements OnInit, O
         }
       ]);
     } else {
-      // Supertask: No link
+      // Supertask: clicking the name opens the subtasks dialog (same path as the row action).
       return of([
         {
           label: wrapper.displayName ?? '',
           routerLink: null,
-          tooltip: ''
+          tooltip: 'Show subtasks',
+          onClick: () => this.rowActionEditSubtasks(wrapper)
         }
       ]);
     }


### PR DESCRIPTION
Previously in the task list the supertask name had no clickable name.

Now open the subtask dialog (same dialog can also be opened with the action dot menu at the end of the row).

Needed small change to ht table as previously we had just links to another page but now we need an action handler to open a modal (subtasks).

Issue: https://github.com/hashtopolis/server/issues/1704
