### PR TITLE
When config setting 'Use speed benchmarking estimation' is checked then new task/preconfigured task is now set to 'Speed Test' otherwise 'Runtime Benchmark'

### DIFF
--- a/src/app/core/_models/config-ui.schema.ts
+++ b/src/app/core/_models/config-ui.schema.ts
@@ -19,7 +19,8 @@ export const uisCacheNames = [
   'statustimer',
   'agenttimeout',
   'maxSessionLength',
-  'hideImportMasks'
+  'hideImportMasks',
+  'defaultBenchmark'
 ] as const;
 
 export type UisCacheName = (typeof uisCacheNames)[number];
@@ -66,6 +67,7 @@ export const uisSettingsSchema = z.preprocess(
     maxSessionLength: z.coerce.number().default(0),
     hashcatBrainEnable: z.coerce.number().default(0),
     hideImportMasks: z.coerce.number().default(1),
+    defaultBenchmark: z.coerce.number().default(1),
     // String (already strings from API)
     hashlistAlias: z.coerce.string().default('#HL#'),
     blacklistChars: z.coerce.string().default(''),

--- a/src/app/core/_services/shared/storage.service.spec.ts
+++ b/src/app/core/_services/shared/storage.service.spec.ts
@@ -29,6 +29,7 @@ function makeUiSettings(overrides: Partial<UiSettings> = {}): UiSettings {
     hashlistAlias: '#HL#',
     blacklistChars: '',
     hideImportMasks: 1,
+    defaultBenchmark: 1,
     _timestamp: Date.now(),
     _expiresin: 72 * 60 * 60 * 1000,
     ...overrides

--- a/src/app/tasks/new-preconfigured-tasks/new-preconfigured-tasks.form.ts
+++ b/src/app/tasks/new-preconfigured-tasks/new-preconfigured-tasks.form.ts
@@ -28,6 +28,7 @@ export interface NewPretaskForm {
  * Get an empty instance of NewPretaskForm
  */
 export function getNewPretaskForm(uiService: UIConfigService): FormGroup<NewPretaskForm> {
+  const useSpeedBenchmark = uiService.getUISettings()?.defaultBenchmark !== 0;
   return new FormGroup<NewPretaskForm>({
     taskName: new FormControl('', {
       nonNullable: true,
@@ -45,7 +46,7 @@ export function getNewPretaskForm(uiService: UIConfigService): FormGroup<NewPret
     isCpuTask: new FormControl(false, { nonNullable: true }),
     crackerBinaryTypeId: new FormControl(1, { nonNullable: true }),
     isSmall: new FormControl(false, { nonNullable: true }),
-    useNewBench: new FormControl(true, { nonNullable: true }),
+    useNewBench: new FormControl(useSpeedBenchmark, { nonNullable: true }),
     isMaskImport: new FormControl(false, { nonNullable: true }),
     files: new FormControl([], { nonNullable: true })
   });

--- a/src/app/tasks/new-tasks/new-tasks.component.spec.ts
+++ b/src/app/tasks/new-tasks/new-tasks.component.spec.ts
@@ -355,6 +355,32 @@ describe('NewTasksComponent', () => {
     });
   });
 
+  describe('Benchmark default from settings (useNewBench)', () => {
+    it('should default useNewBench to true (Speed Test) when defaultBenchmark is 1', async () => {
+      uiServiceMock.getUISettings.and.returnValue({ defaultBenchmark: 1 } as unknown as UiSettings);
+
+      await initComponent(fixture);
+
+      expect(component.form.controls.useNewBench.value).toBe(true);
+    });
+
+    it('should default useNewBench to false (Runtime Benchmark) when defaultBenchmark is 0', async () => {
+      uiServiceMock.getUISettings.and.returnValue({ defaultBenchmark: 0 } as unknown as UiSettings);
+
+      await initComponent(fixture);
+
+      expect(component.form.controls.useNewBench.value).toBe(false);
+    });
+
+    it('should fall back to true (Speed Test) when defaultBenchmark is absent', async () => {
+      uiServiceMock.getUISettings.and.returnValue({} as unknown as UiSettings);
+
+      await initComponent(fixture);
+
+      expect(component.form.controls.useNewBench.value).toBe(true);
+    });
+  });
+
   describe('onSubmit', () => {
     it('should have an invalid form by default after init', async () => {
       await initComponent(fixture);

--- a/src/app/tasks/new-tasks/new-tasks.form.ts
+++ b/src/app/tasks/new-tasks/new-tasks.form.ts
@@ -46,6 +46,7 @@ export const getNewTaskForm = (uiService: UIConfigService) => {
   const priority = environment.config.tasks.priority;
   const maxAgents = environment.config.tasks.maxAgents;
   const chunkSize = environment.config.tasks.chunkSize;
+  const useSpeedBenchmark = uiService.getUISettings()?.defaultBenchmark !== 0;
   return new FormGroup<NewTaskForm>({
     taskName: new FormControl<string>('', {
       nonNullable: true,
@@ -76,7 +77,7 @@ export const getNewTaskForm = (uiService: UIConfigService) => {
     preprocessorId: new FormControl<number>(0, { nonNullable: true }),
     preprocessorCommand: new FormControl<string>('', { nonNullable: true }),
     isSmall: new FormControl<boolean>(false, { nonNullable: true }),
-    useNewBench: new FormControl<boolean>(true, { nonNullable: true }),
+    useNewBench: new FormControl<boolean>(useSpeedBenchmark, { nonNullable: true }),
     files: new FormControl<number[]>([], { nonNullable: true })
   });
 };


### PR DESCRIPTION
When the checkbox (Use speed benchmarking estimation) is enabled -> on new task / new preconfigured task, the benchmark type preselected should be "Speed Test"
When the checkbox (Use speed benchmarking estimation) is disabled -> on new task / new preconfigured task, the benchmark type preselected should be "Runtime Benchmark"

Issue: https://github.com/hashtopolis/server/issues/2248