### PR TITLE
Added use/not use brain option in hashlist creation page

### DIFF
--- a/src/app/hashlists/new-hashlist/new-hashlist.component.html
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.html
@@ -53,7 +53,7 @@
           @if (useBrain) {
             <input-select title="Brain mode" formControlName="brainFeatures" [items]="selectFormatbrain"></input-select>
             <fixed-alert
-              message="Note: When brain is enabled, it'll create a network server. If used wrongly, it could cause bottlenecks or collapse the network server. You can disable this setting in Config > Server > General Settings."
+              message="Note: When brain is enabled, Hashtopolis will connect to your Hashcat Brain server using the host, port and password configured in Config > Server > General Settings. Make sure your Brain server is running independently before using this option."
             ></fixed-alert>
           }
           <app-divider />

--- a/src/app/hashlists/new-hashlist/new-hashlist.component.html
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.html
@@ -49,12 +49,13 @@
         <div>
           <app-divider />
           <h5>Hashcat Brain Enabled</h5>
-          <input-select title="Brain mode" formControlName="brainFeatures" [items]="selectFormatbrain"></input-select>
-          <fixed-alert
-            message="Note: When brain is enabled, it'll create a network server. If used wrongly,
-      it could cause bottlenecks or collapse the network server. You can disable
-      this setting in Config > Server > General Settings."
-          ></fixed-alert>
+          <input-check title="Use Hashcat Brain for this hashlist" formControlName="useBrain"></input-check>
+          @if (useBrain) {
+            <input-select title="Brain mode" formControlName="brainFeatures" [items]="selectFormatbrain"></input-select>
+            <fixed-alert
+              message="Note: When brain is enabled, it'll create a network server. If used wrongly, it could cause bottlenecks or collapse the network server. You can disable this setting in Config > Server > General Settings."
+            ></fixed-alert>
+          }
           <app-divider />
         </div>
       }

--- a/src/app/hashlists/new-hashlist/new-hashlist.component.spec.ts
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.spec.ts
@@ -163,9 +163,9 @@ describe('NewHashlistComponent', () => {
       expect(component.isLoadingHashtypes).toBeFalse();
     });
 
-    it('should load config and patch form for brainenabled', () => {
+    it('should load config and set brainenabled, keeping useBrain false by default', () => {
       expect(component.brainenabled).toBe(1);
-      expect(component.form.controls.useBrain.value).toBeTrue();
+      expect(component.form.controls.useBrain.value).toBeFalse();
     });
   });
 
@@ -323,6 +323,49 @@ describe('NewHashlistComponent', () => {
     expect(unsubSpy.unsubscribeAll).toHaveBeenCalled();
     expect(nextSpy).toHaveBeenCalled();
     expect(completeSpy).toHaveBeenCalled();
+  });
+
+  describe('Hashcat Brain opt-in', () => {
+    it('should show the "Use Hashcat Brain" checkbox when brain is globally enabled', () => {
+      fixture.detectChanges();
+      const checkbox = fixture.debugElement.query(By.css('input-check[formcontrolname="useBrain"]'));
+      expect(checkbox).not.toBeNull();
+    });
+
+    it('should NOT render brain mode selector when useBrain is false', () => {
+      component.form.controls.useBrain.setValue(false);
+      fixture.detectChanges();
+      const modeSelect = fixture.debugElement.query(By.css('input-select[formcontrolname="brainFeatures"]'));
+      expect(modeSelect).toBeNull();
+    });
+
+    it('should render brain mode selector when useBrain is true', () => {
+      component.form.controls.useBrain.setValue(true);
+      component['changeDetectorRef'].detectChanges();
+      const modeSelect = fixture.debugElement.query(By.css('input-select[formcontrolname="brainFeatures"]'));
+      expect(modeSelect).not.toBeNull();
+    });
+
+    it('should NOT show brain section when brain is globally disabled', fakeAsync(() => {
+      const disabledConfig: ResponseWrapper = mockResponse({
+        data: {
+          id: 66,
+          type: 'config',
+          attributes: { configSectionId: 1, item: 'Enable Brain', value: '0' }
+        }
+      });
+      (gsSpy.get as jasmine.Spy).withArgs(SERV.CONFIGS, 66).and.returnValue(of(disabledConfig));
+
+      fixture = TestBed.createComponent(NewHashlistComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(component.brainenabled).toBe(0);
+      const checkbox = fixture.debugElement.query(By.css('input-check[formcontrolname="useBrain"]'));
+      expect(checkbox).toBeNull();
+    }));
   });
 
   describe('Access group scoping', () => {

--- a/src/app/hashlists/new-hashlist/new-hashlist.component.ts
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.ts
@@ -188,6 +188,10 @@ export class NewHashlistComponent implements OnInit, OnDestroy {
     return this.form.controls.sourceType.value;
   }
 
+  get useBrain() {
+    return this.form.controls.useBrain.value;
+  }
+
   /**
    * Load configurations
    * ToDO. id could change
@@ -196,7 +200,6 @@ export class NewHashlistComponent implements OnInit, OnDestroy {
     const configSubscription$ = this.gs.get(SERV.CONFIGS, 66).subscribe((response: ResponseWrapper) => {
       const config: JConfig = new JsonAPISerializer().deserialize(response, zConfigResponse);
       this.brainenabled = Number(config.value);
-      this.form.patchValue({ useBrain: !!this.brainenabled });
       this.changeDetectorRef.detectChanges();
     });
     this.unsubscribeService.add(configSubscription$);


### PR DESCRIPTION
UseBrain getter added to the component to use it on the html, where a checkbox to use Brain or not has been added in order to allow de user choose if Brain is wanted or not. This functionality exists only when hashcat brain is enabled in General Settings.