### PR TITLE
Fixed texts to be consistent

### DIFF
--- a/src/app/config/health-checks/new-health-check/new-health-checks.component.ts
+++ b/src/app/config/health-checks/new-health-check/new-health-checks.component.ts
@@ -72,7 +72,7 @@ export class NewHealthChecksComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Builds the form for creating a new SuperHashlist.
+   * Builds the form for creating a new Superhashlist.
    */
   buildForm(): void {
     this.form = new FormGroup<NewHealthCheckForm>({

--- a/src/app/core/_components/forms/custom-forms/superhashlist/new-superhashlist/new-superhashlist.component.html
+++ b/src/app/core/_components/forms/custom-forms/superhashlist/new-superhashlist/new-superhashlist.component.html
@@ -1,4 +1,4 @@
-<app-page title="Create SuperHashlist">
+<app-page title="Create Superhashlist">
   <grid-main [narrow]="true">
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
       <input-text title="Name" formControlName="name" [isRequired]="true"></input-text>

--- a/src/app/core/_components/forms/custom-forms/superhashlist/new-superhashlist/new-superhashlist.component.ts
+++ b/src/app/core/_components/forms/custom-forms/superhashlist/new-superhashlist/new-superhashlist.component.ts
@@ -27,7 +27,7 @@ interface NewSuperhashlistForm {
 }
 
 /**
- * Represents the NewSuperhashlistComponent responsible for creating a new SuperHashlist.
+ * Represents the NewSuperhashlistComponent responsible for creating a new Superhashlist.
  */
 @Component({
   selector: 'app-new-superhashlist',
@@ -39,7 +39,7 @@ export class NewSuperhashlistComponent implements OnInit, OnDestroy {
   /** Flag indicating whether data is still loading. */
   isLoading = true;
 
-  /** Form group for the new SuperHashlist. */
+  /** Form group for the new Superhashlist. */
   form: FormGroup<NewSuperhashlistForm>;
 
   /** Select List of hashlists. */
@@ -56,7 +56,7 @@ export class NewSuperhashlistComponent implements OnInit, OnDestroy {
 
   constructor() {
     this.buildForm();
-    this.titleService.set(['New SuperHashlist']);
+    this.titleService.set(['New Superhashlist']);
   }
 
   /**
@@ -75,7 +75,7 @@ export class NewSuperhashlistComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Builds the form for creating a new SuperHashlist.
+   * Builds the form for creating a new Superhashlist.
    */
   buildForm(): void {
     this.form = new FormGroup<NewSuperhashlistForm>({
@@ -110,15 +110,15 @@ export class NewSuperhashlistComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Handles form submission, creating a new SuperHashlist.
-   * If the form is valid, it makes an API request and navigates to the SuperHashlist page.
+   * Handles form submission, creating a new Superhashlist.
+   * If the form is valid, it makes an API request and navigates to the Superhashlist page.
    */
   onSubmit(): void {
     if (this.form.valid) {
       const createSubscription$ = this.globalService
         .chelper(SERV.HELPER, 'createSuperHashlist', this.form.value)
         .subscribe(() => {
-          this.alert.showSuccessMessage('New SuperHashList created');
+          this.alert.showSuccessMessage('New Superhashlist created');
           this.router.navigate(['hashlists/superhashlist']);
         });
 

--- a/src/app/core/_components/forms/custom-forms/task/new-supertasks/new-supertasks.component.html
+++ b/src/app/core/_components/forms/custom-forms/task/new-supertasks/new-supertasks.component.html
@@ -1,4 +1,4 @@
-<app-page title="Create SuperTask">
+<app-page title="Create Supertask">
   <grid-main [narrow]="true">
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
       <input-text title="Name" formControlName="supertaskName" [isRequired]="true"></input-text>

--- a/src/app/core/_components/forms/custom-forms/task/new-supertasks/new-supertasks.component.ts
+++ b/src/app/core/_components/forms/custom-forms/task/new-supertasks/new-supertasks.component.ts
@@ -19,7 +19,7 @@ import { PRETASKS_FIELD_MAPPING } from '@src/app/core/_constants/select.config';
 import { SelectOption, transformSelectOptions } from '@src/app/shared/utils/forms';
 
 /**
- * Component class to create a new supertask
+ * Component class to create a new Supertask
  */
 @Component({
   selector: 'app-new-supertasks',
@@ -31,10 +31,10 @@ export class NewSupertasksComponent implements OnInit, OnDestroy {
   /** Flag indicating whether data is still loading. */
   isLoading = true;
 
-  /** Form group for the new SuperTask. */
+  /** Form group for the new Supertask. */
   form: FormGroup;
 
-  /** List of PreTasks. */
+  /** List of Preconfigured Tasks. */
   selectPretasks: SelectOption<PretaskId>[];
 
   private unsubscribeService = inject(UnsubscribeService);
@@ -47,7 +47,7 @@ export class NewSupertasksComponent implements OnInit, OnDestroy {
 
   constructor() {
     this.buildForm();
-    this.titleService.set(['New SuperTask']);
+    this.titleService.set(['New Supertask']);
   }
 
   /**
@@ -66,7 +66,7 @@ export class NewSupertasksComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Builds the form for creating a new SuperHashlist.
+   * Builds the form for creating a new Supertask.
    */
   buildForm(): void {
     this.form = this.formBuilder.group({
@@ -95,7 +95,7 @@ export class NewSupertasksComponent implements OnInit, OnDestroy {
   onSubmit() {
     if (this.form.valid) {
       const createSubscription$ = this.gs.create(SERV.SUPER_TASKS, this.form.value).subscribe(() => {
-        this.alert.showSuccessMessage('New SuperTask created');
+        this.alert.showSuccessMessage('New Supertask created');
         this.router.navigate(['tasks/supertasks']);
       });
 

--- a/src/app/core/_components/tables/base-table/base-table.component.spec.ts
+++ b/src/app/core/_components/tables/base-table/base-table.component.spec.ts
@@ -96,11 +96,11 @@ describe('BaseTableComponent', () => {
   });
 
   it('should render supertask link', (done) => {
-    const mockSuperTask = { id: 1, supertaskName: 'Test SuperTask' } as JSuperTask;
+    const mockSuperTask = { id: 1, supertaskName: 'Test Supertask' } as JSuperTask;
     component.renderSupertaskLink(mockSuperTask).subscribe((links) => {
       expect(links.length).toBe(1);
       expect(links[0].routerLink).toEqual(['/tasks/', 1, 'edit']);
-      expect(links[0].label).toBe('Test SuperTask');
+      expect(links[0].label).toBe('Test Supertask');
       done();
     });
   });

--- a/src/app/core/_components/tables/search-hash-table/search-hash-table.constants.ts
+++ b/src/app/core/_components/tables/search-hash-table/search-hash-table.constants.ts
@@ -8,7 +8,7 @@ export enum SearchHashTableCol {
 export const SearchHashTableColumnLabel = {
   [SearchHashTableCol.HASH]: 'Hash',
   [SearchHashTableCol.PLAINTEXT]: 'Plaintext',
-  [SearchHashTableCol.HASHLIST]: 'HashLists',
+  [SearchHashTableCol.HASHLIST]: 'Hashlists',
   [SearchHashTableCol.INFO]: 'Info'
 };
 

--- a/src/app/core/_components/tables/tasks-table/tasks-table.component.spec.ts
+++ b/src/app/core/_components/tables/tasks-table/tasks-table.component.spec.ts
@@ -188,7 +188,7 @@ describe('TasksTableComponent', () => {
       const typeColumn = columns.find((col) => col.id === TaskTableCol.TASK_TYPE);
       const taskWrapper = { taskType: TaskType.SUPERTASK } as JTaskWrapperDisplay;
 
-      expect(typeColumn?.render!(taskWrapper)).toBe('<b>SuperTask</b>');
+      expect(typeColumn?.render!(taskWrapper)).toBe('<b>Supertask</b>');
     });
 
     it('should include NAME column with routerLink function', () => {

--- a/src/app/core/_components/tables/tasks-table/tasks-table.component.ts
+++ b/src/app/core/_components/tables/tasks-table/tasks-table.component.ts
@@ -137,7 +137,7 @@ export class TasksTableComponent extends BaseTableComponent implements OnInit, O
         id: TaskTableCol.TASK_TYPE,
         dataKey: 'taskType',
         render: (wrapper: JTaskWrapperDisplayOverview) =>
-          wrapper.taskType === TaskType.TASK ? 'Task' : '<b>SuperTask</b>',
+          wrapper.taskType === TaskType.TASK ? 'Task' : '<b>Supertask</b>',
         export: async (wrapper: JTaskWrapperDisplayOverview) =>
           wrapper.taskType === TaskType.TASK ? 'Task' : 'Supertask' + '',
         isSortable: true

--- a/src/app/core/_services/main.config.ts
+++ b/src/app/core/_services/main.config.ts
@@ -75,8 +75,8 @@ export class SERV {
   public static GET_FILES = { URL: '/helper/getFile', RESOURCE: 'Files' };
   // HASHLISTS
   public static HASHES = { URL: '/ui/hashes', RESOURCE: 'Hashes' };
-  public static HASHLISTS = { URL: '/ui/hashlists', RESOURCE: 'HashLists' };
-  public static SUPER_HASHLISTS = { URL: '/ui/superhashlists', RESOURCE: 'SuperHashLists' };
+  public static HASHLISTS = { URL: '/ui/hashlists', RESOURCE: 'Hashlists' };
+  public static SUPER_HASHLISTS = { URL: '/ui/superhashlists', RESOURCE: 'Superhashlists' };
   public static HASHES_COUNT = { URL: '/ui/hashes/count', RESOURCE: 'HashesCount' };
   // TASKS
   public static CHUNKS = { URL: '/ui/chunks', RESOURCE: 'Chunks' };

--- a/src/app/core/_services/metadata.service.ts
+++ b/src/app/core/_services/metadata.service.ts
@@ -148,7 +148,7 @@ export class MetadataService {
       title: 'New Supertask',
       customform: false,
       subtitle: false,
-      submitok: 'New SuperTask created!',
+      submitok: 'New Supertask created!',
       submitokredirect: 'tasks/supertasks'
     }
   ];

--- a/src/app/hashlists/edit-hashlist/edit-hashlist.component.html
+++ b/src/app/hashlists/edit-hashlist/edit-hashlist.component.html
@@ -1,5 +1,5 @@
 @if (!isLoading) {
-  <app-page [title]="(type === 3 ? 'SuperHashlist ' : 'Hashlist ') + (editedHashlist?.name ?? '')">
+  <app-page [title]="(type === 3 ? 'Superhashlist ' : 'Hashlist ') + (editedHashlist?.name ?? '')">
     <div class="grid grid-cols-12 gap-4">
       <div class="col-span-12 md:col-span-6">
         <grid-main>

--- a/src/app/hashlists/edit-hashlist/edit-hashlist.component.ts
+++ b/src/app/hashlists/edit-hashlist/edit-hashlist.component.ts
@@ -46,7 +46,7 @@ export class EditHashlistComponent implements OnInit, OnDestroy, CanComponentDea
   editedHashlistIndex: number;
   editedHashlist: JHashlist | undefined; // Change to Model
   hashtype: JHashtype | undefined;
-  type: number | undefined; // Hashlist or SuperHashlist (format)
+  type: number | undefined; // Hashlist or Superhashlist (format)
 
   // Lists of Selected inputs
   selectAccessgroup: Array<SelectOption<AccessGroupId>> = [];

--- a/src/app/hashlists/import-cracked-hashes/import-cracked-hashes.component.html
+++ b/src/app/hashlists/import-cracked-hashes/import-cracked-hashes.component.html
@@ -1,4 +1,4 @@
-<app-page [title]="type === 3 ? 'SuperHashlist details' : 'HashList details'" subtitle="Import pre-cracked hashes">
+<app-page [title]="type === 3 ? 'Superhashlist details' : 'Hashlist details'" subtitle="Import pre-cracked hashes">
   <div class="flex flex-col gap-3">
     <div class="col-md-7">
       @if (!isLoading) {

--- a/src/app/hashlists/import-cracked-hashes/import-cracked-hashes.component.ts
+++ b/src/app/hashlists/import-cracked-hashes/import-cracked-hashes.component.ts
@@ -49,7 +49,7 @@ export class ImportCrackedHashesComponent implements OnInit, OnDestroy {
   // Edit variables
   editedHashlistIndex: number;
   hashtype: JHashtype;
-  type: number; // Hashlist or SuperHashlist
+  type: number; // Hashlist or Superhashlist
 
   selectSource = hashSource;
 

--- a/src/app/hashlists/new-hashlist/new-hashlist.component.spec.ts
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.spec.ts
@@ -277,7 +277,7 @@ describe('NewHashlistComponent', () => {
         jasmine.objectContaining({ sourceData: expectedEncoded })
       );
       expect(component.form.controls.sourceData.value).toBe('some data');
-      expect(alertSpy.showSuccessMessage).toHaveBeenCalledWith('New HashList created');
+      expect(alertSpy.showSuccessMessage).toHaveBeenCalledWith('New Hashlist created');
       expect(routerSpy.navigate).toHaveBeenCalledWith(['/hashlists/hashlist']);
     }));
   });

--- a/src/app/hashlists/new-hashlist/new-hashlist.component.ts
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.ts
@@ -52,7 +52,7 @@ export class NewHashlistComponent implements OnInit, OnDestroy {
   isLoadingAccessGroups = true;
   isLoadingHashtypes = true;
 
-  /** Form group for the new SuperHashlist. */
+  /** Form group for the new Superhashlist. */
   form: FormGroup<NewHashlistForm>;
 
   /** On form create show a spinner loading */

--- a/src/app/hashlists/new-hashlist/new-hashlist.component.ts
+++ b/src/app/hashlists/new-hashlist/new-hashlist.component.ts
@@ -326,11 +326,11 @@ export class NewHashlistComponent implements OnInit, OnDestroy {
 
       try {
         await firstValueFrom(this.gs.create(SERV.HASHLISTS, payload));
-        this.alert.showSuccessMessage('New HashList created');
+        this.alert.showSuccessMessage('New Hashlist created');
         this.router.navigate(['/hashlists/hashlist']);
       } catch (error) {
         console.error('Error creating Hashlist', error);
-        this.alert.showErrorMessage('Failed to create hashlist.');
+        this.alert.showErrorMessage('Failed to create Hashlist.');
       } finally {
         this.isCreatingLoading = false;
       }
@@ -338,11 +338,11 @@ export class NewHashlistComponent implements OnInit, OnDestroy {
       this.isCreatingLoading = true;
       try {
         await firstValueFrom(this.gs.create(SERV.HASHLISTS, this.form.getRawValue()));
-        this.alert.showSuccessMessage('New HashList created');
+        this.alert.showSuccessMessage('New Hashlist created');
         this.router.navigate(['/hashlists/hashlist']);
       } catch (error) {
         console.error('Error creating Hashlist', error);
-        this.alert.showErrorMessage('Failed to create hashlist.');
+        this.alert.showErrorMessage('Failed to create Hashlist.');
       } finally {
         this.isCreatingLoading = false;
       }

--- a/src/app/hashlists/superhashlist/superhashlist.component.ts
+++ b/src/app/hashlists/superhashlist/superhashlist.component.ts
@@ -1,22 +1,21 @@
-import { AutoTitleService } from 'src/app/core/_services/shared/autotitle.service';
+import { Component, OnInit, inject } from '@angular/core';
 
-import { Component } from '@angular/core';
-
+import { RoleService } from '@services/roles/base/role.service';
 import { SuperHashListRoleService } from '@services/roles/hashlists/superhashlist-role.service';
+import { AutoTitleService } from '@services/shared/autotitle.service';
 
 @Component({
   selector: 'app-superhashlist',
   templateUrl: './superhashlist.component.html',
   standalone: false
 })
-export class SuperhashlistComponent {
-  protected showCreateButton: boolean = true;
+export class SuperhashlistComponent implements OnInit {
+  private readonly titleService = inject(AutoTitleService);
+  private readonly roleService: RoleService = inject(SuperHashListRoleService);
 
-  constructor(
-    private titleService: AutoTitleService,
-    private roleService: SuperHashListRoleService
-  ) {
+  protected showCreateButton = this.roleService.hasRole('create');
+
+  ngOnInit(): void {
     this.titleService.set(['Show Superhashlist']);
-    this.showCreateButton = this.roleService.hasRole('create');
   }
 }

--- a/src/app/hashlists/superhashlist/superhashlist.component.ts
+++ b/src/app/hashlists/superhashlist/superhashlist.component.ts
@@ -16,7 +16,7 @@ export class SuperhashlistComponent {
     private titleService: AutoTitleService,
     private roleService: SuperHashListRoleService
   ) {
-    this.titleService.set(['Show SuperHashlist']);
+    this.titleService.set(['Show Superhashlist']);
     this.showCreateButton = this.roleService.hasRole('create');
   }
 }

--- a/src/app/shared/input/multiselect/multiselect.component.html
+++ b/src/app/shared/input/multiselect/multiselect.component.html
@@ -82,7 +82,7 @@
             <span>This field is required.</span>
           }
           @if (errors['mixedHashTypes']) {
-            <span>All selected hashlists must share the same hash type to be combined into a SuperHashlist.</span>
+            <span>All selected hashlists must share the same hash type to be combined into a Superhashlist.</span>
           }
         </mat-hint>
       }

--- a/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.ts
+++ b/src/app/tasks/edit-preconfigured-tasks/edit-preconfigured-tasks.component.ts
@@ -199,7 +199,7 @@ export class EditPreconfiguredTasksComponent implements OnInit, OnDestroy {
 
   /**
    * Handles form submission, edit Pretask
-   * If the form is valid, it makes an API request and navigates to the SuperHashlist page.
+   * If the form is valid, it makes an API request and navigates to the Pretask page.
    */
   onSubmit(): void {
     if (this.updateForm.valid && !this.isReadOnly) {
@@ -208,7 +208,7 @@ export class EditPreconfiguredTasksComponent implements OnInit, OnDestroy {
         .update(SERV.PRETASKS, this.editedPretaskIndex, this.updateForm.value['updateData'])
         .subscribe({
           next: () => {
-            this.alert.showSuccessMessage('PreTask saved');
+            this.alert.showSuccessMessage('Preconfigured Task saved');
             this.isUpdatingLoading = false;
             this.router.navigate(['tasks/preconfigured-tasks']);
           },

--- a/src/app/tasks/edit-supertasks/edit-supertasks.component.ts
+++ b/src/app/tasks/edit-supertasks/edit-supertasks.component.ts
@@ -34,12 +34,12 @@ export class EditSupertasksComponent implements OnInit, OnDestroy {
   /** Flag indicating whether data is still loading. */
   isLoading = true;
 
-  /** Form group for the new SuperTask. */
+  /** Form group for the new Supertask. */
   updateForm: FormGroup;
   etForm: FormGroup; //estimation time form
   viewForm: FormGroup; //Supertask details
 
-  /** List of PreTasks. */
+  /** List of Preconfigured Tasks. */
   selectPretasks: SelectOption<PretaskId>[] | undefined;
 
   // Edit
@@ -76,7 +76,7 @@ export class EditSupertasksComponent implements OnInit, OnDestroy {
 
   constructor() {
     this.buildForm();
-    this.titleService.set(['Edit SuperTasks']);
+    this.titleService.set(['Edit Supertasks']);
   }
 
   /**
@@ -96,7 +96,7 @@ export class EditSupertasksComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Builds the form for creating a new SuperHashlist.
+   * Builds the form for creating a new Superhashlist.
    */
   buildForm(): void {
     // Form details
@@ -247,9 +247,9 @@ export class EditSupertasksComponent implements OnInit, OnDestroy {
       const updateSubscription$ = this.gs
         .postRelationships(SERV.SUPER_TASKS, this.editedSTIndex, RelationshipType.PRETASKS, responseBody)
         .subscribe(() => {
-          this.alert.showSuccessMessage('SuperTask saved');
+          this.alert.showSuccessMessage('Supertask saved');
           this.refresh(); // Reload the Pretask-Select-Component
-          this.superTasksPretasksTable.reload(); // reload SuperTasks table
+          this.superTasksPretasksTable.reload(); // reload Supertasks table
         });
       this.unsubscribeService.add(updateSubscription$);
     } else {

--- a/src/app/tasks/edit-tasks/edit-tasks.component.html
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.html
@@ -54,7 +54,7 @@
                       hashlistinform.format === 0
                         ? 'Hashlist'
                         : hashlistinform.format === 3
-                          ? 'SuperHashlist'
+                          ? 'Superhashlist'
                           : 'Hashlist not found'
                     "
                     [value]="hashlistinform.name + ' / ' + hashlistDescrip"

--- a/src/app/tasks/import-supertasks/masks/masks.component.ts
+++ b/src/app/tasks/import-supertasks/masks/masks.component.ts
@@ -21,7 +21,7 @@ import { JsonAPISerializer } from '@src/app/core/_services/api/serializer-servic
 import { SelectOption, transformSelectOptions } from '@src/app/shared/utils/forms';
 
 /**
- * ImportSupertaskMaskComponent is a component responsible for importing SuperTasks with masks.
+ * ImportSupertaskMaskComponent is a component responsible for importing Supertasks with masks.
  *
  */
 @Component({

--- a/src/app/tasks/new-preconfigured-tasks/new-preconfigured-tasks.component.ts
+++ b/src/app/tasks/new-preconfigured-tasks/new-preconfigured-tasks.component.ts
@@ -178,12 +178,12 @@ export class NewPreconfiguredTasksComponent implements OnInit, OnDestroy {
       this.isCreatingLoading = true;
       const onSubmitSubscription$ = this.gs.create(SERV.PRETASKS, this.createForm.value).subscribe({
         next: () => {
-          this.alert.showSuccessMessage('New PreTask created');
+          this.alert.showSuccessMessage('New Preconfigured Task created');
           this.isCreatingLoading = false;
           this.router.navigate(['tasks/preconfigured-tasks']);
         },
         error: (err) => {
-          console.error('Error creating PreTask', err);
+          console.error('Error creating Preconfigured Task', err);
           this.isCreatingLoading = false;
         }
       });

--- a/src/app/tasks/new-tasks/new-tasks.component.ts
+++ b/src/app/tasks/new-tasks/new-tasks.component.ts
@@ -88,7 +88,7 @@ export class NewTasksComponent implements OnInit {
   selectCrackerversions: SelectOption<CrackerBinaryId>[];
   selectPreprocessor: SelectOption<PreprocessorId>[];
 
-  // Copy Task or PreTask configuration
+  // Copy Task or Preconfigured Task configuration
   copyMode = false;
   copyFiles: FileId[];
   editedIndex: number;

--- a/src/app/tasks/supertasks/applyhashlist.component.ts
+++ b/src/app/tasks/supertasks/applyhashlist.component.ts
@@ -46,7 +46,7 @@ export class ApplyHashlistComponent implements OnInit, OnDestroy {
   /** Flag indicating whether data is still loading. */
   isLoading = true;
 
-  /** Form group for the new SuperHashlist. */
+  /** Form group for the new Superhashlist. */
   form: FormGroup<ApplyHashlistForm>;
 
   /** On form create show a spinner loading */
@@ -57,7 +57,7 @@ export class ApplyHashlistComponent implements OnInit, OnDestroy {
   selectCrackertype: SelectOption<CrackerBinaryTypeId>[];
   selectCrackerversions: SelectOption<CrackerBinaryId>[];
 
-  // Get SuperTask Index
+  // Get Supertask Index
   editedIndex: number;
 
   /**
@@ -112,7 +112,7 @@ export class ApplyHashlistComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Builds the form for creating a new SuperHashlist.
+   * Builds the form for creating a new Superhashlist.
    */
   buildForm(): void {
     this.form = new FormGroup<ApplyHashlistForm>({
@@ -124,7 +124,7 @@ export class ApplyHashlistComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Initializes the form for creating a new SuperHashlist.
+   * Initializes the form for creating a new Superhashlist.
    * Sets up form controls with default values and subscribes to changes for handling select cracker binary.
    * Loads necessary data.
    *
@@ -255,7 +255,7 @@ export class ApplyHashlistComponent implements OnInit, OnDestroy {
         crackerVersionId: formValue.crackerBinaryTypeId
       };
       const onSubmitSubscription$ = this.gs.chelper(SERV.HELPER, 'createSupertask', adaptedFormValue).subscribe(() => {
-        this.alert.showSuccessMessage('New SuperTask created');
+        this.alert.showSuccessMessage('New Supertask created');
         this.router.navigate(['tasks/show-tasks']);
         this.isCreatingLoading = false;
       });


### PR DESCRIPTION
There were inconsistencies how titles and texts were written for some objects (where presented to the user), these adjusts it to what should be used (and was used already until now also in the previous frontend), typically not having camel case for single words:

- `Hashlist` (not `HashList` 
- `Superhashlist` (not `SuperHashlist` or `SuperHashList`)
- `Preconfigured Task` (not `PreTask`)
- `Supertask` (not `SuperTask`)


NOTE: I only changed any textual representation shown to the user and in comments, not in any variables or other programmatic elements!

