### PR TITLE
added display limit to fix visual bug

### DIFF
--- a/src/app/core/_components/tables/tasks-table/tasks-table.component.spec.ts
+++ b/src/app/core/_components/tables/tasks-table/tasks-table.component.spec.ts
@@ -330,7 +330,11 @@ describe('TasksTableComponent', () => {
     it('should render DISPATCHED_SEARCHED with "0" fallback when dispatched is undefined', () => {
       const columns = component.getColumns();
       const dispatchedCol = columns.find((col) => col.id === TaskTableCol.DISPATCHED_SEARCHED);
-      const taskWrapper = { dispatched: undefined, searched: '10', taskType: TaskType.TASK } as unknown as JTaskWrapperDisplay;
+      const taskWrapper = {
+        dispatched: undefined,
+        searched: '10',
+        taskType: TaskType.TASK
+      } as unknown as JTaskWrapperDisplay;
 
       expect(dispatchedCol?.render!(taskWrapper)).toBe('0 / 10');
     });
@@ -338,7 +342,11 @@ describe('TasksTableComponent', () => {
     it('should render DISPATCHED_SEARCHED with "0" fallback when searched is undefined', () => {
       const columns = component.getColumns();
       const dispatchedCol = columns.find((col) => col.id === TaskTableCol.DISPATCHED_SEARCHED);
-      const taskWrapper = { dispatched: '30', searched: undefined, taskType: TaskType.TASK } as unknown as JTaskWrapperDisplay;
+      const taskWrapper = {
+        dispatched: '30',
+        searched: undefined,
+        taskType: TaskType.TASK
+      } as unknown as JTaskWrapperDisplay;
 
       expect(dispatchedCol?.render!(taskWrapper)).toBe('30 / 0');
     });
@@ -346,7 +354,11 @@ describe('TasksTableComponent', () => {
     it('should render DISPATCHED_SEARCHED as "0 / 0" when both are undefined', () => {
       const columns = component.getColumns();
       const dispatchedCol = columns.find((col) => col.id === TaskTableCol.DISPATCHED_SEARCHED);
-      const taskWrapper = { dispatched: undefined, searched: undefined, taskType: TaskType.TASK } as unknown as JTaskWrapperDisplay;
+      const taskWrapper = {
+        dispatched: undefined,
+        searched: undefined,
+        taskType: TaskType.TASK
+      } as unknown as JTaskWrapperDisplay;
 
       expect(dispatchedCol?.render!(taskWrapper)).toBe('0 / 0');
     });
@@ -420,6 +432,23 @@ describe('TasksTableComponent', () => {
       hashlistsColumn?.routerLink!(taskWrapper).subscribe((links) => {
         expect(links[0].label).toBe('Test Hashlist');
         expect(links[0].routerLink).toEqual(['/hashlists', 'hashlist', 5, 'edit']);
+        done();
+      });
+    });
+
+    it('should truncate long HASHLISTS label and keep full name in tooltip', (done) => {
+      const columns = component.getColumns();
+      const hashlistsColumn = columns.find((col) => col.id === TaskTableCol.HASHLISTS);
+      const longName = 'This is a very long hashlist name that should be truncated';
+      const taskWrapper = {
+        hashlistId: 11,
+        hashlistName: longName
+      } as JTaskWrapperDisplay;
+
+      hashlistsColumn?.routerLink!(taskWrapper).subscribe((links) => {
+        expect(links[0].label).toBe('This is a very long ...');
+        expect(links[0].tooltip).toBe(longName);
+        expect(links[0].routerLink).toEqual(['/hashlists', 'hashlist', 11, 'edit']);
         done();
       });
     });

--- a/src/app/core/_components/tables/tasks-table/tasks-table.component.ts
+++ b/src/app/core/_components/tables/tasks-table/tasks-table.component.ts
@@ -890,14 +890,18 @@ export class TasksTableComponent extends BaseTableComponent implements OnInit, O
    */
   private renderHashlistLinkFromWrapper(wrapper: JTaskWrapperDisplayOverview): Observable<HTTableRouterLink[]> {
     const links: HTTableRouterLink[] = [];
+    const maxHashlistLabelLength = 20;
 
     if (wrapper && wrapper.hashlistId !== undefined) {
       const id = wrapper.hashlistId;
-      const name = wrapper.hashlistName || String(id);
+      const fullName = wrapper.hashlistName || String(id);
+      const truncatedName =
+        fullName.length > maxHashlistLabelLength ? `${fullName.substring(0, maxHashlistLabelLength)}...` : fullName;
 
       links.push({
         routerLink: ['/hashlists', 'hashlist', id, 'edit'],
-        label: name
+        label: truncatedName,
+        tooltip: fullName
       });
     }
     return of(links);


### PR DESCRIPTION
Added a 20 character display limit on the hashlist's name in order to ensure cracked-check visibility. Spec updated regarding this scenario