### PR TITLE
Increase truncation length for hashes

### DIFF
--- a/src/app/core/_components/tables/cracks-table/cracks-table.component.ts
+++ b/src/app/core/_components/tables/cracks-table/cracks-table.component.ts
@@ -15,6 +15,7 @@ import { CracksTableCol, CracksTableColumnLabel } from '@components/tables/crack
 import { HTTableColumn, HTTableRouterLink } from '@components/tables/ht-table/ht-table.models';
 import { TableDialogComponent } from '@components/tables/table-dialog/table-dialog.component';
 import { DialogData } from '@components/tables/table-dialog/table-dialog.model';
+import { TABLE_TRUNCATE_MAX_LENGTH } from '@components/tables/table-truncate/table-truncate.component';
 
 import { CracksDataSource } from '@datasources/cracks.datasource';
 
@@ -95,7 +96,7 @@ export class CracksTableComponent extends BaseTableComponent implements OnInit, 
         isSortable: true,
         isSearchable: true,
         isCopy: true,
-        truncate: (crack: JHash) => crack.hash.length > 40,
+        truncate: (crack: JHash) => crack.hash.length > TABLE_TRUNCATE_MAX_LENGTH,
         export: async (crack: JHash) => crack.hash
       },
       {

--- a/src/app/core/_components/tables/hashes-table/hashes-table.component.ts
+++ b/src/app/core/_components/tables/hashes-table/hashes-table.component.ts
@@ -8,6 +8,7 @@ import { RowActionMenuAction } from '@components/menus/row-action-menu/row-actio
 import { BaseTableComponent } from '@components/tables/base-table/base-table.component';
 import { HashesTableCol, HashesTableColColumnLabel } from '@components/tables/hashes-table/hashes-table.constants';
 import { HTTableColumn } from '@components/tables/ht-table/ht-table.models';
+import { TABLE_TRUNCATE_MAX_LENGTH } from '@components/tables/table-truncate/table-truncate.component';
 
 import { HashesDataSource } from '@datasources/hashes.datasource';
 
@@ -78,7 +79,7 @@ export class HashesTableComponent extends BaseTableComponent implements OnInit, 
         isSortable: true,
         isSearchable: true,
         isCopy: true,
-        truncate: (hash: JHash) => hash.hash.length > 40,
+        truncate: (hash: JHash) => hash.hash.length > TABLE_TRUNCATE_MAX_LENGTH,
         export: async (hash: JHash) => hash.hash + ''
       },
       {

--- a/src/app/core/_components/tables/table-truncate/table-truncate.component.html
+++ b/src/app/core/_components/tables/table-truncate/table-truncate.component.html
@@ -1,4 +1,4 @@
-<div class="flex relative max-w-full">
+<div class="flex relative max-w-full font-mono">
   @if (!expanded) {
     <div>{{ abbr }}</div>
   }

--- a/src/app/core/_components/tables/table-truncate/table-truncate.component.ts
+++ b/src/app/core/_components/tables/table-truncate/table-truncate.component.ts
@@ -2,6 +2,11 @@ import { Component, Input, OnInit } from '@angular/core';
 
 import { BaseModel, DynamicModel } from '@models/base.model';
 
+import { truncateMiddle } from '@src/app/shared/utils/util';
+
+/** Text up to this length is shown in full; longer values get a middle ellipsis. */
+export const TABLE_TRUNCATE_MAX_LENGTH = 64;
+
 /**
  * Component for truncating and expanding text with a "More/Less" button.
  */
@@ -14,7 +19,7 @@ import { BaseModel, DynamicModel } from '@models/base.model';
 export class TableTruncateComponent implements OnInit {
   @Input() text: string | BaseModel;
   @Input() path: string;
-  @Input() maxLength = 30;
+  @Input() maxLength = TABLE_TRUNCATE_MAX_LENGTH;
   @Input() endLength = 10;
 
   expanded = false;
@@ -24,13 +29,7 @@ export class TableTruncateComponent implements OnInit {
   ngOnInit(): void {
     this.displayText = typeof this.text === 'string' ? this.text : String((this.text as DynamicModel)[this.path] ?? '');
 
-    if (this.displayText.length > this.maxLength) {
-      const start = this.displayText.substring(0, this.maxLength);
-      const end = this.displayText.substring(this.displayText.length - this.endLength);
-      this.abbr = `${start}…${end}`;
-    } else {
-      this.abbr = this.displayText;
-    }
+    this.abbr = truncateMiddle(this.displayText, this.maxLength, this.endLength);
   }
 
   toggleExpansion(event: MouseEvent): void {

--- a/src/app/shared/utils/util.spec.ts
+++ b/src/app/shared/utils/util.spec.ts
@@ -1,0 +1,32 @@
+import { truncateMiddle } from '@src/app/shared/utils/util';
+
+describe('truncateMiddle', () => {
+  it('returns the value unchanged when it is not longer than maxLength', () => {
+    expect(truncateMiddle('000405dbc07c3b595fc87031af6f9879', 64, 10)).toBe('000405dbc07c3b595fc87031af6f9879');
+  });
+
+  it('leaves a value at exactly maxLength untouched (boundary)', () => {
+    const sha256 = 'a'.repeat(64);
+    expect(truncateMiddle(sha256, 64, 10)).toBe(sha256);
+  });
+
+  it('cuts a contiguous middle slice once longer than maxLength', () => {
+    // 65 chars: keep first 54 + "…" + last 10, removing exactly the 1 middle char (index 54).
+    const value = Array.from({ length: 65 }, (_, i) => String(i % 10)).join('');
+    const result = truncateMiddle(value, 64, 10);
+    expect(result).toBe(value.slice(0, 54) + '…' + value.slice(-10));
+  });
+
+  it('never overlaps the start and end slices (no duplicated characters)', () => {
+    const value = 'x'.repeat(128);
+    const [start, end] = truncateMiddle(value, 64, 10).split('…');
+    // start + end must sum to at most maxLength, so the ellipsis stands for real omitted chars.
+    expect(start.length + end.length).toBe(64);
+    expect(128 - (start.length + end.length)).toBeGreaterThan(0);
+  });
+
+  it('is never rendered longer than the original value', () => {
+    const value = 'y'.repeat(65);
+    expect(truncateMiddle(value, 64, 10).length).toBeLessThanOrEqual(value.length);
+  });
+});

--- a/src/app/shared/utils/util.ts
+++ b/src/app/shared/utils/util.ts
@@ -139,3 +139,21 @@ export const convertCrackingSpeed = (speed: number): string => {
 export const convertToLocale = (value: number) => {
   return (Math.round(value * 100) / 100).toLocaleString();
 };
+
+/**
+ * Shortens a string with a single "…" in the middle, keeping the leading and trailing characters.
+ * Strings no longer than `maxLength` are returned unchanged.
+ *
+ * @param value - the string to shorten
+ * @param maxLength - length up to which the value is shown in full
+ * @param endLength - number of trailing characters to keep (must not exceed `maxLength`)
+ * @returns the original string, or `<start>…<end>` when longer than `maxLength`
+ */
+export const truncateMiddle = (value: string, maxLength: number, endLength: number): string => {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  const start = value.substring(0, maxLength - endLength);
+  const end = value.slice(-endLength);
+  return `${start}…${end}`;
+};


### PR DESCRIPTION
Increase length of hashes to truncate to 64 characters limit instead of shorter one. 

Issue: https://github.com/hashtopolis/server/issues/2324