### PR TITLE
Make tables fill container width

### DIFF
--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -84,7 +84,7 @@ table.hashtopolis-table {
   overflow: visible;
   background: linear-gradient(var(--card), var(--card)), var(--background);
   width: auto;
-  min-width: 0;
+  min-width: 100%;
 
   .mat-mdc-row,
   .mat-mdc-cell,


### PR DESCRIPTION
Make sure table expands even when no elements are present.

Before this change when no items were present the tables did not take up full width, for example look at the api keys table. http://localhost:4200/#/account/api-keys

Issue: https://github.com/hashtopolis/server/issues/2251