### PR TITLE
Make sure that visual task speed does not display mixed unit values in same unit graph

### DIFF
--- a/src/app/core/_pipes/hashrate-pipe.spec.ts
+++ b/src/app/core/_pipes/hashrate-pipe.spec.ts
@@ -1,0 +1,17 @@
+import { HashRatePipe } from '@src/app/core/_pipes/hashrate-pipe';
+
+describe('HashRatePipe', () => {
+  const pipe = new HashRatePipe();
+
+  it('formats a hashrate as a human-readable string by default', () => {
+    expect(pipe.transform(5_000_000)).toBe('5 MH/s');
+  });
+
+  it('exposes value, unit and scale (divisor) in object form', () => {
+    expect(pipe.transform(5_000_000, 2, true)).toEqual({ value: 5, unit: 'MH/s', scale: 1_000_000 });
+  });
+
+  it('returns scale 1 for non-positive values', () => {
+    expect(pipe.transform(0, 2, true)).toEqual({ value: 0, unit: 'H/s', scale: 1 });
+  });
+});

--- a/src/app/core/_pipes/hashrate-pipe.spec.ts
+++ b/src/app/core/_pipes/hashrate-pipe.spec.ts
@@ -16,4 +16,26 @@ describe('getHashRateFormatComponents', () => {
   it('returns scale 1 for non-positive values', () => {
     expect(getHashRateFormatComponents(0)).toEqual({ value: 0, unit: 'H/s', scale: 1 });
   });
+
+  it('steps up to the next unit exactly at the 1000 boundary', () => {
+    expect(getHashRateFormatComponents(1000)).toEqual({ value: 1, unit: 'kH/s', scale: 1000 });
+  });
+
+  it('stays in the lower unit just below the boundary', () => {
+    expect(getHashRateFormatComponents(999)).toEqual({ value: 999, unit: 'H/s', scale: 1 });
+  });
+
+  it('keeps scale = 1000 ** i in step with the chosen unit at higher tiers', () => {
+    expect(getHashRateFormatComponents(2_500_000_000)).toEqual({ value: 2.5, unit: 'GH/s', scale: 1_000_000_000 });
+  });
+
+  it('clamps at the largest unit instead of running past the units array', () => {
+    // 3 EH/s worth of H/s: no unit above PH/s, so it stays PH/s with the value left large.
+    expect(getHashRateFormatComponents(3e18)).toEqual({ value: 3000, unit: 'PH/s', scale: 1e15 });
+  });
+
+  it('rounds the scaled value to the requested decimals', () => {
+    expect(getHashRateFormatComponents(1_234_567).value).toBe(1.23);
+    expect(getHashRateFormatComponents(1_234_567, 0).value).toBe(1);
+  });
 });

--- a/src/app/core/_pipes/hashrate-pipe.spec.ts
+++ b/src/app/core/_pipes/hashrate-pipe.spec.ts
@@ -1,17 +1,19 @@
-import { HashRatePipe } from '@src/app/core/_pipes/hashrate-pipe';
+import { HashRatePipe, getHashRateFormatComponents } from '@src/app/core/_pipes/hashrate-pipe';
 
 describe('HashRatePipe', () => {
   const pipe = new HashRatePipe();
 
-  it('formats a hashrate as a human-readable string by default', () => {
+  it('formats a hashrate as a human-readable string', () => {
     expect(pipe.transform(5_000_000)).toBe('5 MH/s');
   });
+});
 
+describe('getHashRateFormatComponents', () => {
   it('exposes value, unit and scale (divisor) in object form', () => {
-    expect(pipe.transform(5_000_000, 2, true)).toEqual({ value: 5, unit: 'MH/s', scale: 1_000_000 });
+    expect(getHashRateFormatComponents(5_000_000)).toEqual({ value: 5, unit: 'MH/s', scale: 1_000_000 });
   });
 
   it('returns scale 1 for non-positive values', () => {
-    expect(pipe.transform(0, 2, true)).toEqual({ value: 0, unit: 'H/s', scale: 1 });
+    expect(getHashRateFormatComponents(0)).toEqual({ value: 0, unit: 'H/s', scale: 1 });
   });
 });

--- a/src/app/core/_pipes/hashrate-pipe.ts
+++ b/src/app/core/_pipes/hashrate-pipe.ts
@@ -1,5 +1,31 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+const UNITS = ['H/s', 'kH/s', 'MH/s', 'GH/s', 'TH/s', 'PH/s'];
+
+/**
+ * Pick a human-readable hash rate unit and return the pieces needed to render it.
+ * @param value - The raw hash rate (e.g. 1000000)
+ * @param decimals - Number of decimal places (default: 2)
+ * @returns value scaled into the chosen unit, the unit label, and the scale
+ *          (raw H/s per displayed unit, i.e. rawValue = value * scale)
+ */
+export function getHashRateFormatComponents(
+  value: number,
+  decimals = 2
+): { value: number; unit: string; scale: number } {
+  if (!value || value <= 0) {
+    return { value: 0, unit: 'H/s', scale: 1 };
+  }
+
+  let i = 0;
+  while (value >= 1000 && i < UNITS.length - 1) {
+    value /= 1000;
+    i++;
+  }
+
+  return { value: +value.toFixed(decimals), unit: UNITS[i], scale: 1000 ** i };
+}
+
 /**
  * Transform hash rate into human-readable format (e.g. H/s, kH/s, MH/s, GH/s)
  * @param hashrate - The hash rate number (e.g. 1000000)
@@ -15,25 +41,8 @@ import { Pipe, PipeTransform } from '@angular/core';
   standalone: false
 })
 export class HashRatePipe implements PipeTransform {
-  private readonly units = ['H/s', 'kH/s', 'MH/s', 'GH/s', 'TH/s', 'PH/s'];
-
-  transform(
-    value: number,
-    decimals: number = 2,
-    asObject: boolean = false
-  ): string | { value: number; unit: string; scale: number } {
-    if (!value || value <= 0) {
-      return asObject ? { value: 0, unit: 'H/s', scale: 1 } : '0 H/s';
-    }
-
-    let i = 0;
-    while (value >= 1000 && i < this.units.length - 1) {
-      value /= 1000;
-      i++;
-    }
-
-    const rounded = +value.toFixed(decimals);
-
-    return asObject ? { value: rounded, unit: this.units[i], scale: 1000 ** i } : `${rounded} ${this.units[i]}`;
+  transform(value: number, decimals = 2): string {
+    const { value: scaled, unit } = getHashRateFormatComponents(value, decimals);
+    return `${scaled} ${unit}`;
   }
 }

--- a/src/app/core/_pipes/hashrate-pipe.ts
+++ b/src/app/core/_pipes/hashrate-pipe.ts
@@ -17,9 +17,13 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class HashRatePipe implements PipeTransform {
   private readonly units = ['H/s', 'kH/s', 'MH/s', 'GH/s', 'TH/s', 'PH/s'];
 
-  transform(value: number, decimals: number = 2, asObject: boolean = false): string | { value: number; unit: string } {
+  transform(
+    value: number,
+    decimals: number = 2,
+    asObject: boolean = false
+  ): string | { value: number; unit: string; scale: number } {
     if (!value || value <= 0) {
-      return asObject ? { value: 0, unit: 'H/s' } : '0 H/s';
+      return asObject ? { value: 0, unit: 'H/s', scale: 1 } : '0 H/s';
     }
 
     let i = 0;
@@ -30,6 +34,6 @@ export class HashRatePipe implements PipeTransform {
 
     const rounded = +value.toFixed(decimals);
 
-    return asObject ? { value: rounded, unit: this.units[i] } : `${rounded} ${this.units[i]}`;
+    return asObject ? { value: rounded, unit: this.units[i], scale: 1000 ** i } : `${rounded} ${this.units[i]}`;
   }
 }

--- a/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.spec.ts
+++ b/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.spec.ts
@@ -51,4 +51,43 @@ describe('TaskSpeedGraphComponent', () => {
     expect(min?.coord[1]).toBe(0.8);
     expect(min?.value).toBe('0.8 MH/s');
   });
+
+  it('sums the speeds of agents reporting at the same timestamp', () => {
+    // Two agents at t=100 (3 MH/s each) collapse into one 6 MH/s point; t=200 stays separate.
+    const option = drawWith([
+      speedStat(100, 3_000_000),
+      speedStat(100, 3_000_000),
+      speedStat(200, 1_000_000)
+    ]);
+    const plotted = option.series[0].data.map((point: { value: [string, number] }) => point.value[1]);
+
+    expect(plotted).toEqual([6, 1]);
+  });
+
+  it('picks the unit from the fastest point even across several orders of magnitude', () => {
+    // Fastest is 2.5 GH/s, so a 20 MH/s point must render proportionally tiny on a GH/s axis, not tower over it.
+    const option = drawWith([speedStat(100, 2_500_000_000), speedStat(200, 20_000_000)]);
+    const plotted = option.series[0].data.map((point: { value: [string, number] }) => point.value[1]);
+
+    expect(option.yAxis[0].name).toBe('GH/s');
+    expect(plotted).toEqual([2.5, 0.02]);
+  });
+
+  it('rounds each plotted value to two decimals', () => {
+    const option = drawWith([speedStat(100, 1_234_000_000)]);
+
+    expect(option.series[0].data[0].value[1]).toBe(1.23);
+  });
+
+  it('clears the chart when the speeds input becomes empty', () => {
+    drawWith([speedStat(100, 5_000_000)]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const chart = (component as any).chart;
+    spyOn(chart, 'clear').and.callThrough();
+
+    component.speeds = [];
+    component.ngOnChanges({ speeds: new SimpleChange([speedStat(100, 5_000_000)], [], false) });
+
+    expect(chart.clear).toHaveBeenCalled();
+  });
 });

--- a/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.spec.ts
+++ b/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.spec.ts
@@ -54,11 +54,7 @@ describe('TaskSpeedGraphComponent', () => {
 
   it('sums the speeds of agents reporting at the same timestamp', () => {
     // Two agents at t=100 (3 MH/s each) collapse into one 6 MH/s point; t=200 stays separate.
-    const option = drawWith([
-      speedStat(100, 3_000_000),
-      speedStat(100, 3_000_000),
-      speedStat(200, 1_000_000)
-    ]);
+    const option = drawWith([speedStat(100, 3_000_000), speedStat(100, 3_000_000), speedStat(200, 1_000_000)]);
     const plotted = option.series[0].data.map((point: { value: [string, number] }) => point.value[1]);
 
     expect(plotted).toEqual([6, 1]);

--- a/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.spec.ts
+++ b/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.spec.ts
@@ -1,10 +1,22 @@
+import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { SpeedStat } from '@src/app/core/_models/speed-stat.model';
 import { TaskSpeedGraphComponent } from '@src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component';
 
 describe('TaskSpeedGraphComponent', () => {
   let component: TaskSpeedGraphComponent;
   let fixture: ComponentFixture<TaskSpeedGraphComponent>;
+
+  const speedStat = (time: number, speed: number): SpeedStat =>
+    ({ id: time, type: 'speed', agentId: 1, taskId: 1, speed, time }) as SpeedStat;
+
+  const drawWith = (speeds: SpeedStat[]) => {
+    component.speeds = speeds;
+    component.ngOnChanges({ speeds: new SimpleChange([], speeds, false) });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (component as any).chart.getOption();
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -18,5 +30,25 @@ describe('TaskSpeedGraphComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('scales every point by one shared unit chosen from the fastest speed', () => {
+    const option = drawWith([speedStat(100, 5_000_000), speedStat(200, 800_000)]);
+    const plotted = option.series[0].data.map((point: { value: [string, number] }) => point.value[1]);
+
+    expect(plotted).toEqual([5, 0.8]);
+    expect(option.yAxis[0].name).toBe('MH/s');
+  });
+
+  it('places the Max/Min markers on the true extremes with the shared unit', () => {
+    const option = drawWith([speedStat(100, 5_000_000), speedStat(200, 800_000)]);
+    const markPoints = option.series[0].markPoint.data as { name: string; coord: [string, number]; value: string }[];
+    const max = markPoints.find((point) => point.name === 'Max');
+    const min = markPoints.find((point) => point.name === 'Min');
+
+    expect(max?.coord[1]).toBe(5);
+    expect(max?.value).toBe('5 MH/s');
+    expect(min?.coord[1]).toBe(0.8);
+    expect(min?.value).toBe('0.8 MH/s');
   });
 });

--- a/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.ts
+++ b/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.ts
@@ -25,12 +25,11 @@ import {
   Input,
   OnChanges,
   SimpleChanges,
-  ViewChild,
-  inject
+  ViewChild
 } from '@angular/core';
 
 import { SpeedStat } from '@src/app/core/_models/speed-stat.model';
-import { HashRatePipe } from '@src/app/core/_pipes/hashrate-pipe';
+import { getHashRateFormatComponents } from '@src/app/core/_pipes/hashrate-pipe';
 
 // Compose ECharts option type
 type EChartsOption = ComposeOption<
@@ -56,8 +55,7 @@ use([
 
 @Component({
   selector: 'app-task-speed-graph',
-  template: `<div #chart style="height: 310px;"></div>`,
-  providers: [HashRatePipe]
+  template: `<div #chart style="height: 310px;"></div>`
 })
 export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
   @Input() speeds: SpeedStat[] = [];
@@ -65,8 +63,6 @@ export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
   @ViewChild('chart', { static: true }) chartRef!: ElementRef;
 
   private chart: EChartsType;
-
-  private hashratePipe = inject(HashRatePipe);
 
   /**
    * Initializes the chart after view is ready.
@@ -110,11 +106,7 @@ export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
     }, {});
 
     const maxRawSpeed = Math.max(...result.map((item) => item.speed));
-    const { unit, scale } = this.hashratePipe.transform(maxRawSpeed, 2, true) as {
-      value: number;
-      unit: string;
-      scale: number;
-    };
+    const { unit, scale } = getHashRateFormatComponents(maxRawSpeed);
 
     const arr: { name: string; value: [string, number]; unit: string }[] = [];
     const timestamps: number[] = [];

--- a/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.ts
+++ b/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.ts
@@ -109,22 +109,23 @@ export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
       return res;
     }, {});
 
+    const maxRawSpeed = Math.max(...result.map((item) => item.speed));
+    const { unit, scale } = this.hashratePipe.transform(maxRawSpeed, 2, true) as {
+      value: number;
+      unit: string;
+      scale: number;
+    };
+
     const arr: { name: string; value: [string, number]; unit: string }[] = [];
     const timestamps: number[] = [];
 
     for (const item of result) {
       const iso = this.transDate(item.time);
-      const transformed = this.hashratePipe.transform(item.speed, 2, true) as {
-        value: number;
-        unit: string;
-      };
-
-      if (!transformed) continue;
 
       arr.push({
         name: iso,
-        value: [iso, transformed.value],
-        unit: transformed.unit
+        value: [iso, +(item.speed / scale).toFixed(2)],
+        unit
       });
 
       timestamps.push(item.time);
@@ -141,7 +142,6 @@ export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
     const maxIndex = speedsOnly.indexOf(maxSpeed);
     const minIndex = speedsOnly.indexOf(minSpeed);
 
-    const displayUnit = arr[maxIndex]?.unit || 'H/s';
     const startdate = timestamps[0];
     const enddate = timestamps[timestamps.length - 1];
     const datelabel = this.transDate(enddate);
@@ -163,7 +163,7 @@ export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
           }
           const data = params.data as { value: [string, number]; unit: string } | undefined;
           if (data?.value?.[1]) {
-            return `${params.name}: <strong>${data.value[1]} ${data.unit ?? ''}</strong>`;
+            return `${params.name}: <strong>${data.value[1]} ${data.unit}</strong>`;
           }
           return '';
         }
@@ -178,7 +178,7 @@ export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
       },
       yAxis: {
         type: 'value',
-        name: displayUnit,
+        name: unit,
         position: 'left',
         alignTicks: true
       },
@@ -214,12 +214,12 @@ export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
             {
               name: 'Max',
               coord: arr[maxIndex]?.value ?? [],
-              value: `${arr[maxIndex]?.value?.[1]} ${arr[maxIndex]?.unit}`
+              value: `${arr[maxIndex]?.value?.[1]} ${unit}`
             },
             {
               name: 'Min',
               coord: arr[minIndex]?.value ?? [],
-              value: `${arr[minIndex]?.value?.[1]} ${arr[minIndex]?.unit}`
+              value: `${arr[minIndex]?.value?.[1]} ${unit}`
             }
           ]
         },

--- a/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.ts
+++ b/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.ts
@@ -18,15 +18,7 @@ import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import type { TopLevelFormatterParams } from 'echarts/types/dist/shared';
 
-import {
-  AfterViewInit,
-  Component,
-  ElementRef,
-  Input,
-  OnChanges,
-  SimpleChanges,
-  ViewChild
-} from '@angular/core';
+import { AfterViewInit, Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
 
 import { SpeedStat } from '@src/app/core/_models/speed-stat.model';
 import { getHashRateFormatComponents } from '@src/app/core/_pipes/hashrate-pipe';
@@ -113,10 +105,11 @@ export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
 
     for (const item of result) {
       const iso = this.transDate(item.time);
+      const convertedValue = +(item.speed / scale).toFixed(2);
 
       arr.push({
         name: iso,
-        value: [iso, +(item.speed / scale).toFixed(2)],
+        value: [iso, convertedValue],
         unit
       });
 


### PR DESCRIPTION
Fix mixed unit values being displayed in the same visual task speed graph. 
Previously the converted values were plotted on the same graph so some values were converted to H/s and some to MH/s for example. Now plot the values in the unit for values that are largest.
For example plot all in MH/s. 

Issue: https://github.com/hashtopolis/server/issues/2315