### PR TITLE
Allow toggling is secret and triggering recount file in file overview page

### DIFF
--- a/src/app/core/_components/tables/files-table/files-table.component.spec.ts
+++ b/src/app/core/_components/tables/files-table/files-table.component.spec.ts
@@ -3,12 +3,17 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { of } from 'rxjs';
+
 import { BaseModel } from '@models/base.model';
 import { JFile } from '@models/file.model';
 
+import { SERV } from '@services/main.config';
+
 import { ActionMenuEvent } from '@components/menus/action-menu/action-menu.model';
+import { RowActionMenuAction } from '@components/menus/row-action-menu/row-action-menu.constants';
 import { FilesTableComponent } from '@components/tables/files-table/files-table.component';
-import { FilesTableColumnLabel } from '@components/tables/files-table/files-table.constants';
+import { FilesRowAction, FilesTableColumnLabel } from '@components/tables/files-table/files-table.constants';
 import { HTTableComponent } from '@components/tables/ht-table/ht-table.component';
 import { HTTableColumn } from '@components/tables/ht-table/ht-table.models';
 
@@ -64,6 +69,50 @@ describe('FilesTableComponent', () => {
   describe('table columns', () => {
     it('should expose columns for files', () => {
       expect(component.tableColumns.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('rowActionClicked', () => {
+    let gs: { update: jasmine.Spy; chelper: jasmine.Spy };
+
+    beforeEach(() => {
+      gs = component['gs'] as unknown as typeof gs;
+      spyOn(gs, 'update').and.returnValue(of({}));
+      spyOn(gs, 'chelper').and.returnValue(of({}));
+      spyOn(component['alertService'], 'showSuccessMessage');
+      spyOn(component, 'reload');
+    });
+
+    it('should set a non-secret file to secret', () => {
+      const file = { id: 7, filename: 'a.txt', isSecret: false } as JFile;
+      component.rowActionClicked({ data: file, menuItem: { action: FilesRowAction.TOGGLE_SECRET, label: '' } });
+
+      expect(gs.update).toHaveBeenCalledWith(SERV.FILES, 7, { isSecret: true });
+      expect(component.reload).toHaveBeenCalled();
+    });
+
+    it('should unset a secret file', () => {
+      const file = { id: 7, filename: 'a.txt', isSecret: true } as JFile;
+      component.rowActionClicked({ data: file, menuItem: { action: FilesRowAction.TOGGLE_SECRET, label: '' } });
+
+      expect(gs.update).toHaveBeenCalledWith(SERV.FILES, 7, { isSecret: false });
+    });
+
+    it('should call the recountFileLines helper', () => {
+      const file = { id: 7, filename: 'a.txt', isSecret: false } as JFile;
+      component.rowActionClicked({ data: file, menuItem: { action: FilesRowAction.RECOUNT_LINES, label: '' } });
+
+      expect(gs.chelper).toHaveBeenCalledWith(SERV.HELPER, 'recountFileLines', { fileId: 7 });
+      expect(component.reload).toHaveBeenCalled();
+    });
+
+    it('should not update or recount on a plain edit action', () => {
+      spyOn(component as unknown as { rowActionEdit: () => void }, 'rowActionEdit');
+      const file = { id: 7, filename: 'a.txt', isSecret: false } as JFile;
+      component.rowActionClicked({ data: file, menuItem: { action: RowActionMenuAction.EDIT, label: '' } });
+
+      expect(gs.update).not.toHaveBeenCalled();
+      expect(gs.chelper).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/core/_components/tables/files-table/files-table.component.ts
+++ b/src/app/core/_components/tables/files-table/files-table.component.ts
@@ -12,7 +12,11 @@ import { ActionMenuEvent } from '@components/menus/action-menu/action-menu.model
 import { BulkActionMenuAction } from '@components/menus/bulk-action-menu/bulk-action-menu.constants';
 import { RowActionMenuAction } from '@components/menus/row-action-menu/row-action-menu.constants';
 import { BaseTableComponent } from '@components/tables/base-table/base-table.component';
-import { FilesTableCol, FilesTableColumnLabel } from '@components/tables/files-table/files-table.constants';
+import {
+  FilesRowAction,
+  FilesTableCol,
+  FilesTableColumnLabel
+} from '@components/tables/files-table/files-table.constants';
 import { HTTableColumn, HTTableRouterLink } from '@components/tables/ht-table/ht-table.models';
 import { TableDialogComponent } from '@components/tables/table-dialog/table-dialog.component';
 import { DialogData } from '@components/tables/table-dialog/table-dialog.model';
@@ -238,6 +242,12 @@ export class FilesTableComponent extends BaseTableComponent implements OnInit, O
       case RowActionMenuAction.DOWNLOAD:
         this.rowActionDownload(event.data);
         break;
+      case FilesRowAction.TOGGLE_SECRET:
+        this.rowActionToggleSecret(event.data);
+        break;
+      case FilesRowAction.RECOUNT_LINES:
+        this.rowActionRecount(event.data);
+        break;
     }
   }
 
@@ -322,5 +332,40 @@ export class FilesTableComponent extends BaseTableComponent implements OnInit, O
 
   private rowActionDownload(file: JFile): void {
     this.gs.getFile(SERV.GET_FILES, file.id, file.filename);
+  }
+
+  private rowActionToggleSecret(file: JFile): void {
+    const isSecret = !file.isSecret;
+    this.subscriptions.push(
+      this.gs
+        .update(SERV.FILES, file.id, { isSecret })
+        .pipe(
+          catchError((error) => {
+            console.error('Error updating secret flag:', error);
+            return [];
+          })
+        )
+        .subscribe(() => {
+          this.alertService.showSuccessMessage(`File ${file.filename} is now ${isSecret ? 'secret' : 'not secret'}!`);
+          this.reload();
+        })
+    );
+  }
+
+  private rowActionRecount(file: JFile): void {
+    this.subscriptions.push(
+      this.gs
+        .chelper(SERV.HELPER, 'recountFileLines', { fileId: file.id })
+        .pipe(
+          catchError((error) => {
+            console.error('Error recounting file lines:', error);
+            return [];
+          })
+        )
+        .subscribe(() => {
+          this.alertService.showSuccessMessage(`Recounted lines for ${file.filename}!`);
+          this.reload();
+        })
+    );
   }
 }

--- a/src/app/core/_components/tables/files-table/files-table.constants.ts
+++ b/src/app/core/_components/tables/files-table/files-table.constants.ts
@@ -13,3 +13,21 @@ export const FilesTableColumnLabel = {
   [FilesTableCol.LINE_COUNT]: 'Line Count',
   [FilesTableCol.ACCESS_GROUP]: 'Access Group'
 };
+
+export const FilesRowAction = {
+  TOGGLE_SECRET: 'toggle-secret',
+  RECOUNT_LINES: 'recount-lines'
+} as const;
+export type FilesRowAction = (typeof FilesRowAction)[keyof typeof FilesRowAction];
+
+export const FilesRowActionLabel = {
+  SET_SECRET: 'Set Secret',
+  UNSET_SECRET: 'Unset Secret',
+  RECOUNT_LINES: 'Recount Lines'
+} as const;
+
+export const FilesRowActionIcon = {
+  SET_SECRET: 'lock',
+  UNSET_SECRET: 'lock_open',
+  RECOUNT_LINES: 'calculate'
+} as const;

--- a/src/app/core/_services/context-menu/files-menu.service.ts
+++ b/src/app/core/_services/context-menu/files-menu.service.ts
@@ -3,6 +3,11 @@ import { PermissionService } from '@services/permission/permission.service';
 
 import { BulkActionMenuLabel } from '@components/menus/bulk-action-menu/bulk-action-menu.constants';
 import { RowActionMenuAction, RowActionMenuLabel } from '@components/menus/row-action-menu/row-action-menu.constants';
+import {
+  FilesRowAction,
+  FilesRowActionIcon,
+  FilesRowActionLabel
+} from '@components/tables/files-table/files-table.constants';
 
 import { Perm, PermissionValues } from '@src/app/core/_constants/userpermissions.config';
 
@@ -18,6 +23,29 @@ export class FilesContextMenuService extends ContextMenuService {
 
     this.addCtxEditItem(RowActionMenuLabel.EDIT_FILE, RowActionMenuAction.EDIT, permUpdate);
     this.addCtxDownloadItem(RowActionMenuLabel.DOWNLOAD_FILE, permRead);
+
+    // Secret toggle: only the entry matching the current state is shown per row.
+    this.addCtxCustomItem({
+      label: FilesRowActionLabel.SET_SECRET,
+      action: FilesRowAction.TOGGLE_SECRET,
+      icon: FilesRowActionIcon.SET_SECRET,
+      permissions: permUpdate,
+      condition: { key: 'isSecret', value: false }
+    });
+    this.addCtxCustomItem({
+      label: FilesRowActionLabel.UNSET_SECRET,
+      action: FilesRowAction.TOGGLE_SECRET,
+      icon: FilesRowActionIcon.UNSET_SECRET,
+      permissions: permUpdate,
+      condition: { key: 'isSecret', value: true }
+    });
+    this.addCtxCustomItem({
+      label: FilesRowActionLabel.RECOUNT_LINES,
+      action: FilesRowAction.RECOUNT_LINES,
+      icon: FilesRowActionIcon.RECOUNT_LINES,
+      permissions: permUpdate
+    });
+
     this.addCtxDeleteItem(RowActionMenuLabel.DELETE_FILE, permDelete);
 
     this.addBulkDeleteItem(BulkActionMenuLabel.DELETE_FILES, permDelete);

--- a/src/app/core/_services/main.config.ts
+++ b/src/app/core/_services/main.config.ts
@@ -37,6 +37,7 @@ export const HELPER_ENDPOINTS = [
   'resetChunk',
   'rebuildChunkCache',
   'rescanGlobalFiles',
+  'recountFileLines',
   'resetUserPassword'
 ] as const;
 


### PR DESCRIPTION
These actions were not available yet in the angular ui and have been added now.

<img width="1736" height="872" alt="image" src="https://github.com/user-attachments/assets/75cf4794-bf71-4d17-8254-a452553258c3" />


Issue: https://github.com/hashtopolis/server/issues/2317