### PR TITLE
Render progress bar correctly on wider screens

### DIFF
--- a/src/app/tasks/edit-tasks/edit-tasks.component.html
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.html
@@ -158,7 +158,7 @@
             [hidden]="!taskProgressImageUrl"
             [src]="taskProgressImageUrl"
             alt="Task progress image"
-            class="max-w-full h-auto"
+            class="w-full max-w-[1920px] h-8"
           />
 
           <mat-card class="mt-5">


### PR DESCRIPTION
Previously: 
<img width="1841" height="335" alt="image" src="https://github.com/user-attachments/assets/3f0f10fe-447e-4a4f-93e0-f13940e6444c" />

Now (different example from my data set):

<img width="2131" height="850" alt="image" src="https://github.com/user-attachments/assets/1a24e00a-ca46-42a6-8eb9-cfea6dba792a" />




Issue: https://github.com/hashtopolis/server/issues/2206