### PR TITLE
Only count non archived supertasks in dashboard

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -268,16 +268,19 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   /**
    * Fetches total and completed supertasks count.
+   * Archived supertasks are excluded.
    * @returns Observable<void> completing when data is loaded or errored
    */
   private getSuperTasks$(): Observable<void> {
     const paramsTotalSupertasks = new RequestParamBuilder()
       .addFilter({ field: 'taskType', operator: FilterType.EQUAL, value: TaskType.SUPERTASK })
+      .addFilter({ field: 'isArchived', operator: FilterType.EQUAL, value: 0 })
       .create();
 
     const paramsCompletedSupertasks = new RequestParamBuilder()
       .addFilter({ field: 'keyspace', operator: FilterType.GREATER, value: 0 })
       .addFilter({ field: 'taskType', operator: FilterType.EQUAL, value: TaskType.SUPERTASK })
+      .addFilter({ field: 'isArchived', operator: FilterType.EQUAL, value: 0 })
       .create();
 
     return forkJoin([


### PR DESCRIPTION
Exclude archived entities on the dashboard. 

It might make sense to replace 0/1 with true/false in the api at some point (also in other places). 

Issue: https://github.com/hashtopolis/server/issues/2343