### PR TITLE
Forward from dashboard supertask card to the task list instead of supertask list

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -62,7 +62,7 @@
       </mat-card-content>
     </mat-card>
 
-    <mat-card appearance="outlined" class="metric-card cursor-pointer" [routerLink]="['/tasks/supertasks']">
+    <mat-card appearance="outlined" class="metric-card cursor-pointer" [routerLink]="['/tasks/show-tasks']">
       <mat-card-content>
         <div class="flex items-center gap-sm">
           <div class="icon-box w-9 h-9 rounded-md bg-primary-muted flex items-center justify-center shrink-0">


### PR DESCRIPTION
The dashboard supertask card links now to the task list.

Issue: https://github.com/hashtopolis/server/issues/2340