### PR TITLE
Sum up multiple agent speed reports per task not by exact timestamp but by bucket of 10s

### DIFF
--- a/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.spec.ts
+++ b/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.spec.ts
@@ -8,8 +8,8 @@ describe('TaskSpeedGraphComponent', () => {
   let component: TaskSpeedGraphComponent;
   let fixture: ComponentFixture<TaskSpeedGraphComponent>;
 
-  const speedStat = (time: number, speed: number): SpeedStat =>
-    ({ id: time, type: 'speed', agentId: 1, taskId: 1, speed, time }) as SpeedStat;
+  const speedStat = (time: number, speed: number, agentId = 1): SpeedStat =>
+    ({ id: time, type: 'speed', agentId, taskId: 1, speed, time }) as SpeedStat;
 
   const drawWith = (speeds: SpeedStat[]) => {
     component.speeds = speeds;
@@ -33,16 +33,16 @@ describe('TaskSpeedGraphComponent', () => {
   });
 
   it('scales every point by one shared unit chosen from the fastest speed', () => {
-    const option = drawWith([speedStat(100, 5_000_000), speedStat(200, 800_000)]);
-    const plotted = option.series[0].data.map((point: { value: [string, number] }) => point.value[1]);
+    const option = drawWith([speedStat(100, 5_000_000), speedStat(110, 800_000)]);
+    const plotted = option.series[0].data.map((point: { value: [number, number] }) => point.value[1]);
 
     expect(plotted).toEqual([5, 0.8]);
     expect(option.yAxis[0].name).toBe('MH/s');
   });
 
   it('places the Max/Min markers on the true extremes with the shared unit', () => {
-    const option = drawWith([speedStat(100, 5_000_000), speedStat(200, 800_000)]);
-    const markPoints = option.series[0].markPoint.data as { name: string; coord: [string, number]; value: string }[];
+    const option = drawWith([speedStat(100, 5_000_000), speedStat(110, 800_000)]);
+    const markPoints = option.series[0].markPoint.data as { name: string; coord: [number, number]; value: string }[];
     const max = markPoints.find((point) => point.name === 'Max');
     const min = markPoints.find((point) => point.name === 'Min');
 
@@ -52,18 +52,54 @@ describe('TaskSpeedGraphComponent', () => {
     expect(min?.value).toBe('0.8 MH/s');
   });
 
-  it('sums the speeds of agents reporting at the same timestamp', () => {
-    // Two agents at t=100 (3 MH/s each) collapse into one 6 MH/s point; t=200 stays separate.
-    const option = drawWith([speedStat(100, 3_000_000), speedStat(100, 3_000_000), speedStat(200, 1_000_000)]);
-    const plotted = option.series[0].data.map((point: { value: [string, number] }) => point.value[1]);
+  it('sums all agents into a single total even when their timestamps do not line up', () => {
+    // Agent 1 (t=100) and agent 2 (t=105) both fall in the same 10s bucket: one 6 MH/s total, not two lines.
+    const option = drawWith([speedStat(100, 3_000_000, 1), speedStat(105, 3_000_000, 2)]);
+    const plotted = option.series[0].data.map((point: { value: [number, number] }) => point.value[1]);
 
-    expect(plotted).toEqual([6, 1]);
+    expect(plotted).toEqual([6]);
+  });
+
+  it('keeps only the latest sample per agent within a bucket, never double-counting one agent', () => {
+    // The same agent reports twice inside one 10s bucket; the later 4 MH/s wins instead of summing to 7.
+    const option = drawWith([speedStat(100, 3_000_000, 1), speedStat(105, 4_000_000, 1)]);
+    const plotted = option.series[0].data.map((point: { value: [number, number] }) => point.value[1]);
+
+    expect(plotted).toEqual([4]);
+  });
+
+  it('carries an agent through a bucket it skipped so the total has no false dip', () => {
+    // Agent 1 reports at 100 and 120 but skips the 110 bucket; agent 2 reports in all three.
+    // The 110 bucket must still show the full 8 MH/s (5 carried + 3), not drop to 3.
+    const option = drawWith([
+      speedStat(100, 5_000_000, 1),
+      speedStat(120, 5_000_000, 1),
+      speedStat(100, 3_000_000, 2),
+      speedStat(110, 3_000_000, 2),
+      speedStat(120, 3_000_000, 2)
+    ]);
+    const plotted = option.series[0].data.map((point: { value: [number, number] }) => point.value[1]);
+
+    expect(plotted).toEqual([8, 8, 8]);
+  });
+
+  it('drops an agent from the total once it stops reporting past the activity window', () => {
+    // Agent 1 runs the whole time; agent 2 stops after t=110. Beyond the 60s window the total falls to agent 1 alone.
+    const running = [];
+    for (let t = 100; t <= 300; t += 10) {
+      running.push(speedStat(t, 5_000_000, 1));
+    }
+    const option = drawWith([...running, speedStat(100, 3_000_000, 2), speedStat(110, 3_000_000, 2)]);
+    const plotted = option.series[0].data.map((point: { value: [number, number] }) => point.value[1]);
+
+    expect(plotted[0]).toBe(8); // both agents active
+    expect(plotted[plotted.length - 1]).toBe(5); // agent 2 long gone
   });
 
   it('picks the unit from the fastest point even across several orders of magnitude', () => {
     // Fastest is 2.5 GH/s, so a 20 MH/s point must render proportionally tiny on a GH/s axis, not tower over it.
-    const option = drawWith([speedStat(100, 2_500_000_000), speedStat(200, 20_000_000)]);
-    const plotted = option.series[0].data.map((point: { value: [string, number] }) => point.value[1]);
+    const option = drawWith([speedStat(100, 2_500_000_000), speedStat(110, 20_000_000)]);
+    const plotted = option.series[0].data.map((point: { value: [number, number] }) => point.value[1]);
 
     expect(option.yAxis[0].name).toBe('GH/s');
     expect(plotted).toEqual([2.5, 0.02]);
@@ -73,6 +109,107 @@ describe('TaskSpeedGraphComponent', () => {
     const option = drawWith([speedStat(100, 1_234_000_000)]);
 
     expect(option.series[0].data[0].value[1]).toBe(1.23);
+  });
+
+  it('plots against a time axis and defaults the zoom to the most recent 30 minutes', () => {
+    // One hour of data: the initial view starts 30 minutes before the last record.
+    const option = drawWith([speedStat(0, 1_000_000, 1), speedStat(3600, 2_000_000, 1)]);
+    const [slider] = option.dataZoom;
+
+    expect(option.xAxis[0].type).toBe('time');
+    expect(slider.startValue).toBe(30 * 60 * 1000);
+    expect(slider.endValue).toBe(3600 * 1000);
+  });
+
+  it('shows the whole range when it is shorter than the default window', () => {
+    const option = drawWith([speedStat(100, 1_000_000, 1), speedStat(200, 2_000_000, 1)]);
+    const [slider] = option.dataZoom;
+
+    expect(slider.startValue).toBe(100 * 1000);
+    expect(slider.endValue).toBe(200 * 1000);
+  });
+
+  it('applies the recent-window bounds to both the slider and the inside (wheel/drag) zoom', () => {
+    const option = drawWith([speedStat(0, 1_000_000, 1), speedStat(3600, 2_000_000, 1)]);
+    const [slider, inside] = option.dataZoom;
+
+    expect(slider.type).toBe('slider');
+    expect(inside.type).toBe('inside');
+    expect(inside.startValue).toBe(slider.startValue);
+    expect(inside.endValue).toBe(slider.endValue);
+  });
+
+  it('spans the x-axis over the full data range so zooming out still shows everything', () => {
+    const option = drawWith([speedStat(0, 1_000_000, 1), speedStat(3600, 2_000_000, 1)]);
+
+    expect(option.xAxis[0].min).toBe(0);
+    expect(option.xAxis[0].max).toBe(3600 * 1000);
+  });
+
+  it('falls back to the H/s unit for sub-kH/s totals', () => {
+    const option = drawWith([speedStat(100, 500, 1)]);
+    const plotted = option.series[0].data.map((point: { value: [number, number] }) => point.value[1]);
+
+    expect(option.yAxis[0].name).toBe('H/s');
+    expect(plotted).toEqual([500]);
+  });
+
+  it('breaks the line where reporting pauses longer than the activity window', () => {
+    // A 900s silence (>> the 60s window) leaves every bucket in between with no active agent.
+    const option = drawWith([speedStat(100, 5_000_000, 1), speedStat(1000, 5_000_000, 1)]);
+    const times = option.series[0].data.map((point: { value: [number, number] }) => point.value[0]);
+
+    expect(times).toContain(100 * 1000);
+    expect(times).toContain(1000 * 1000);
+    expect(times).not.toContain(500 * 1000); // the silent middle produces no point
+  });
+
+  it('places both Max and Min markers on the sole point when there is only one sample', () => {
+    const option = drawWith([speedStat(100, 5_000_000, 1)]);
+    const markPoints = option.series[0].markPoint.data as { name: string; coord: [number, number]; value: string }[];
+    const max = markPoints.find((point) => point.name === 'Max');
+    const min = markPoints.find((point) => point.name === 'Min');
+
+    expect(max?.coord[1]).toBe(5);
+    expect(min?.coord[1]).toBe(5);
+    expect(max?.value).toBe('5 MH/s');
+    expect(min?.value).toBe('5 MH/s');
+  });
+
+  it('formats the axis tooltip as "<time>: <summed speed> <unit>"', () => {
+    const option = drawWith([speedStat(100, 3_000_000, 1), speedStat(105, 3_000_000, 2)]);
+    const tooltip = Array.isArray(option.tooltip) ? option.tooltip[0] : option.tooltip;
+    const html = tooltip.formatter([{ data: { value: [100 * 1000, 6], unit: 'MH/s' } }]);
+
+    expect(html).toContain('<strong>6 MH/s</strong>');
+    expect(html).toContain('00:01:40'); // 100s after the UTC epoch
+  });
+
+  it('renders no tooltip for a mark-point style param without a [time, value] pair', () => {
+    const option = drawWith([speedStat(100, 3_000_000, 1)]);
+    const tooltip = Array.isArray(option.tooltip) ? option.tooltip[0] : option.tooltip;
+
+    expect(tooltip.formatter({ data: { value: '3 MH/s' } })).toBe('');
+    expect(tooltip.formatter([])).toBe('');
+  });
+
+  it('labels the time axis with a UTC HH:MM:SS formatter', () => {
+    const option = drawWith([speedStat(100, 3_000_000, 1)]);
+
+    expect(option.xAxis[0].axisLabel.formatter(100 * 1000)).toBe('00:01:40');
+  });
+
+  it('draws on ngAfterViewInit when speeds are already present (initial load path)', () => {
+    // Fresh component whose speeds are set before the first render, mirroring the real @Input binding.
+    const freshFixture = TestBed.createComponent(TaskSpeedGraphComponent);
+    const fresh = freshFixture.componentInstance;
+    fresh.speeds = [speedStat(100, 5_000_000, 1), speedStat(105, 3_000_000, 2)];
+    freshFixture.detectChanges(); // triggers ngAfterViewInit
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const option = (fresh as any).chart.getOption();
+    expect(option.series[0].data.length).toBe(1);
+    expect(option.series[0].data[0].value[1]).toBe(8); // 5 + 3 MH/s, summed
   });
 
   it('clears the chart when the speeds input becomes empty', () => {

--- a/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.ts
+++ b/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.ts
@@ -26,7 +26,7 @@ import { SpeedStat } from '@src/app/core/_models/speed-stat.model';
 import { getHashRateFormatComponents } from '@src/app/core/_pipes/hashrate-pipe';
 
 /**
- * Group speeds into bucket (previously exact timestamp was used) so that we sum up the speed reports of parallel agents. 
+ * Group speeds into bucket (previously exact timestamp was used) so that we sum up the speed reports of parallel agents.
  */
 const BUCKET_SECONDS = 10;
 

--- a/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.ts
+++ b/src/app/shared/graphs/echarts/task-speed-graph/task-speed-graph.component.ts
@@ -20,8 +20,28 @@ import type { TopLevelFormatterParams } from 'echarts/types/dist/shared';
 
 import { AfterViewInit, Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
 
+import { AgentId } from '@models/id.types';
+
 import { SpeedStat } from '@src/app/core/_models/speed-stat.model';
 import { getHashRateFormatComponents } from '@src/app/core/_pipes/hashrate-pipe';
+
+/**
+ * Group speeds into bucket (previously exact timestamp was used) so that we sum up the speed reports of parallel agents. 
+ */
+const BUCKET_SECONDS = 10;
+
+/**
+ * If an agent has not given a report within this time it is not counted to the current bucket.
+ * Deliberately larger than the sampling interval: err towards keeping an active
+ * agent rather than dropping it.
+ */
+const ACTIVE_WINDOW_SECONDS = 60;
+
+/**
+ * How much of the most recent history the chart shows by default. The full range
+ * (roughly the last hour) stays reachable via the zoom slider and mouse wheel.
+ */
+const DEFAULT_WINDOW_SECONDS = 30 * 60;
 
 // Compose ECharts option type
 type EChartsOption = ComposeOption<
@@ -87,70 +107,43 @@ export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
       return;
     }
 
-    const result: { time: number; speed: number }[] = [];
-    this.speeds.reduce<Record<number, { time: number; speed: number }>>((res, value) => {
-      if (!res[value.time]) {
-        res[value.time] = { time: value.time, speed: 0 };
-        result.push(res[value.time]);
-      }
-      res[value.time].speed += value.speed;
-      return res;
-    }, {});
+    const result = this.aggregateTotalSpeeds();
 
-    const maxRawSpeed = Math.max(...result.map((item) => item.speed));
-    const { unit, scale } = getHashRateFormatComponents(maxRawSpeed);
-
-    const arr: { name: string; value: [string, number]; unit: string }[] = [];
-    const timestamps: number[] = [];
-
-    for (const item of result) {
-      const iso = this.transDate(item.time);
-      const convertedValue = +(item.speed / scale).toFixed(2);
-
-      arr.push({
-        name: iso,
-        value: [iso, convertedValue],
-        unit
-      });
-
-      timestamps.push(item.time);
-    }
-
-    if (!arr.length) {
+    if (!result.length) {
       this.chart.clear();
       return;
     }
 
+    const maxRawSpeed = Math.max(...result.map((item) => item.speed));
+    const { unit, scale } = getHashRateFormatComponents(maxRawSpeed);
+
+    const arr = result.map((item) => ({
+      name: this.transDate(item.time),
+      value: [item.time * 1000, +(item.speed / scale).toFixed(2)] as [number, number],
+      unit
+    }));
+
     const speedsOnly = arr.map((item) => item.value[1]);
-    const maxSpeed = Math.max(...speedsOnly);
-    const minSpeed = Math.min(...speedsOnly);
-    const maxIndex = speedsOnly.indexOf(maxSpeed);
-    const minIndex = speedsOnly.indexOf(minSpeed);
+    const maxIndex = speedsOnly.indexOf(Math.max(...speedsOnly));
+    const minIndex = speedsOnly.indexOf(Math.min(...speedsOnly));
 
-    const startdate = timestamps[0];
-    const enddate = timestamps[timestamps.length - 1];
-    const datelabel = this.transDate(enddate);
-
-    const xAxis = this.generateIntervalsOf(1, +startdate, +enddate);
-    const xAxisData = xAxis.map((ts) => this.transDate(ts));
+    const startdate = result[0].time;
+    const enddate = result[result.length - 1].time;
+    const lastRecord = this.speeds.reduce((latest, stat) => Math.max(latest, stat.time), enddate);
+    const windowStart = Math.max(startdate, enddate - DEFAULT_WINDOW_SECONDS);
 
     const option: EChartsOption = {
       title: {
-        subtext: 'Last record: ' + datelabel
+        subtext: 'Last record: ' + this.transDate(lastRecord)
       },
       tooltip: {
+        trigger: 'axis',
         position: 'top',
         formatter: (params: TopLevelFormatterParams) => {
-          if (Array.isArray(params)) return '';
-
-          if (params.componentType === 'markPoint') {
-            return `${params.name}: <strong>${(params.data as { value: string }).value}</strong>`;
-          }
-          const data = params.data as { value: [string, number]; unit: string } | undefined;
-          if (data?.value?.[1]) {
-            return `${params.name}: <strong>${data.value[1]} ${data.unit}</strong>`;
-          }
-          return '';
+          const point = Array.isArray(params) ? params[0] : params;
+          const data = point?.data as { value: [number, number]; unit: string } | undefined;
+          if (!Array.isArray(data?.value)) return '';
+          return `${this.transDate(data.value[0] / 1000)}: <strong>${data.value[1]} ${data.unit}</strong>`;
         }
       },
       grid: {
@@ -158,8 +151,12 @@ export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
         right: '4%'
       },
       xAxis: {
-        type: 'category',
-        data: xAxisData
+        type: 'time',
+        min: startdate * 1000,
+        max: enddate * 1000,
+        axisLabel: {
+          formatter: (value: number) => this.transTime(value)
+        }
       },
       yAxis: {
         type: 'value',
@@ -186,8 +183,8 @@ export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
         }
       },
       dataZoom: [
-        { type: 'slider', xAxisIndex: 0, start: 0, end: 100 },
-        { type: 'inside', xAxisIndex: 0, start: 0, end: 100 }
+        { type: 'slider', xAxisIndex: 0, startValue: windowStart * 1000, endValue: enddate * 1000 },
+        { type: 'inside', xAxisIndex: 0, startValue: windowStart * 1000, endValue: enddate * 1000 }
       ],
       series: {
         name: '',
@@ -218,6 +215,66 @@ export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
   }
 
   /**
+   * Aggregates the per-agent speed samples into a single total-throughput series.
+   *
+   * Speeds are grouped into buckets. Sweeping the bucket
+   * grid, each agent contributes its most recent speed for as long as it keeps
+   * reporting (within ACTIVE_WINDOW_SECONDS), so a bucket the agent
+   * happens to skip carries its previous value instead of dropping to a false
+   * dip, while an agent that stops reporting falls out of the total once its last
+   * sample ages past the window. Returns points sorted ascending by time, where
+   * `time` is the bucket start in UNIX seconds.
+   */
+  private aggregateTotalSpeeds(): { time: number; speed: number }[] {
+    const sorted = [...this.speeds].sort((a, b) => a.time - b.time);
+    if (!sorted.length) {
+      return [];
+    }
+
+    const bucketOf = (time: number): number => Math.floor(time / BUCKET_SECONDS) * BUCKET_SECONDS;
+
+    // Latest speed each agent reported within each bucket.
+    const perAgent = new Map<AgentId, Map<number, number>>();
+    for (const { time, agentId, speed } of sorted) {
+      let byBucket = perAgent.get(agentId);
+      if (!byBucket) {
+        byBucket = new Map<number, number>();
+        perAgent.set(agentId, byBucket);
+      }
+      byBucket.set(bucketOf(time), speed);
+    }
+
+    const firstBucket = bucketOf(sorted[0].time);
+    const lastBucket = bucketOf(sorted[sorted.length - 1].time);
+
+    const lastValue = new Map<AgentId, number>();
+    const lastSeen = new Map<AgentId, number>();
+    const result: { time: number; speed: number }[] = [];
+
+    for (let bucket = firstBucket; bucket <= lastBucket; bucket += BUCKET_SECONDS) {
+      let speed = 0;
+      let active = false;
+      for (const [agentId, byBucket] of perAgent) {
+        const reported = byBucket.get(bucket);
+        if (reported !== undefined) {
+          lastValue.set(agentId, reported);
+          lastSeen.set(agentId, bucket);
+        }
+        const seen = lastSeen.get(agentId);
+        if (seen !== undefined && bucket - seen <= ACTIVE_WINDOW_SECONDS) {
+          speed += lastValue.get(agentId) as number;
+          active = true;
+        }
+      }
+      if (active) {
+        result.push({ time: bucket, speed });
+      }
+    }
+
+    return result;
+  }
+
+  /**
    * Returns a date string with leading zeros for formatting.
    */
   private leadingZeros(dt: number): string {
@@ -245,15 +302,16 @@ export class TaskSpeedGraphComponent implements AfterViewInit, OnChanges {
   }
 
   /**
-   * Generates an array of timestamps from `start` to `end` with a fixed `interval`.
+   * Converts a millisecond timestamp to a compact UTC time label (HH:MM:SS) for axis ticks.
    */
-  private generateIntervalsOf(interval: number, start: number, end: number): number[] {
-    const result = [];
-    let current = start;
-    while (current < end) {
-      result.push(current);
-      current += interval;
-    }
-    return result;
+  private transTime(ms: number): string {
+    const date = new Date(ms);
+    return (
+      this.leadingZeros(date.getUTCHours()) +
+      ':' +
+      this.leadingZeros(date.getUTCMinutes()) +
+      ':' +
+      this.leadingZeros(date.getUTCSeconds())
+    );
   }
 }


### PR DESCRIPTION
Beforehand when multiple agents reported speed per task they were grouped by exact timestamp.
As the timestamp is not matching in nearly all cases as exact they were reported as separate speeds.

Change to use buckets of 10s instead. Also change zoom level and show last 30 minutes by default.

Issue: https://github.com/hashtopolis/server/issues/2342