### PR TITLE
When filtering hashes of superhashlist fetch hashlist ids first and then use these for filtering

### DIFF
--- a/src/app/core/_datasources/hashes.datasource.ts
+++ b/src/app/core/_datasources/hashes.datasource.ts
@@ -1,8 +1,9 @@
-import { zHashListResponse } from '@generated/api/zod';
-import { EMPTY, catchError, finalize } from 'rxjs';
+import { zHashListResponse, zHashlistResponse } from '@generated/api/zod';
+import { EMPTY, Observable, catchError, finalize, of, switchMap } from 'rxjs';
 import { z } from 'zod';
 
 import { JHash } from '@models/hash.model';
+import { JHashlist } from '@models/hashlist.model';
 import { Filter, FilterType } from '@models/request-params.model';
 import { ResponseWrapper } from '@models/response.model';
 
@@ -10,6 +11,8 @@ import { SERV } from '@services/main.config';
 import { RequestParamBuilder } from '@services/params/builder-implementation.service';
 
 import { BaseDataSource } from '@datasources/base.datasource';
+
+import { HashListFormat } from '@src/app/core/_constants/hashlist.config';
 
 const crackedFilterSchema = z.enum(['cracked', 'uncracked']);
 
@@ -48,48 +51,97 @@ export class HashesDataSource extends BaseDataSource<JHash> {
             this.setData(hashes);
           })
       );
-    } else {
-      const params = new RequestParamBuilder().addInitial(this).addInclude('hashlist').addInclude('chunk');
-      if (query) {
-        params.addFilter(query);
-      }
-      if (this._dataType === 'chunks') {
-        params.addFilter({ field: 'chunkId', operator: FilterType.EQUAL, value: this._id });
-      } else if (this._dataType === 'hashlists') {
-        params.addFilter({ field: 'hashlistId', operator: FilterType.EQUAL, value: this._id });
-
-        const crackedFilter = crackedFilterSchema.safeParse(this._filterparam);
-        if (crackedFilter.success) {
-          params.addFilter({
-            field: 'isCracked',
-            operator: FilterType.EQUAL,
-            value: crackedFilter.data === 'cracked'
-          });
-        }
-      }
-
-      const hashes$ = this.service.getAll(SERV.HASHES, params.create());
-
-      this.subscriptions.push(
-        hashes$
-          .pipe(
-            catchError(() => EMPTY),
-            finalize(() => (this.loading = false))
-          )
-          .subscribe((response: ResponseWrapper) => {
-            const hashes: JHash[] = this.serializer.deserialize(response, zHashListResponse);
-
-            const length = response.meta.page.total_elements;
-            const nextLink = response.links.next;
-            const prevLink = response.links.prev;
-            const after = nextLink ? new URL(nextLink).searchParams.get('page[after]') : null;
-            const before = prevLink ? new URL(prevLink).searchParams.get('page[before]') : null;
-
-            this.setPaginationConfig(this.pageSize, length, after, before, this.index);
-            this.setData(hashes);
-          })
-      );
+      return;
     }
+
+    if (this._dataType === 'hashlists') {
+      this.loadHashlistHashes(query);
+      return;
+    }
+
+    const params = new RequestParamBuilder().addInitial(this).addInclude('hashlist').addInclude('chunk');
+    if (query) {
+      params.addFilter(query);
+    }
+    if (this._dataType === 'chunks') {
+      params.addFilter({ field: 'chunkId', operator: FilterType.EQUAL, value: this._id });
+    }
+
+    this.subscriptions.push(
+      this.service
+        .getAll(SERV.HASHES, params.create())
+        .pipe(
+          catchError(() => EMPTY),
+          finalize(() => (this.loading = false))
+        )
+        .subscribe((response: ResponseWrapper) => this.setHashesData(response))
+    );
+  }
+
+  /**
+   * A superhashlist owns no hashes directly — they belong to its member hashlists. So resolve the record
+   * first: for a superhashlist filter the hashes by `hashlistId IN <member ids>`, otherwise by the id itself.
+   */
+  private loadHashlistHashes(query?: Filter): void {
+    const hashlistParams = new RequestParamBuilder().addInclude('hashlists');
+
+    this.subscriptions.push(
+      this.service
+        .get(SERV.HASHLISTS, this._id, hashlistParams.create())
+        .pipe(
+          switchMap((response: ResponseWrapper): Observable<ResponseWrapper | null> => {
+            const hashlist: JHashlist = this.serializer.deserialize(response, zHashlistResponse);
+            const params = new RequestParamBuilder().addInitial(this).addInclude('hashlist').addInclude('chunk');
+            if (query) {
+              params.addFilter(query);
+            }
+
+            if (hashlist.format === HashListFormat.SUPERHASHLIST) {
+              const memberIds = (hashlist.hashlists ?? []).map((member) => member.id);
+              if (memberIds.length === 0) {
+                return of(null);
+              }
+              params.addFilter({ field: 'hashlistId', operator: FilterType.IN, value: memberIds });
+            } else {
+              params.addFilter({ field: 'hashlistId', operator: FilterType.EQUAL, value: this._id });
+            }
+
+            const crackedFilter = crackedFilterSchema.safeParse(this._filterparam);
+            if (crackedFilter.success) {
+              params.addFilter({
+                field: 'isCracked',
+                operator: FilterType.EQUAL,
+                value: crackedFilter.data === 'cracked'
+              });
+            }
+
+            return this.service.getAll(SERV.HASHES, params.create());
+          }),
+          catchError(() => EMPTY),
+          finalize(() => (this.loading = false))
+        )
+        .subscribe((response: ResponseWrapper | null) => {
+          if (!response) {
+            this.setPaginationConfig(this.pageSize, 0, null, null, this.index);
+            this.setData([]);
+            return;
+          }
+          this.setHashesData(response);
+        })
+    );
+  }
+
+  private setHashesData(response: ResponseWrapper): void {
+    const hashes: JHash[] = this.serializer.deserialize(response, zHashListResponse);
+
+    const length = response.meta.page.total_elements;
+    const nextLink = response.links.next;
+    const prevLink = response.links.prev;
+    const after = nextLink ? new URL(nextLink).searchParams.get('page[after]') : null;
+    const before = prevLink ? new URL(prevLink).searchParams.get('page[before]') : null;
+
+    this.setPaginationConfig(this.pageSize, length, after, before, this.index);
+    this.setData(hashes);
   }
 
   reload(): void {

--- a/src/app/core/_datasources/specs/hashes.datasource.spec.ts
+++ b/src/app/core/_datasources/specs/hashes.datasource.spec.ts
@@ -1,0 +1,401 @@
+/// <reference types="jasmine" />
+import { HashListFormat } from '@constants/hashlist.config';
+import { zHashListResponse, zHashlistResponse } from '@generated/api/zod';
+import { of, throwError } from 'rxjs';
+
+import { ChangeDetectorRef, Injector } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { JHash } from '@models/hash.model';
+import { JHashlist } from '@models/hashlist.model';
+import { Filter, FilterType, RequestParams } from '@models/request-params.model';
+
+import { JsonAPISerializer } from '@services/api/serializer-service';
+import { SERV } from '@services/main.config';
+import { GlobalService } from '@services/main.service';
+import { HttpCacheService } from '@services/shared/http-cache.service';
+import { AutoRefreshService } from '@services/shared/refresh/auto-refresh.service';
+import { UIConfigService } from '@services/shared/storage.service';
+import { LocalStorageService } from '@services/storage/local-storage.service';
+
+import { HashesDataSource } from '@src/app/core/_datasources/hashes.datasource';
+import { mockResponse } from '@src/app/testing/mock-response';
+
+// Mock data
+
+const MOCK_MEMBER_A: JHashlist = {
+  id: 11,
+  type: 'hashlist',
+  name: 'member_a',
+  format: HashListFormat.TEXT
+} as unknown as JHashlist;
+
+const MOCK_MEMBER_B: JHashlist = {
+  id: 22,
+  type: 'hashlist',
+  name: 'member_b',
+  format: HashListFormat.TEXT
+} as unknown as JHashlist;
+
+const MOCK_PLAIN_HASHLIST: JHashlist = {
+  id: 5,
+  type: 'hashlist',
+  name: 'plain_hashlist',
+  format: HashListFormat.TEXT
+} as unknown as JHashlist;
+
+const MOCK_SUPER_HASHLIST: JHashlist = {
+  id: 77,
+  type: 'hashlist',
+  name: 'super_hashlist',
+  format: HashListFormat.SUPERHASHLIST,
+  hashlists: [MOCK_MEMBER_A, MOCK_MEMBER_B]
+} as unknown as JHashlist;
+
+const MOCK_EMPTY_SUPER_HASHLIST: JHashlist = {
+  ...MOCK_SUPER_HASHLIST,
+  id: 88,
+  name: 'empty_super_hashlist',
+  hashlists: []
+};
+
+const MOCK_HASHES: JHash[] = [
+  {
+    id: 1,
+    type: 'hash',
+    hash: 'aabbcc',
+    plaintext: 'secret',
+    hashlistId: 11,
+    salt: '',
+    timeCracked: 0,
+    isCracked: true,
+    chunkId: null,
+    crackPos: 0
+  } as unknown as JHash
+];
+
+// Suite
+
+describe('HashesDataSource', () => {
+  let dataSource: HashesDataSource;
+  let gsSpy: jasmine.SpyObj<GlobalService>;
+  let deserializeSpy: jasmine.Spy;
+
+  // The hashlist returned when a `hashlists` load resolves the record; reassign per test.
+  let resolvedHashlist: JHashlist;
+
+  beforeEach(() => {
+    resolvedHashlist = MOCK_PLAIN_HASHLIST;
+
+    gsSpy = jasmine.createSpyObj('GlobalService', ['get', 'getAll', 'ghelper']);
+
+    const cdrSpy = jasmine.createSpyObj('ChangeDetectorRef', ['markForCheck', 'detectChanges']);
+    const uiServiceSpy = jasmine.createSpyObj('UIConfigService', ['getUISettings']);
+    uiServiceSpy.getUISettings.and.returnValue({});
+    const autoRefreshSpy = jasmine.createSpyObj(
+      'AutoRefreshService',
+      ['toggleAutoRefresh', 'startAutoRefresh', 'stopAutoRefresh'],
+      { refresh$: of() }
+    );
+    const cacheSpy = jasmine.createSpyObj('HttpCacheService', ['invalidate']);
+    const storageSpy = jasmine.createSpyObj('LocalStorageService', ['getItem', 'setItem']);
+    storageSpy.getItem.and.returnValue(null);
+
+    gsSpy.get.and.returnValue(of(mockResponse()));
+    gsSpy.getAll.and.returnValue(of(mockResponse()));
+    gsSpy.ghelper.and.returnValue(of(mockResponse()));
+
+    deserializeSpy = spyOn(JsonAPISerializer.prototype, 'deserialize').and.callFake((_body: unknown, schema?: unknown) => {
+      if (schema === zHashlistResponse) return resolvedHashlist;
+      if (schema === zHashListResponse) return MOCK_HASHES;
+      return [];
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: GlobalService, useValue: gsSpy },
+        { provide: ChangeDetectorRef, useValue: cdrSpy },
+        { provide: UIConfigService, useValue: uiServiceSpy },
+        { provide: AutoRefreshService, useValue: autoRefreshSpy },
+        { provide: HttpCacheService, useValue: cacheSpy },
+        { provide: LocalStorageService, useValue: storageSpy }
+      ]
+    });
+
+    const injector = TestBed.inject(Injector);
+    dataSource = new HashesDataSource(injector);
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  // setters
+
+  describe('setters', () => {
+    it('should store id, dataType and filterParam', () => {
+      dataSource.setId(42);
+      dataSource.setDataType('hashlists');
+      dataSource.setFilterParam('cracked');
+
+      expect(dataSource['_id']).toBe(42);
+      expect(dataSource['_dataType']).toBe('hashlists');
+      expect(dataSource['_filterparam']).toBe('cracked');
+    });
+  });
+
+  // loadAll() - plain hashlist
+
+  describe('loadAll() - plain hashlist', () => {
+    beforeEach(() => {
+      resolvedHashlist = MOCK_PLAIN_HASHLIST;
+      dataSource.setId(5);
+      dataSource.setDataType('hashlists');
+    });
+
+    it('should first resolve the hashlist record via service.get including its members', () => {
+      dataSource.loadAll();
+
+      const [serviceConfig, entityId, params] = gsSpy.get.calls.mostRecent().args;
+      expect(serviceConfig).toEqual(SERV.HASHLISTS);
+      expect(entityId).toBe(5);
+      expect((params as RequestParams).include).toContain('hashlists');
+    });
+
+    it('should fetch hashes filtered by hashlistId EQUAL the hashlist id', () => {
+      dataSource.loadAll();
+
+      const [serviceConfig, params] = gsSpy.getAll.calls.mostRecent().args;
+      expect(serviceConfig).toEqual(SERV.HASHES);
+      expect((params as RequestParams).filter).toContain(
+        jasmine.objectContaining({ field: 'hashlistId', operator: FilterType.EQUAL, value: 5 })
+      );
+    });
+
+    it('should populate hashes and totalItems from the hashes response', () => {
+      gsSpy.getAll.and.returnValue(of(mockResponse({ meta: { page: { total_elements: 12 } } })));
+
+      dataSource.loadAll();
+
+      expect(dataSource.getOriginalData().length).toBe(1);
+      expect(dataSource.getOriginalData()[0].hash).toBe('aabbcc');
+      expect(dataSource.totalItems).toBe(12);
+    });
+
+    it('should append the query filter when provided', () => {
+      const query: Filter = { field: 'hash', operator: FilterType.ICONTAINS, value: 'aa' };
+      dataSource.loadAll(query);
+
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      expect((params as RequestParams).filter).toContain(jasmine.objectContaining({ field: 'hash', value: 'aa' }));
+    });
+
+    it('should add isCracked=true when filterParam is "cracked"', () => {
+      dataSource.setFilterParam('cracked');
+      dataSource.loadAll();
+
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      expect((params as RequestParams).filter).toContain(
+        jasmine.objectContaining({ field: 'isCracked', operator: FilterType.EQUAL, value: true })
+      );
+    });
+
+    it('should add isCracked=false when filterParam is "uncracked"', () => {
+      dataSource.setFilterParam('uncracked');
+      dataSource.loadAll();
+
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      expect((params as RequestParams).filter).toContain(
+        jasmine.objectContaining({ field: 'isCracked', operator: FilterType.EQUAL, value: false })
+      );
+    });
+
+    it('should not add an isCracked filter when filterParam is unset', () => {
+      dataSource.loadAll();
+
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      const filter = (params as RequestParams).filter ?? [];
+      expect(filter.some((f: Filter) => f.field === 'isCracked')).toBeFalse();
+    });
+
+    it('should stop loading after a successful response', () => {
+      dataSource.loadAll();
+      expect(dataSource['loadingSubject'].getValue()).toBeFalse();
+    });
+  });
+
+  // loadAll() - super hashlist (the bug fix)
+
+  describe('loadAll() - super hashlist', () => {
+    beforeEach(() => {
+      resolvedHashlist = MOCK_SUPER_HASHLIST;
+      dataSource.setId(77);
+      dataSource.setDataType('hashlists');
+    });
+
+    it('should fetch hashes filtered by hashlistId IN the member ids', () => {
+      dataSource.loadAll();
+
+      const [serviceConfig, params] = gsSpy.getAll.calls.mostRecent().args;
+      expect(serviceConfig).toEqual(SERV.HASHES);
+      expect((params as RequestParams).filter).toContain(
+        jasmine.objectContaining({
+          field: 'hashlistId',
+          operator: FilterType.IN,
+          value: [MOCK_MEMBER_A.id, MOCK_MEMBER_B.id]
+        })
+      );
+    });
+
+    it('should NOT filter by the superhashlist id itself (regression for empty hashes)', () => {
+      dataSource.loadAll();
+
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      const filter = (params as RequestParams).filter ?? [];
+      expect(filter).not.toContain(
+        jasmine.objectContaining({ field: 'hashlistId', operator: FilterType.EQUAL, value: 77 })
+      );
+    });
+
+    it('should populate hashes from the member hashes response', () => {
+      dataSource.loadAll();
+      expect(dataSource.getOriginalData().length).toBe(1);
+      expect(dataSource.getOriginalData()[0].hash).toBe('aabbcc');
+    });
+
+    it('should still apply the isCracked filter alongside the IN filter', () => {
+      dataSource.setFilterParam('cracked');
+      dataSource.loadAll();
+
+      const [, params] = gsSpy.getAll.calls.mostRecent().args;
+      const filter = (params as RequestParams).filter ?? [];
+      expect(filter).toContain(jasmine.objectContaining({ field: 'hashlistId', operator: FilterType.IN }));
+      expect(filter).toContain(jasmine.objectContaining({ field: 'isCracked', value: true }));
+    });
+  });
+
+  // loadAll() - empty super hashlist
+
+  describe('loadAll() - empty super hashlist', () => {
+    beforeEach(() => {
+      resolvedHashlist = MOCK_EMPTY_SUPER_HASHLIST;
+      dataSource.setId(88);
+      dataSource.setDataType('hashlists');
+    });
+
+    it('should not request any hashes when the superhashlist has no members', () => {
+      dataSource.loadAll();
+      expect(gsSpy.getAll).not.toHaveBeenCalled();
+    });
+
+    it('should render an empty, zeroed table', () => {
+      dataSource.loadAll();
+      expect(dataSource.getOriginalData().length).toBe(0);
+      expect(dataSource.totalItems).toBe(0);
+      expect(dataSource.pageAfter).toBeNull();
+      expect(dataSource.pageBefore).toBeNull();
+    });
+
+    it('should stop loading', () => {
+      dataSource.loadAll();
+      expect(dataSource['loadingSubject'].getValue()).toBeFalse();
+    });
+  });
+
+  // loadAll() - chunks
+
+  describe('loadAll() - chunks', () => {
+    beforeEach(() => {
+      dataSource.setId(9);
+      dataSource.setDataType('chunks');
+    });
+
+    it('should query hashes directly without resolving a hashlist record', () => {
+      dataSource.loadAll();
+      expect(gsSpy.get).not.toHaveBeenCalled();
+      expect(gsSpy.getAll).toHaveBeenCalled();
+    });
+
+    it('should filter by chunkId EQUAL the id', () => {
+      dataSource.loadAll();
+      const [serviceConfig, params] = gsSpy.getAll.calls.mostRecent().args;
+      expect(serviceConfig).toEqual(SERV.HASHES);
+      expect((params as RequestParams).filter).toContain(
+        jasmine.objectContaining({ field: 'chunkId', operator: FilterType.EQUAL, value: 9 })
+      );
+    });
+  });
+
+  // loadAll() - tasks
+
+  describe('loadAll() - tasks', () => {
+    beforeEach(() => {
+      dataSource.setId(3);
+      dataSource.setDataType('tasks');
+    });
+
+    it('should load cracks via the getCracksOfTask helper', () => {
+      dataSource.loadAll();
+
+      expect(gsSpy.get).not.toHaveBeenCalled();
+      expect(gsSpy.getAll).not.toHaveBeenCalled();
+      const [serviceConfig, helper, payload] = gsSpy.ghelper.calls.mostRecent().args;
+      expect(serviceConfig).toEqual(SERV.HELPER);
+      expect(helper).toBe('getCracksOfTask');
+      expect(payload).toEqual({ task: 3 });
+    });
+
+    it('should populate the hashes from the helper response', () => {
+      dataSource.loadAll();
+      expect(dataSource.getOriginalData().length).toBe(1);
+    });
+  });
+
+  // error handling
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      dataSource.setId(5);
+      dataSource.setDataType('hashlists');
+    });
+
+    it('should stop loading and leave data untouched when the hashlist lookup fails', () => {
+      gsSpy.get.and.returnValue(throwError(() => new Error('backend error')));
+
+      dataSource.loadAll();
+
+      expect(dataSource.getOriginalData().length).toBe(0);
+      expect(dataSource['loadingSubject'].getValue()).toBeFalse();
+    });
+
+    it('should stop loading when the hashes request fails', () => {
+      gsSpy.getAll.and.returnValue(throwError(() => new Error('backend error')));
+
+      dataSource.loadAll();
+
+      expect(dataSource['loadingSubject'].getValue()).toBeFalse();
+    });
+  });
+
+  // reload()
+
+  describe('reload()', () => {
+    it('should clear the current selection', () => {
+      dataSource.setId(5);
+      dataSource.setDataType('hashlists');
+      dataSource.selection.select(MOCK_HASHES[0]);
+
+      dataSource.reload();
+
+      expect(dataSource.selection.selected.length).toBe(0);
+    });
+
+    it('should trigger a fresh load', () => {
+      dataSource.setId(9);
+      dataSource.setDataType('chunks');
+      gsSpy.getAll.calls.reset();
+
+      dataSource.reload();
+
+      expect(gsSpy.getAll).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/core/_datasources/specs/hashes.datasource.spec.ts
+++ b/src/app/core/_datasources/specs/hashes.datasource.spec.ts
@@ -79,7 +79,6 @@ const MOCK_HASHES: JHash[] = [
 describe('HashesDataSource', () => {
   let dataSource: HashesDataSource;
   let gsSpy: jasmine.SpyObj<GlobalService>;
-  let deserializeSpy: jasmine.Spy;
 
   // The hashlist returned when a `hashlists` load resolves the record; reassign per test.
   let resolvedHashlist: JHashlist;
@@ -105,7 +104,7 @@ describe('HashesDataSource', () => {
     gsSpy.getAll.and.returnValue(of(mockResponse()));
     gsSpy.ghelper.and.returnValue(of(mockResponse()));
 
-    deserializeSpy = spyOn(JsonAPISerializer.prototype, 'deserialize').and.callFake((_body: unknown, schema?: unknown) => {
+    spyOn(JsonAPISerializer.prototype, 'deserialize').and.callFake((_body: unknown, schema?: unknown) => {
       if (schema === zHashlistResponse) return resolvedHashlist;
       if (schema === zHashListResponse) return MOCK_HASHES;
       return [];


### PR DESCRIPTION
When having a superhashlist the filtering hashes we have to pass the hashlist ids of the superhashlist instead of the id of the superhashlist itself. Therefore add a check for that and pass member ids in this case. 

Issue: https://github.com/hashtopolis/server/issues/2350