### PR TITLE
Do not cutoff at year start but always show cracks of the last year

### DIFF
--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -440,20 +440,45 @@ describe('HomeComponent — updateHeatmapData$()', () => {
     expect(jan2Entry![1]).toBe(42);
   });
 
-  it('should include all days from Jan 1st to today', () => {
+  it('should include all days across the trailing 12 months up to today', () => {
     permissionServiceMock.hasPermissionSync.and.callFake((perm: PermissionValues) => perm === Perm.Hash.READ);
     globalServiceMock.ghelper.and.returnValue(of({ meta: {}, data: [] }));
 
-    fixture = TestBed.createComponent(HomeComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date(2026, 6, 23)); // 2026-07-23
+    try {
+      fixture = TestBed.createComponent(HomeComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
 
-    const today = new Date();
-    const year = today.getFullYear();
-    const start = new Date(year, 0, 1);
-    const expectedDays = Math.floor((today.getTime() - start.getTime()) / 86400000) + 1;
+      // 2025-07-23 .. 2026-07-23 inclusive
+      expect(component.heatmapData.length).toBe(366);
+      expect(component.heatmapData[0][0]).toBe('2025-07-23');
+      expect(component.heatmapData[component.heatmapData.length - 1][0]).toBe('2026-07-23');
+    } finally {
+      jasmine.clock().uninstall();
+    }
+  });
 
-    expect(component.heatmapData.length).toBe(expectedDays);
+  it('should include crack days from the previous calendar year that fall within the trailing 12 months', () => {
+    permissionServiceMock.hasPermissionSync.and.callFake((perm: PermissionValues) => perm === Perm.Hash.READ);
+
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date(2026, 6, 23)); // 2026-07-23
+    try {
+      // A crack recorded in the previous calendar year, still inside the trailing 12-month window.
+      globalServiceMock.ghelper.and.returnValue(of({ meta: { '2025-09-15': 7 }, data: [] }));
+
+      fixture = TestBed.createComponent(HomeComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      const entry = component.heatmapData.find(([d]) => d === '2025-09-15');
+      expect(entry).toBeTruthy();
+      expect(entry![1]).toBe(7);
+    } finally {
+      jasmine.clock().uninstall();
+    }
   });
 
   it('should handle ghelper errors gracefully and keep heatmapData empty', () => {

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -100,9 +100,9 @@ globalServiceMock.getAll.and.callFake((service: ServiceConfig, params?: RequestP
 });
 
 /**
- * Mock for `ghelper` — returns an empty meta object for any helper endpoint.
+ * Mock for `ghelper` — returns an empty data object for any helper endpoint.
  */
-globalServiceMock.ghelper.and.returnValue(of({ meta: {}, data: [] }));
+globalServiceMock.ghelper.and.returnValue(of({ data: {} }));
 
 /**
  * Mock implementation of LocalStorageService for testing purposes.
@@ -376,7 +376,7 @@ describe('HomeComponent — updateHeatmapData$()', () => {
     mockAutoRefreshService = createMockAutoRefreshService();
 
     // Reset ghelper to a clean state before each test
-    globalServiceMock.ghelper.and.returnValue(of({ meta: {}, data: [] }));
+    globalServiceMock.ghelper.and.returnValue(of({ data: {} }));
 
     await TestBed.configureTestingModule({
       declarations: [HomeComponent],
@@ -424,7 +424,7 @@ describe('HomeComponent — updateHeatmapData$()', () => {
     const today = new Date();
     const year = today.getFullYear();
     const jan2 = `${year}-01-02`;
-    globalServiceMock.ghelper.and.returnValue(of({ meta: { [jan2]: 42 }, data: [] }));
+    globalServiceMock.ghelper.and.returnValue(of({ data: { [jan2]: 42 } }));
 
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
@@ -442,7 +442,7 @@ describe('HomeComponent — updateHeatmapData$()', () => {
 
   it('should include all days across the trailing 12 months up to today', () => {
     permissionServiceMock.hasPermissionSync.and.callFake((perm: PermissionValues) => perm === Perm.Hash.READ);
-    globalServiceMock.ghelper.and.returnValue(of({ meta: {}, data: [] }));
+    globalServiceMock.ghelper.and.returnValue(of({ data: {} }));
 
     jasmine.clock().install();
     jasmine.clock().mockDate(new Date(2026, 6, 23)); // 2026-07-23
@@ -467,7 +467,7 @@ describe('HomeComponent — updateHeatmapData$()', () => {
     jasmine.clock().mockDate(new Date(2026, 6, 23)); // 2026-07-23
     try {
       // A crack recorded in the previous calendar year, still inside the trailing 12-month window.
-      globalServiceMock.ghelper.and.returnValue(of({ meta: { '2025-09-15': 7 }, data: [] }));
+      globalServiceMock.ghelper.and.returnValue(of({ data: { '2025-09-15': 7 } }));
 
       fixture = TestBed.createComponent(HomeComponent);
       component = fixture.componentInstance;

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -325,7 +325,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   /**
    * Calls getCracksPerDay, validates the JSON:API response with Zod and builds
-   * heatmap data for every day from January 1st of the current year up to today,
+   * heatmap data for every day across the trailing 12 months up to today,
    * filling days with no cracks with a count of 0.
    * @returns Observable<void> completing when data is loaded or errored
    */
@@ -340,9 +340,9 @@ export class HomeComponent implements OnInit, OnDestroy {
         const rawData = parsed.meta;
 
         const today = new Date();
-        const year = today.getFullYear();
         const allDays: [string, number][] = [];
-        const cursor = new Date(year, 0, 1);
+        const cursor = new Date(today);
+        cursor.setFullYear(cursor.getFullYear() - 1);
 
         while (cursor <= today) {
           const dateStr = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, '0')}-${String(cursor.getDate()).padStart(2, '0')}`;

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -331,13 +331,13 @@ export class HomeComponent implements OnInit, OnDestroy {
    */
   private updateHeatmapData$(): Observable<void> {
     const cracksPerDaySchema = z.object({
-      meta: z.record(z.string(), z.number())
+      data: z.record(z.string(), z.number())
     });
 
     return this.gs.ghelper(SERV.HELPER, 'getCracksPerDay').pipe(
       map((res: ResponseWrapper) => {
         const parsed = cracksPerDaySchema.parse(res);
-        const rawData = parsed.meta;
+        const rawData = parsed.data;
 
         const today = new Date();
         const allDays: [string, number][] = [];


### PR DESCRIPTION
The "cursor" which defines the starting date was set to `new Date(year, 0, 1);`, instead of choosing first of january here
go back one year. Also use slightly changed api response that returns data in 'data' part instead of 'meta'.

Requires backend branch: https://github.com/hashtopolis/server/pull/2358

Issue: https://github.com/hashtopolis/server/issues/2348