### PR TITLE
Use new endpoints to count completed tasks and supertasks

### DIFF
--- a/src/app/core/_services/main.config.ts
+++ b/src/app/core/_services/main.config.ts
@@ -19,6 +19,7 @@ export const HELPER_ENDPOINTS = [
   'getBestTasksAgent',
   'getCracksOfTask',
   'getCracksPerDay',
+  'getCompletedCount',
   'getAccessGroups',
   // POST helpers (chelper)
   'changeOwnPassword',

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -7,7 +7,7 @@ import { By } from '@angular/platform-browser';
 import { RouterLink, RouterLinkWithHref, provideRouter } from '@angular/router';
 
 import { uiConfigDefault } from '@models/config-ui.model';
-import { Filter, FilterType, RequestParams } from '@models/request-params.model';
+import { Filter, RequestParams } from '@models/request-params.model';
 import { TaskType } from '@models/task.model';
 
 import { SERV, ServiceConfig } from '@services/main.config';
@@ -62,22 +62,13 @@ const globalServiceMock = jasmine.createSpyObj('GlobalService', ['getAll', 'ghel
  * Returns different counts depending on the service and filter parameters.
  */
 globalServiceMock.getAll.and.callFake((service: ServiceConfig, params?: RequestParams) => {
-  // Handle TASKS_WRAPPER_COUNT — differentiate between Supertasks and regular Tasks
+  // TASKS_WRAPPER_COUNT only yields the total now (tasks vs supertasks by taskType filter);
+  // completed counts come from the getCompletedCount ghelper mock below.
   if (service === SERV.TASKS_WRAPPER_COUNT) {
     const isSuperTask = params?.filter?.some(
       (filter: Filter) => filter.field === 'taskType' && filter.value === TaskType.SUPERTASK
     );
-
-    const isCompleted = params?.filter?.some(
-      (filter: Filter) => filter.field === 'keyspace' && filter.operator === FilterType.GREATER
-    );
-
-    // Return counts based on task type and completion status
-    if (isSuperTask) {
-      return of({ meta: { count: isCompleted ? 5 : 10 } }); // 5 completed, 10 total supertasks
-    } else {
-      return of({ meta: { count: isCompleted ? 15 : 30 } }); // 15 completed, 30 total tasks
-    }
+    return of({ meta: { count: isSuperTask ? 10 : 30 } }); // 10 total supertasks, 30 total tasks
   }
 
   // Handle AGENTS_COUNT — returns total and active agent counts
@@ -100,9 +91,17 @@ globalServiceMock.getAll.and.callFake((service: ServiceConfig, params?: RequestP
 });
 
 /**
- * Mock for `ghelper` — returns an empty meta object for any helper endpoint.
+ * Default `ghelper` mock: returns the completed task/supertask counts for the
+ * getCompletedCount endpoint (15 tasks, 5 supertasks) and an empty meta object
+ * for every other helper (e.g. getCracksPerDay).
  */
-globalServiceMock.ghelper.and.returnValue(of({ meta: {}, data: [] }));
+function ghelperDefaultFake(_service: ServiceConfig, option: string) {
+  if (option === 'getCompletedCount') {
+    return of({ data: { completedTasks: 15, completedSupertasks: 5 } });
+  }
+  return of({ meta: {}, data: [] });
+}
+globalServiceMock.ghelper.and.callFake(ghelperDefaultFake);
 
 /**
  * Mock implementation of LocalStorageService for testing purposes.
@@ -191,6 +190,9 @@ describe('HomeComponent (template permissions and view)', () => {
 
     permissionServiceMock.hasPermissionSync.calls.reset();
     globalServiceMock.getAll.calls.reset();
+    // Re-arm the ghelper callFake: specs share this spy and run in random order, so a
+    // heatmap test that set a plain returnValue could otherwise zero out the counts here.
+    globalServiceMock.ghelper.and.callFake(ghelperDefaultFake);
 
     fixture.detectChanges();
     mockAutoRefreshService.toggleAutoRefresh.calls.reset();
@@ -407,15 +409,19 @@ describe('HomeComponent — updateHeatmapData$()', () => {
     expect(globalServiceMock.ghelper).toHaveBeenCalledWith(SERV.HELPER, 'getCracksPerDay');
   });
 
-  it('should NOT call ghelper when canReadCracks is false', () => {
+  it('should NOT call ghelper for getCracksPerDay when canReadCracks is false', () => {
     permissionServiceMock.hasPermissionSync.and.callFake((perm: PermissionValues) => perm !== Perm.Hash.READ);
+    // canReadTasks is true here, so getCompletedCounts$ still runs — give it a valid response.
+    globalServiceMock.ghelper.and.callFake(ghelperDefaultFake);
     globalServiceMock.ghelper.calls.reset();
 
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
 
-    expect(globalServiceMock.ghelper).not.toHaveBeenCalled();
+    // ghelper is still used for getCompletedCount (gated by canReadTasks), so assert
+    // specifically that the cracks-per-day helper was not requested.
+    expect(globalServiceMock.ghelper).not.toHaveBeenCalledWith(SERV.HELPER, 'getCracksPerDay');
   });
 
   it('should populate heatmapData from ghelper response and fill missing days with 0', () => {
@@ -465,5 +471,22 @@ describe('HomeComponent — updateHeatmapData$()', () => {
 
     expect(() => fixture.detectChanges()).not.toThrow();
     expect(component.heatmapData).toEqual([]);
+  });
+
+  it('should fetch completed counts via getCompletedCount when canReadTasks is true', () => {
+    permissionServiceMock.hasPermissionSync.and.callFake((perm: PermissionValues) => perm === Perm.Task.READ);
+    globalServiceMock.ghelper.and.callFake((service: ServiceConfig, option: string) =>
+      option === 'getCompletedCount'
+        ? of({ data: { completedTasks: 12, completedSupertasks: 3 } })
+        : of({ meta: {}, data: [] })
+    );
+
+    fixture = TestBed.createComponent(HomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(globalServiceMock.ghelper).toHaveBeenCalledWith(SERV.HELPER, 'getCompletedCount');
+    expect(component.completedTasks).toBe(12);
+    expect(component.completedSupertasks).toBe(3);
   });
 });

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -62,13 +62,11 @@ const globalServiceMock = jasmine.createSpyObj('GlobalService', ['getAll', 'ghel
  * Returns different counts depending on the service and filter parameters.
  */
 globalServiceMock.getAll.and.callFake((service: ServiceConfig, params?: RequestParams) => {
-  // TASKS_WRAPPER_COUNT only yields the total now (tasks vs supertasks by taskType filter);
-  // completed counts come from the getCompletedCount ghelper mock below.
   if (service === SERV.TASKS_WRAPPER_COUNT) {
     const isSuperTask = params?.filter?.some(
       (filter: Filter) => filter.field === 'taskType' && filter.value === TaskType.SUPERTASK
     );
-    return of({ meta: { count: isSuperTask ? 10 : 30 } }); // 10 total supertasks, 30 total tasks
+    return of({ meta: { count: isSuperTask ? 10 : 30 } });
   }
 
   // Handle AGENTS_COUNT — returns total and active agent counts
@@ -90,11 +88,6 @@ globalServiceMock.getAll.and.callFake((service: ServiceConfig, params?: RequestP
   return of({ meta: { count: 0 }, results: [] });
 });
 
-/**
- * Default `ghelper` mock: returns the completed task/supertask counts for the
- * getCompletedCount endpoint (15 tasks, 5 supertasks) and an empty data object
- * for every other helper (e.g. getCracksPerDay).
- */
 function ghelperDefaultFake(_service: ServiceConfig, option: string) {
   if (option === 'getCompletedCount') {
     return of({ data: { completedTasks: 15, completedSupertasks: 5 } });
@@ -190,8 +183,6 @@ describe('HomeComponent (template permissions and view)', () => {
 
     permissionServiceMock.hasPermissionSync.calls.reset();
     globalServiceMock.getAll.calls.reset();
-    // Re-arm the ghelper callFake: specs share this spy and run in random order, so a
-    // heatmap test that set a plain returnValue could otherwise zero out the counts here.
     globalServiceMock.ghelper.and.callFake(ghelperDefaultFake);
 
     fixture.detectChanges();
@@ -411,7 +402,6 @@ describe('HomeComponent — updateHeatmapData$()', () => {
 
   it('should NOT call ghelper for getCracksPerDay when canReadCracks is false', () => {
     permissionServiceMock.hasPermissionSync.and.callFake((perm: PermissionValues) => perm !== Perm.Hash.READ);
-    // canReadTasks is true here, so getCompletedCounts$ still runs — give it a valid response.
     globalServiceMock.ghelper.and.callFake(ghelperDefaultFake);
     globalServiceMock.ghelper.calls.reset();
 
@@ -419,8 +409,6 @@ describe('HomeComponent — updateHeatmapData$()', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
 
-    // ghelper is still used for getCompletedCount (gated by canReadTasks), so assert
-    // specifically that the cracks-per-day helper was not requested.
     expect(globalServiceMock.ghelper).not.toHaveBeenCalledWith(SERV.HELPER, 'getCracksPerDay');
   });
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -175,7 +175,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     const observables: Observable<void>[] = [];
 
     if (this.canReadAgents) observables.push(this.getAgents$());
-    if (this.canReadTasks) observables.push(this.getTasks$(), this.getSuperTasks$());
+    if (this.canReadTasks) observables.push(this.getTasks$(), this.getSuperTasks$(), this.getCompletedCounts$());
     if (this.canReadCracks) observables.push(this.getCracks$(), this.updateHeatmapData$());
 
     if (observables.length === 0) return of(undefined);
@@ -230,75 +230,77 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Fetches total and completed tasks count.
-   * Archived tasks are excluded.
+   * Fetches the total number of tasks. Archived tasks are excluded.
+   * The completed count is fetched separately, see {@link getCompletedCounts$}.
    * @returns Observable<void> completing when data is loaded or errored
    */
   private getTasks$(): Observable<void> {
-    const paramsTotalTasks = new RequestParamBuilder()
+    const params = new RequestParamBuilder()
       .addInclude('tasks')
       .addFilter({ field: 'taskType', operator: FilterType.EQUAL, value: 0 })
       .addFilter({ field: 'isArchived', operator: FilterType.EQUAL, value: 0 })
       .create();
 
-    const paramsCompletedTasks = new RequestParamBuilder()
-      .addInclude('tasks')
-      .addFilter({ field: 'taskType', operator: FilterType.EQUAL, value: 0 })
-      .addFilter({ field: 'isArchived', operator: FilterType.EQUAL, value: 0 })
-      .addFilter({ field: 'keyspace', operator: FilterType.GREATER, value: 0 })
-      .create();
-
-    return forkJoin([
-      this.gs.getAll(SERV.TASKS_WRAPPER_COUNT, paramsTotalTasks).pipe(
-        map((res: ResponseWrapper) => (this.totalTasks = res.meta.count ?? 0)),
-        catchError((err) => {
-          console.error('Failed to fetch total tasks:', err);
-          return of(undefined);
-        })
-      ),
-      this.gs.getAll(SERV.TASKS_WRAPPER_COUNT, paramsCompletedTasks).pipe(
-        map((res: ResponseWrapper) => (this.completedTasks = res.meta.count ?? 0)),
-        catchError((err) => {
-          console.error('Failed to fetch completed tasks:', err);
-          return of(undefined);
-        })
-      )
-    ]).pipe(map(() => undefined));
+    return this.gs.getAll(SERV.TASKS_WRAPPER_COUNT, params).pipe(
+      map((res: ResponseWrapper) => {
+        this.totalTasks = res.meta.count ?? 0;
+      }),
+      catchError((err) => {
+        console.error('Failed to fetch total tasks:', err);
+        return of(undefined);
+      })
+    );
   }
 
   /**
-   * Fetches total and completed supertasks count.
-   * Archived supertasks are excluded.
+   * Fetches the total number of supertasks. Archived supertasks are excluded.
+   * The completed count is fetched separately, see {@link getCompletedCounts$}.
    * @returns Observable<void> completing when data is loaded or errored
    */
   private getSuperTasks$(): Observable<void> {
-    const paramsTotalSupertasks = new RequestParamBuilder()
+    const params = new RequestParamBuilder()
       .addFilter({ field: 'taskType', operator: FilterType.EQUAL, value: TaskType.SUPERTASK })
       .addFilter({ field: 'isArchived', operator: FilterType.EQUAL, value: 0 })
       .create();
 
-    const paramsCompletedSupertasks = new RequestParamBuilder()
-      .addFilter({ field: 'keyspace', operator: FilterType.GREATER, value: 0 })
-      .addFilter({ field: 'taskType', operator: FilterType.EQUAL, value: TaskType.SUPERTASK })
-      .addFilter({ field: 'isArchived', operator: FilterType.EQUAL, value: 0 })
-      .create();
+    return this.gs.getAll(SERV.TASKS_WRAPPER_COUNT, params).pipe(
+      map((res: ResponseWrapper) => {
+        this.totalSupertasks = res.meta.count ?? 0;
+      }),
+      catchError((err) => {
+        console.error('Failed to fetch total supertasks:', err);
+        return of(undefined);
+      })
+    );
+  }
 
-    return forkJoin([
-      this.gs.getAll(SERV.TASKS_WRAPPER_COUNT, paramsTotalSupertasks).pipe(
-        map((res: ResponseWrapper) => (this.totalSupertasks = res.meta.count ?? 0)),
-        catchError((err) => {
-          console.error('Failed to fetch total supertasks:', err);
-          return of(undefined);
-        })
-      ),
-      this.gs.getAll(SERV.TASKS_WRAPPER_COUNT, paramsCompletedSupertasks).pipe(
-        map((res: ResponseWrapper) => (this.completedSupertasks = res.meta.count ?? 0)),
-        catchError((err) => {
-          console.error('Failed to fetch completed supertasks:', err);
-          return of(undefined);
-        })
-      )
-    ]).pipe(map(() => undefined));
+  /**
+   * Fetches the number of completed tasks and supertasks from the getCompletedCount
+   * helper. The server derives completion from the searched keyspace
+   * (SUM(checkpoint) - SUM(skip) === keyspace) and counts a supertask as completed
+   * only when all of its subtasks are completed. This replaces the keyspace > 0
+   * heuristic, which turned true as soon as the first chunk was measured.
+   * @returns Observable<void> completing when data is loaded or errored
+   */
+  private getCompletedCounts$(): Observable<void> {
+    const completedCountSchema = z.object({
+      data: z.object({
+        completedTasks: z.number(),
+        completedSupertasks: z.number()
+      })
+    });
+
+    return this.gs.ghelper(SERV.HELPER, 'getCompletedCount').pipe(
+      map((res: ResponseWrapper) => {
+        const { data } = completedCountSchema.parse(res);
+        this.completedTasks = data.completedTasks;
+        this.completedSupertasks = data.completedSupertasks;
+      }),
+      catchError((err) => {
+        console.error('Failed to fetch completed counts:', err);
+        return of(undefined);
+      })
+    );
   }
 
   /**

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -274,14 +274,6 @@ export class HomeComponent implements OnInit, OnDestroy {
     );
   }
 
-  /**
-   * Fetches the number of completed tasks and supertasks from the getCompletedCount
-   * helper. The server derives completion from the searched keyspace
-   * (SUM(checkpoint) - SUM(skip) === keyspace) and counts a supertask as completed
-   * only when all of its subtasks are completed. This replaces the keyspace > 0
-   * heuristic, which turned true as soon as the first chunk was measured.
-   * @returns Observable<void> completing when data is loaded or errored
-   */
   private getCompletedCounts$(): Observable<void> {
     const completedCountSchema = z.object({
       data: z.object({


### PR DESCRIPTION
A new endpoint has been added to count the completed tasks and supertasks.

Use this one as the count endpoint can not support the correct filters to do this.

Issue: https://github.com/hashtopolis/server/issues/2341