### PR TITLE
Add title attributes to various form fields

### DIFF
--- a/src/app/shared/input/check/check.component.html
+++ b/src/app/shared/input/check/check.component.html
@@ -9,6 +9,7 @@
     (blur)="onTouched()"
     [disabled]="disabled || readonly"
     [id]="inputId"
+    [title]="title"
     [class.mat-mdc-checkbox-invalid]="hasError && isTouched && !readonly"
   >
     @if (linkTo) {

--- a/src/app/shared/input/color/color.component.html
+++ b/src/app/shared/input/color/color.component.html
@@ -1,5 +1,5 @@
 <div class="field-stack" [class.is-invalid]="hasError && isTouched && !readonly" [class.input--readonly]="readonly">
-  <label class="field-stack__label" [attr.for]="inputId">
+  <label class="field-stack__label" [attr.for]="inputId" [title]="title">
     @if (linkTo) {
       <a [routerLink]="linkTo">{{ title }}</a>
     } @else {
@@ -11,7 +11,7 @@
   </label>
 
   <div class="color-input-container">
-    <mat-form-field class="field-stack__field">
+    <mat-form-field class="field-stack__field" [title]="title">
       <input
         #selectInput
         matInput

--- a/src/app/shared/input/date/date.component.html
+++ b/src/app/shared/input/date/date.component.html
@@ -1,5 +1,5 @@
 <div class="field-stack" [class.is-invalid]="hasError && isTouched && !readonly" [class.input--readonly]="readonly">
-  <label class="field-stack__label" [attr.for]="inputId">
+  <label class="field-stack__label" [attr.for]="inputId" [title]="title">
     @if (linkTo) {
       <a [routerLink]="linkTo">{{ title }}</a>
     } @else {
@@ -10,7 +10,7 @@
     }
   </label>
 
-  <mat-form-field class="form-group field-stack__field" appearance="outline">
+  <mat-form-field class="form-group field-stack__field" appearance="outline" [title]="title">
     <input
       matInput
       [matDatepicker]="picker"

--- a/src/app/shared/input/multiselect/multiselect.component.html
+++ b/src/app/shared/input/multiselect/multiselect.component.html
@@ -6,7 +6,7 @@
 </div>
 } @else {
 <div class="field-stack" [class.is-invalid]="hasError && isTouched && !readonly" [class.input--readonly]="readonly">
-  <label class="field-stack__label">
+  <label class="field-stack__label" [title]="label">
     @if (linkTo) {
     <a [routerLink]="linkTo">{{ label }}</a>
     } @else {
@@ -17,7 +17,7 @@
     }
   </label>
 
-  <mat-form-field class="custom-chip-grid field-stack__field show-subscript">
+  <mat-form-field class="custom-chip-grid field-stack__field show-subscript" [title]="label">
     <mat-chip-grid #chipGridRef [required]="isRequired" aria-label="Items selection" [disabled]="disabled || readonly">
       @for (item of readonly ? items : selectedItems; track item.id) {
       <mat-chip-row [removable]="!readonly">

--- a/src/app/shared/input/number/number.component.html
+++ b/src/app/shared/input/number/number.component.html
@@ -1,5 +1,5 @@
 <div class="field-stack" [class.is-invalid]="hasError && isTouched && !readonly" [class.input--readonly]="readonly">
-  <label class="field-stack__label" [attr.for]="inputId">
+  <label class="field-stack__label" [attr.for]="inputId" [title]="title">
     @if (linkTo) {
       <a [routerLink]="linkTo">{{ title }}</a>
     } @else {
@@ -22,7 +22,7 @@
     }
   </label>
 
-  <mat-form-field class="field-stack__field">
+  <mat-form-field class="field-stack__field" [title]="title">
     <div [class.is-invalid]="error && !readonly">
       <input
         #inputField

--- a/src/app/shared/input/select/select.component.html
+++ b/src/app/shared/input/select/select.component.html
@@ -1,5 +1,5 @@
 <div class="field-stack" [class.is-invalid]="hasError && isTouched && !readonly" [class.input--readonly]="readonly">
-  <label class="field-stack__label" [attr.for]="inputId">
+  <label class="field-stack__label" [attr.for]="inputId" [title]="title">
     @if (!isLoading) {
       @if (linkTo) {
         <a [routerLink]="linkTo">{{ title }}</a>
@@ -28,7 +28,7 @@
     }
   </label>
 
-  <mat-form-field class="field-stack__field">
+  <mat-form-field class="field-stack__field" [title]="title">
     <mat-select
       #inputField
       [value]="value"

--- a/src/app/shared/input/text-area/text-area.component.html
+++ b/src/app/shared/input/text-area/text-area.component.html
@@ -4,7 +4,7 @@
   [class.input--readonly]="readonly"
   [class.field-stack--row-aligned]="rowAligned"
 >
-  <label class="field-stack__label" [attr.for]="inputId">
+  <label class="field-stack__label" [attr.for]="inputId" [title]="title">
     @if (linkTo) {
       <a [routerLink]="linkTo">{{ title }}</a>
     } @else {
@@ -28,7 +28,7 @@
     }
   </label>
 
-  <mat-form-field class="custom-textarea field-stack__field">
+  <mat-form-field class="custom-textarea field-stack__field" [title]="title">
     <textarea
       matInput
       [class.is-invalid]="error && !readonly"

--- a/src/app/shared/input/text/text.component.html
+++ b/src/app/shared/input/text/text.component.html
@@ -1,5 +1,5 @@
 <div class="field-stack" [class.is-invalid]="hasError && isTouched && !readonly" [class.input--readonly]="readonly">
-  <label class="field-stack__label" [attr.for]="inputId">
+  <label class="field-stack__label" [attr.for]="inputId" [title]="title">
     @if (linkTo) {
       <a [routerLink]="linkTo" class="field-stack__label-link" [attr.aria-label]="'Open ' + title">
         {{ title }}
@@ -25,7 +25,7 @@
     }
   </label>
 
-  <mat-form-field class="field-stack__field">
+  <mat-form-field class="field-stack__field" [title]="title">
     @if (icon) {
       <mat-icon matPrefix>{{ icon }}</mat-icon>
     }


### PR DESCRIPTION
Closes hashtopolis/server#2389

I've decided to solve the problem of the captions being truncated by adding `title` attributes to the form fields.

The tooltip that was showing on the captions (and the input field itself) up until now was always saying "Settings", that was because the labels and fields did not have `title` attributes, so the Browser (at least that was the case with Chrome) was looking for the next `title` attribute somewhere up the DOM hierarchy and that happend to be that of the page/panel which had the title set to "Settings".

I also didn't want to use a dedicated `mat-icon` tooltip that exists for almost all types input fields because that seems more appropriate to use for further explaining and hints but not for simply writing out the caption in full. Also that would have caused conflicts for situations where the custom tooltip is already in use.

In conclusion I thought it would be the easiest and least intrusive solution to just add `title` attributes as the browser was already showing a standard tooltip anyway, but did so by pulling in a `title` attribute from up the hierarchy in the DOM. At least it is now showing a more sensible tooltip.