### PR TITLE
Add empty title attribute to custom tooltip

### DIFF
--- a/src/app/shared/input/check/check.component.html
+++ b/src/app/shared/input/check/check.component.html
@@ -26,6 +26,7 @@
         matTooltipClass="tooltip-custom-style"
         container="body"
         aria-hidden="true"
+        title=""
       >
         info
       </mat-icon>

--- a/src/app/shared/input/multiselect/multiselect.component.html
+++ b/src/app/shared/input/multiselect/multiselect.component.html
@@ -21,7 +21,7 @@
     <mat-chip-grid #chipGridRef [required]="isRequired" aria-label="Items selection" [disabled]="disabled || readonly">
       @for (item of readonly ? items : selectedItems; track item.id) {
       <mat-chip-row [removable]="!readonly">
-        <div matTooltip="{{ item.name }}">
+        <div matTooltip="{{ item.name }}" title="">
           {{ item.id }}
           <span>{{ item.name.length > 30 ? (item.name | slice: 0 : 30) + '...' : item.name }}</span>
         </div>
@@ -53,7 +53,7 @@
     <input [matChipInputFor]="chipGridRef" hidden aria-hidden="true" tabindex="-1" />
     }
     <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events,@angular-eslint/template/interactive-supports-focus -->
-    <span matSuffix class="multiselect-suffix-slot" (click)="$event.stopPropagation()">
+    <span matSuffix class="multiselect-suffix-slot" title="" (click)="$event.stopPropagation()">
       <ng-content select="[matSuffix]"></ng-content>
     </span>
     @if (hasError && errors && !readonly) {

--- a/src/app/shared/input/number/number.component.html
+++ b/src/app/shared/input/number/number.component.html
@@ -16,6 +16,7 @@
         matTooltipPosition="below"
         matTooltipClass="tooltip-custom-style"
         aria-hidden="true"
+        title=""
       >
         info
       </mat-icon>

--- a/src/app/shared/input/select/select.component.html
+++ b/src/app/shared/input/select/select.component.html
@@ -18,6 +18,7 @@
           matTooltipClass="tooltip-custom-style"
           container="body"
           aria-hidden="true"
+          title=""
         >
           info
         </mat-icon>

--- a/src/app/shared/input/text-area/text-area.component.html
+++ b/src/app/shared/input/text-area/text-area.component.html
@@ -22,6 +22,7 @@
         matTooltipClass="tooltip-custom-style"
         matTooltipShowDelay="500"
         aria-hidden="true"
+        title=""
       >
         info
       </mat-icon>

--- a/src/app/shared/input/text/text.component.html
+++ b/src/app/shared/input/text/text.component.html
@@ -19,6 +19,7 @@
         matTooltipPosition="below"
         matTooltipClass="tooltip-custom-style"
         aria-hidden="true"
+        title=""
       >
         info
       </mat-icon>


### PR DESCRIPTION
Fixes hashtopolis/server#2322

The only feasible way I've found in order to keep the browser's default tooltip from showing and partially blocking our custom tooltip is by adding an empty `title` attribute.

That's just a proposal on solving this, if there is a more elegant way to do that, I'm open do discuss.