### PR TITLE
When opening the picker set default color to white if no colour

### DIFF
--- a/src/app/shared/input/color/color.component.html
+++ b/src/app/shared/input/color/color.component.html
@@ -19,6 +19,7 @@
         [id]="inputId"
         [value]="nativeColor || DEFAULT_NATIVE_INPUT_PLACEHOLDER"
         [class.color-unset]="!value"
+        (click)="onPickerOpen()"
         (input)="onValueChange($event)"
         (blur)="onTouched()"
         [style.background]="nativeColor || null"

--- a/src/app/shared/input/color/color.component.spec.ts
+++ b/src/app/shared/input/color/color.component.spec.ts
@@ -75,6 +75,30 @@ describe('InputColorComponent', () => {
     });
   });
 
+  describe('onPickerOpen', () => {
+    it('emits the fallback color as bare hex when opened from the unset state', () => {
+      const onChange = jasmine.createSpy('onChange');
+      component.registerOnChange(onChange);
+      component.writeValue(null);
+
+      component.onPickerOpen();
+
+      expect(component.value).toBe('FFFFFF');
+      expect(onChange).toHaveBeenCalledWith('FFFFFF');
+    });
+
+    it('leaves an already selected color untouched', () => {
+      const onChange = jasmine.createSpy('onChange');
+      component.registerOnChange(onChange);
+      component.writeValue('#3366ff');
+
+      component.onPickerOpen();
+
+      expect(component.value).toBe('#3366ff');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
   describe('defaultColor', () => {
     it('applies the default visually but does not emit when registerOnChange runs after a null writeValue', () => {
       component.defaultColor = 'random';
@@ -111,6 +135,19 @@ describe('InputColorComponent', () => {
       fixture.detectChanges();
 
       expect(nativeInput().value).toBe(component.DEFAULT_NATIVE_INPUT_PLACEHOLDER.toLowerCase());
+    });
+
+    it('commits the placeholder color when the native input is clicked while unset (regression: #2345)', () => {
+      component.registerOnChange(jasmine.createSpy('onChange'));
+      component.writeValue(null);
+      fixture.detectChanges();
+
+      nativeInput().click();
+      fixture.detectChanges();
+
+      expect(component.value).toBe('FFFFFF');
+      expect(nativeInput().classList).not.toContain('color-unset');
+      expect(swatchText().textContent?.trim()).toBe('#FFFFFF');
     });
 
     it('binds the actual hex to the native input when value is set', () => {

--- a/src/app/shared/input/color/color.component.ts
+++ b/src/app/shared/input/color/color.component.ts
@@ -65,6 +65,16 @@ export class InputColorComponent extends AbstractInputComponent<string> {
     this.setValue(this.stripHash((event.target as HTMLInputElement).value));
   }
 
+  /**
+   * Browsers suppress the picker's `input` event when the chosen color already
+   * equals the element's value, so the fallback hex an unset field displays was
+   * the one color it could never take (hashtopolis#2345). Opening the picker
+   * commits that color up front; every other choice then differs and emits.
+   */
+  onPickerOpen(): void {
+    if (!this.value) this.setValue(this.stripHash(this.DEFAULT_NATIVE_INPUT_PLACEHOLDER));
+  }
+
   private stripHash(value: string): string {
     return (value ?? '').replace(/^#/, '');
   }


### PR DESCRIPTION
Previously when opened with no colour still white was displaid in the picker but not selected yet and you had to pick another colour and then select white again in order to change form no colour to white.
This was done this way as there is no way to have no colour value on the native html input.

Now auto change from no colour to white when opening the colour picker.

Issue: https://github.com/hashtopolis/server/issues/2345