### PR TITLE
Remove api v2 reference

### DIFF
--- a/src/app/core/_interceptors/http-res.interceptor.ts
+++ b/src/app/core/_interceptors/http-res.interceptor.ts
@@ -61,9 +61,7 @@ export class HttpResInterceptor implements HttpInterceptor {
       errmsg = error.error.title;
       showAlert = true;
     } else if (error.status === 0) {
-      errmsg = `Network error. Please verify the IP address (${this.extractIpAndPort(
-        req.url
-      )}) and try again. Note: APIv2 HASHTOPOLIS_APIV2_ENABLE=1 needs to be enabled. `;
+      errmsg = `Network error. Please verify the IP address (${this.extractIpAndPort(req.url)}) and try again.`;
     } else {
       errmsg = error.error?.title || 'An unknown error occurred.';
     }


### PR DESCRIPTION
Remove reference to api v2 this is now set by default and does not have to be set manually in env file.