### PR TITLE
fix: include hashlist in cracked hashes API request to fix modal title

### DIFF
--- a/src/app/core/_datasources/cracks.datasource.ts
+++ b/src/app/core/_datasources/cracks.datasource.ts
@@ -40,7 +40,7 @@ export class CracksDataSource extends BaseDataSource<JHash> {
 
     // Use stored filter if no new filter is provided
     const activeFilter = query || this._currentFilter;
-    let params = new RequestParamBuilder().addInitial(this).addInclude('chunk').addFilter({
+    let params = new RequestParamBuilder().addInitial(this).addInclude('chunk').addInclude('hashlist').addFilter({
       field: 'isCracked',
       operator: FilterType.EQUAL,
       value: true


### PR DESCRIPTION
## Summary

The `showTruncatedData` method in `cracks-table.component.ts` reads `hashlist.name` from the included relationship to display the hashlist name in the modal title. However, the API request in `cracks.datasource.ts` only included `chunk` and not `hashlist`, causing the `hashlistName` variable to be `undefined`.

## Changes

- Added `.addInclude('hashlist')` to the request parameter builder in `loadCrackedHashes` method

## Result

Before: Modal title shows "Full Hash for: " (empty hashlist name)
After: Modal title shows "Full Hash for: {hashlist_name}"

## Related

Fixes hashtopolis/server#2402