### PR TITLE
Fix static chunking detail in the task detail page

### DIFF
--- a/src/app/core/_components/tables/hashlist-pretask-builder-table/hashlist-pretask-builder-table.component.ts
+++ b/src/app/core/_components/tables/hashlist-pretask-builder-table/hashlist-pretask-builder-table.component.ts
@@ -19,6 +19,7 @@ import { AlertService } from '@services/shared/alert.service';
 
 import { HashlistPretaskBuilderDataSource } from '@datasources/hashlist-pretask-builder.datasource';
 
+import { StaticChunkingMode } from '@src/app/core/_constants/tasks.config';
 import { environment } from '@src/environments/environment';
 
 @Component({
@@ -186,7 +187,7 @@ export class HashlistPretaskBuilderTableComponent implements OnInit, OnDestroy {
         crackerBinaryId,
         isArchived: false,
         notes: '',
-        staticChunks: 0,
+        staticChunks: StaticChunkingMode.NONE,
         chunkSize: Number(environment.config.tasks.chunkSize),
         forcePipe: false,
         preprocessorId: 0,

--- a/src/app/core/_constants/tasks.config.ts
+++ b/src/app/core/_constants/tasks.config.ts
@@ -1,7 +1,20 @@
-export const staticChunking = [
-  { id: 0, name: 'No' },
-  { id: 1, name: 'Fixed chunk size' },
-  { id: 2, name: 'Fixed number of chunks' }
+import { SelectOption } from '@src/app/shared/utils/forms';
+
+/**
+ * Static chunking modes as stored in a task's `staticChunks` attribute.
+ * `chunkSize` carries the configured number for both fixed modes.
+ */
+export const StaticChunkingMode = {
+  NONE: 0,
+  FIXED_CHUNK_SIZE: 1,
+  FIXED_NUMBER_OF_CHUNKS: 2
+} as const;
+export type StaticChunkingMode = (typeof StaticChunkingMode)[keyof typeof StaticChunkingMode];
+
+export const staticChunking: SelectOption<number>[] = [
+  { id: StaticChunkingMode.NONE, name: 'No' },
+  { id: StaticChunkingMode.FIXED_CHUNK_SIZE, name: 'Fixed chunk size' },
+  { id: StaticChunkingMode.FIXED_NUMBER_OF_CHUNKS, name: 'Fixed number of chunks' }
 ];
 
 export const benchmarkType = [

--- a/src/app/core/_constants/tasks.config.ts
+++ b/src/app/core/_constants/tasks.config.ts
@@ -1,9 +1,5 @@
 import { SelectOption } from '@src/app/shared/utils/forms';
 
-/**
- * Static chunking modes as stored in a task's `staticChunks` attribute.
- * `chunkSize` carries the configured number for both fixed modes.
- */
 export const StaticChunkingMode = {
   NONE: 0,
   FIXED_CHUNK_SIZE: 1,

--- a/src/app/tasks/edit-tasks/edit-tasks.component.html
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.html
@@ -123,14 +123,8 @@
             </app-form-row>
 
             <app-form-row [columns]="2">
-              <input-text title="Use static chunking" formControlName="staticChunks"></input-text>
+              <input-text title="Static chunking" formControlName="staticChunks"></input-text>
               <input-text title="Enforce Piping" formControlName="forcePipe"></input-text>
-
-              @if (staticChunksMode === StaticChunkingMode.FIXED_CHUNK_SIZE) {
-                <input-text title="Fixed size of chunks" formControlName="chunkSize"></input-text>
-              } @else if (staticChunksMode === StaticChunkingMode.FIXED_NUMBER_OF_CHUNKS) {
-                <input-text title="Fixed number of chunks" formControlName="chunkSize"></input-text>
-              }
             </app-form-row>
           </div>
 

--- a/src/app/tasks/edit-tasks/edit-tasks.component.html
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.html
@@ -24,7 +24,7 @@
                 <input-number title="Priority" formControlName="priority"></input-number>
                 <input-number title="Status timer" formControlName="statusTimer"></input-number>
                 <input-number title="Max agents" formControlName="maxAgents"></input-number>
-                <input-number title="Chunk size" formControlName="chunkTime"></input-number>
+                <input-number title="Chunk time" formControlName="chunkTime"></input-number>
               </app-form-row>
               <app-form-row align="left">
                 <input-check title="CPU only" formControlName="isCpuTask"></input-check>
@@ -125,6 +125,12 @@
             <app-form-row [columns]="2">
               <input-text title="Use static chunking" formControlName="staticChunks"></input-text>
               <input-text title="Enforce Piping" formControlName="forcePipe"></input-text>
+
+              @if (staticChunksMode === StaticChunkingMode.FIXED_CHUNK_SIZE) {
+                <input-text title="Fixed size of chunks" formControlName="chunkSize"></input-text>
+              } @else if (staticChunksMode === StaticChunkingMode.FIXED_NUMBER_OF_CHUNKS) {
+                <input-text title="Fixed number of chunks" formControlName="chunkSize"></input-text>
+              }
             </app-form-row>
           </div>
 

--- a/src/app/tasks/edit-tasks/edit-tasks.component.html
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.html
@@ -123,7 +123,7 @@
             </app-form-row>
 
             <app-form-row [columns]="2">
-              <input-text title="Static chunking" formControlName="staticChunks"></input-text>
+              <input-text title="Use static chunking" formControlName="staticChunks"></input-text>
               <input-text title="Enforce Piping" formControlName="forcePipe"></input-text>
             </app-form-row>
           </div>

--- a/src/app/tasks/edit-tasks/edit-tasks.component.spec.ts
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.spec.ts
@@ -272,45 +272,7 @@ describe('EditTasksComponent', () => {
       expect(component.updateForm.getRawValue()['skipKeyspace']).toBe(500);
     }));
 
-    it('should label staticChunks=1 as "Fixed chunk size"', fakeAsync(() => {
-      const response = mockResponse({
-        data: {
-          ...(mockTaskResponse().data as object),
-          attributes: {
-            ...((mockTaskResponse().data as Record<string, unknown>)['attributes'] as object),
-            staticChunks: 1
-          }
-        }
-      }) as ResponseWrapper;
-
-      initComponent();
-      respondToTaskRequest(response);
-      tick();
-
-      expect(component.updateForm.getRawValue()['staticChunks']).toBe('Fixed chunk size');
-      expect(component.staticChunksMode).toBe(StaticChunkingMode.FIXED_CHUNK_SIZE);
-    }));
-
-    it('should label staticChunks=2 as "Fixed number of chunks"', fakeAsync(() => {
-      const response = mockResponse({
-        data: {
-          ...(mockTaskResponse().data as object),
-          attributes: {
-            ...((mockTaskResponse().data as Record<string, unknown>)['attributes'] as object),
-            staticChunks: 2
-          }
-        }
-      }) as ResponseWrapper;
-
-      initComponent();
-      respondToTaskRequest(response);
-      tick();
-
-      expect(component.updateForm.getRawValue()['staticChunks']).toBe('Fixed number of chunks');
-      expect(component.staticChunksMode).toBe(StaticChunkingMode.FIXED_NUMBER_OF_CHUNKS);
-    }));
-
-    function renderWithStaticChunks(staticChunks: number): HTMLElement | null {
+    function loadWithStaticChunks(staticChunks: number): string {
       const response = mockResponse({
         data: {
           ...(mockTaskResponse().data as object),
@@ -324,25 +286,35 @@ describe('EditTasksComponent', () => {
       initComponent();
       respondToTaskRequest(response);
       tick();
-      fixture.detectChanges();
 
-      return fixture.nativeElement.querySelector('input-text[formControlName="chunkSize"]');
+      return component.updateForm.getRawValue()['staticChunks'];
     }
 
-    it('should render the chunkSize field as "Fixed size of chunks" for staticChunks=1', fakeAsync(() => {
-      const field = renderWithStaticChunks(StaticChunkingMode.FIXED_CHUNK_SIZE);
-
-      expect(field?.getAttribute('title')).toBe('Fixed size of chunks');
+    it('should label staticChunks=0 as "No"', fakeAsync(() => {
+      expect(loadWithStaticChunks(StaticChunkingMode.NONE)).toBe('No');
     }));
 
-    it('should render the chunkSize field as "Fixed number of chunks" for staticChunks=2', fakeAsync(() => {
-      const field = renderWithStaticChunks(StaticChunkingMode.FIXED_NUMBER_OF_CHUNKS);
-
-      expect(field?.getAttribute('title')).toBe('Fixed number of chunks');
+    it('should label staticChunks=1 with the fixed chunk size', fakeAsync(() => {
+      expect(loadWithStaticChunks(StaticChunkingMode.FIXED_CHUNK_SIZE)).toBe(
+        `Fixed chunksize: ${(1000).toLocaleString()}`
+      );
     }));
 
-    it('should not render the chunkSize field when static chunking is off', fakeAsync(() => {
-      expect(renderWithStaticChunks(StaticChunkingMode.NONE)).toBeNull();
+    it('should label staticChunks=2 with the fixed number of chunks', fakeAsync(() => {
+      expect(loadWithStaticChunks(StaticChunkingMode.FIXED_NUMBER_OF_CHUNKS)).toBe(
+        `Fixed number of chunks: ${(1000).toLocaleString()}`
+      );
+    }));
+
+    it('should render the static chunking field in the task information form', fakeAsync(() => {
+      loadWithStaticChunks(StaticChunkingMode.FIXED_CHUNK_SIZE);
+      fixture.detectChanges();
+
+      const field: HTMLElement | null = fixture.nativeElement.querySelector(
+        'input-text[formControlName="staticChunks"]'
+      );
+
+      expect(field?.getAttribute('title')).toBe('Static chunking');
     }));
 
     it('should navigate to /not-found on 404 error', fakeAsync(() => {

--- a/src/app/tasks/edit-tasks/edit-tasks.component.spec.ts
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.spec.ts
@@ -17,6 +17,7 @@ import { AlertService } from '@services/shared/alert.service';
 import { AutoTitleService } from '@services/shared/autotitle.service';
 import { ConfigService } from '@services/shared/config.service';
 
+import { StaticChunkingMode } from '@src/app/core/_constants/tasks.config';
 import { EditTasksComponent } from '@src/app/tasks/edit-tasks/edit-tasks.component';
 import { mockResponse } from '@src/app/testing/mock-response';
 
@@ -271,7 +272,7 @@ describe('EditTasksComponent', () => {
       expect(component.updateForm.getRawValue()['skipKeyspace']).toBe(500);
     }));
 
-    it('should label staticChunks=1 as "Fixed chunk size (1)"', fakeAsync(() => {
+    it('should label staticChunks=1 as "Fixed chunk size"', fakeAsync(() => {
       const response = mockResponse({
         data: {
           ...(mockTaskResponse().data as object),
@@ -286,10 +287,11 @@ describe('EditTasksComponent', () => {
       respondToTaskRequest(response);
       tick();
 
-      expect(component.updateForm.getRawValue()['staticChunks']).toBe('Fixed chunk size (1)');
+      expect(component.updateForm.getRawValue()['staticChunks']).toBe('Fixed chunk size');
+      expect(component.staticChunksMode).toBe(StaticChunkingMode.FIXED_CHUNK_SIZE);
     }));
 
-    it('should label staticChunks=2 as "Fixed number of chunks (2)"', fakeAsync(() => {
+    it('should label staticChunks=2 as "Fixed number of chunks"', fakeAsync(() => {
       const response = mockResponse({
         data: {
           ...(mockTaskResponse().data as object),
@@ -304,7 +306,43 @@ describe('EditTasksComponent', () => {
       respondToTaskRequest(response);
       tick();
 
-      expect(component.updateForm.getRawValue()['staticChunks']).toBe('Fixed number of chunks (2)');
+      expect(component.updateForm.getRawValue()['staticChunks']).toBe('Fixed number of chunks');
+      expect(component.staticChunksMode).toBe(StaticChunkingMode.FIXED_NUMBER_OF_CHUNKS);
+    }));
+
+    function renderWithStaticChunks(staticChunks: number): HTMLElement | null {
+      const response = mockResponse({
+        data: {
+          ...(mockTaskResponse().data as object),
+          attributes: {
+            ...((mockTaskResponse().data as Record<string, unknown>)['attributes'] as object),
+            staticChunks
+          }
+        }
+      }) as ResponseWrapper;
+
+      initComponent();
+      respondToTaskRequest(response);
+      tick();
+      fixture.detectChanges();
+
+      return fixture.nativeElement.querySelector('input-text[formControlName="chunkSize"]');
+    }
+
+    it('should render the chunkSize field as "Fixed size of chunks" for staticChunks=1', fakeAsync(() => {
+      const field = renderWithStaticChunks(StaticChunkingMode.FIXED_CHUNK_SIZE);
+
+      expect(field?.getAttribute('title')).toBe('Fixed size of chunks');
+    }));
+
+    it('should render the chunkSize field as "Fixed number of chunks" for staticChunks=2', fakeAsync(() => {
+      const field = renderWithStaticChunks(StaticChunkingMode.FIXED_NUMBER_OF_CHUNKS);
+
+      expect(field?.getAttribute('title')).toBe('Fixed number of chunks');
+    }));
+
+    it('should not render the chunkSize field when static chunking is off', fakeAsync(() => {
+      expect(renderWithStaticChunks(StaticChunkingMode.NONE)).toBeNull();
     }));
 
     it('should navigate to /not-found on 404 error', fakeAsync(() => {

--- a/src/app/tasks/edit-tasks/edit-tasks.component.spec.ts
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.spec.ts
@@ -314,7 +314,7 @@ describe('EditTasksComponent', () => {
         'input-text[formControlName="staticChunks"]'
       );
 
-      expect(field?.getAttribute('title')).toBe('Static chunking');
+      expect(field?.getAttribute('title')).toBe('Use static chunking');
     }));
 
     it('should navigate to /not-found on 404 error', fakeAsync(() => {

--- a/src/app/tasks/edit-tasks/edit-tasks.component.ts
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.ts
@@ -41,7 +41,7 @@ import { TasksAgentsTableComponent } from '@components/tables/tasks-agents-table
 import { TasksChunksTableComponent } from '@components/tables/tasks-chunks-table/tasks-chunks-table.component';
 
 import { AGENT_MAPPING } from '@src/app/core/_constants/select.config';
-import { StaticChunkingMode, staticChunking } from '@src/app/core/_constants/tasks.config';
+import { StaticChunkingMode } from '@src/app/core/_constants/tasks.config';
 import { FileSizePipe } from '@src/app/core/_pipes/file-size.pipe';
 import { attackCommandWithAliasValidator } from '@src/app/core/_validators/attack-command.validator';
 import { SelectOption, transformSelectOptions } from '@src/app/shared/utils/forms';
@@ -83,8 +83,6 @@ export class EditTasksComponent implements OnInit, OnDestroy {
   isLoadingAgents = false;
   crackerinfo: JCrackerBinary | undefined;
   tkeyspace: number;
-  staticChunksMode: number = StaticChunkingMode.NONE;
-  protected readonly StaticChunkingMode = StaticChunkingMode;
 
   @ViewChild('assignedAgentsTable') agentsTable: TasksAgentsTableComponent;
   @ViewChild(TasksChunksTableComponent) chunkTable!: TasksChunksTableComponent;
@@ -145,7 +143,6 @@ export class EditTasksComponent implements OnInit, OnDestroy {
       this.currenspeed = task.currentSpeed ?? 0;
       this.estimatedTime = task.estimatedTime ?? 0;
       this.cprogress = task.cprogress ?? 0;
-      this.staticChunksMode = task.staticChunks;
 
       if (this.roleService.hasRole('editTaskAgents') && this.roleService.hasRole('editTaskAssignAgents')) {
         this.assingAgentInit((task.assignedAgents ?? []).map((entry) => entry.id));
@@ -166,7 +163,7 @@ export class EditTasksComponent implements OnInit, OnDestroy {
       this.updateForm.setValue({
         taskId: task.id,
         forcePipe: task.forcePipe === true ? 'Yes' : 'No',
-        staticChunks: this.getStaticChunkingLabel(task.staticChunks),
+        staticChunks: this.getStaticChunkingLabel(task.staticChunks, task.chunkSize),
         skipKeyspace: task.skipKeyspace > 0 ? task.skipKeyspace : 'N/A',
         keyspace: task.keyspace,
         keyspaceProgress: task.keyspaceProgress,
@@ -502,7 +499,14 @@ export class EditTasksComponent implements OnInit, OnDestroy {
     });
   }
 
-  private getStaticChunkingLabel(staticChunks: number): string {
-    return staticChunking.find((mode) => mode.id === staticChunks)?.name ?? '';
+  private getStaticChunkingLabel(staticChunks: number, chunkSize: number): string {
+    switch (staticChunks) {
+      case StaticChunkingMode.FIXED_CHUNK_SIZE:
+        return `Fixed chunksize: ${chunkSize.toLocaleString()}`;
+      case StaticChunkingMode.FIXED_NUMBER_OF_CHUNKS:
+        return `Fixed number of chunks: ${chunkSize.toLocaleString()}`;
+      default:
+        return 'No';
+    }
   }
 }

--- a/src/app/tasks/edit-tasks/edit-tasks.component.ts
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.ts
@@ -41,6 +41,7 @@ import { TasksAgentsTableComponent } from '@components/tables/tasks-agents-table
 import { TasksChunksTableComponent } from '@components/tables/tasks-chunks-table/tasks-chunks-table.component';
 
 import { AGENT_MAPPING } from '@src/app/core/_constants/select.config';
+import { StaticChunkingMode, staticChunking } from '@src/app/core/_constants/tasks.config';
 import { FileSizePipe } from '@src/app/core/_pipes/file-size.pipe';
 import { attackCommandWithAliasValidator } from '@src/app/core/_validators/attack-command.validator';
 import { SelectOption, transformSelectOptions } from '@src/app/shared/utils/forms';
@@ -82,6 +83,9 @@ export class EditTasksComponent implements OnInit, OnDestroy {
   isLoadingAgents = false;
   crackerinfo: JCrackerBinary | undefined;
   tkeyspace: number;
+  /** Raw staticChunks value, drives which chunkSize field the template shows. */
+  staticChunksMode: number = StaticChunkingMode.NONE;
+  protected readonly StaticChunkingMode = StaticChunkingMode;
 
   @ViewChild('assignedAgentsTable') agentsTable: TasksAgentsTableComponent;
   @ViewChild(TasksChunksTableComponent) chunkTable!: TasksChunksTableComponent;
@@ -142,6 +146,7 @@ export class EditTasksComponent implements OnInit, OnDestroy {
       this.currenspeed = task.currentSpeed ?? 0;
       this.estimatedTime = task.estimatedTime ?? 0;
       this.cprogress = task.cprogress ?? 0;
+      this.staticChunksMode = task.staticChunks;
 
       if (this.roleService.hasRole('editTaskAgents') && this.roleService.hasRole('editTaskAssignAgents')) {
         this.assingAgentInit((task.assignedAgents ?? []).map((entry) => entry.id));
@@ -499,13 +504,6 @@ export class EditTasksComponent implements OnInit, OnDestroy {
   }
 
   private getStaticChunkingLabel(staticChunks: number): string {
-    switch (staticChunks) {
-      case 1:
-        return 'Fixed chunk size (1)';
-      case 2:
-        return 'Fixed number of chunks (2)';
-      default:
-        return 'No';
-    }
+    return staticChunking.find((mode) => mode.id === staticChunks)?.name ?? '';
   }
 }

--- a/src/app/tasks/edit-tasks/edit-tasks.component.ts
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.ts
@@ -83,7 +83,6 @@ export class EditTasksComponent implements OnInit, OnDestroy {
   isLoadingAgents = false;
   crackerinfo: JCrackerBinary | undefined;
   tkeyspace: number;
-  /** Raw staticChunks value, drives which chunkSize field the template shows. */
   staticChunksMode: number = StaticChunkingMode.NONE;
   protected readonly StaticChunkingMode = StaticChunkingMode;
 

--- a/src/app/tasks/new-tasks/new-tasks.component.html
+++ b/src/app/tasks/new-tasks/new-tasks.component.html
@@ -101,13 +101,13 @@
                   formControlName="staticChunks"
                   [items]="selectStaticChunking"
                 ></input-select>
-                @if (form.controls.staticChunks.value === 1) {
+                @if (form.controls.staticChunks.value === StaticChunkingMode.FIXED_CHUNK_SIZE) {
                   <input-number
                     title="Fixed size of chunks"
                     formControlName="chunkSize"
                     [tooltip]="tasktip.chunkSize"
                   ></input-number>
-                } @else if (form.controls.staticChunks.value === 2) {
+                } @else if (form.controls.staticChunks.value === StaticChunkingMode.FIXED_NUMBER_OF_CHUNKS) {
                   <input-number title="Fixed number of chunks" formControlName="chunkSize"></input-number>
                 }
               </app-form-row>

--- a/src/app/tasks/new-tasks/new-tasks.component.ts
+++ b/src/app/tasks/new-tasks/new-tasks.component.ts
@@ -39,7 +39,7 @@ import {
   CRACKER_VERSION_FIELD_MAPPING,
   DEFAULT_FIELD_MAPPING
 } from '@src/app/core/_constants/select.config';
-import { benchmarkType, staticChunking } from '@src/app/core/_constants/tasks.config';
+import { StaticChunkingMode, benchmarkType, staticChunking } from '@src/app/core/_constants/tasks.config';
 import { CheatsheetComponent } from '@src/app/shared/alert/cheatsheet/cheatsheet.component';
 import { SelectOption, transformSelectOptions } from '@src/app/shared/utils/forms';
 import { AttackCommandData, NewTaskForm, getNewTaskForm } from '@src/app/tasks/new-tasks/new-tasks.form';
@@ -99,6 +99,7 @@ export class NewTasksComponent implements OnInit {
 
   // Tables File Types
   protected readonly FileType = FileType;
+  protected readonly StaticChunkingMode = StaticChunkingMode;
 
   private formReady = false;
 
@@ -467,7 +468,7 @@ export class NewTasksComponent implements OnInit {
       hashlistId: null,
       skipKeyspace: 0,
       crackerBinaryId: 1,
-      staticChunks: 0,
+      staticChunks: StaticChunkingMode.NONE,
       chunkSize: environment.config.tasks.chunkSize,
       forcePipe: false,
       preprocessorId: 0,

--- a/src/app/tasks/new-tasks/new-tasks.form.ts
+++ b/src/app/tasks/new-tasks/new-tasks.form.ts
@@ -7,6 +7,7 @@ import { CrackerBinaryId, CrackerBinaryTypeId, FileId, HashlistId, PreprocessorI
 
 import { UIConfigService } from '@services/shared/storage.service';
 
+import { StaticChunkingMode } from '@src/app/core/_constants/tasks.config';
 import { attackCommandWithAliasValidator } from '@src/app/core/_validators/attack-command.validator';
 import { environment } from '@src/environments/environment';
 
@@ -71,7 +72,7 @@ export const getNewTaskForm = (uiService: UIConfigService) => {
     crackerBinaryId: new FormControl<number>(1, { nonNullable: true, validators: [Validators.required] }),
     crackerBinaryTypeId: new FormControl<number | null>(null, [Validators.required]),
     isArchived: new FormControl<boolean>(false, { nonNullable: true }),
-    staticChunks: new FormControl<number>(0, { nonNullable: true }),
+    staticChunks: new FormControl<number>(StaticChunkingMode.NONE, { nonNullable: true }),
     chunkSize: new FormControl<number>(chunkSize, { nonNullable: true }),
     forcePipe: new FormControl<boolean>(false, { nonNullable: true }),
     preprocessorId: new FormControl<number>(0, { nonNullable: true }),


### PR DESCRIPTION
Show text in task detail / edit task for static chunking

- `No`
- `Fixed chunksize: <num>`
- `Fixed number of chunks: <num>`

<img width="1549" height="736" alt="image" src="https://github.com/user-attachments/assets/ed5aa6c8-a853-4d55-9ef9-1a535af12016" />

<img width="1532" height="729" alt="image" src="https://github.com/user-attachments/assets/29e10190-4a75-4c5d-a030-9b29de3752ad" />

<img width="1533" height="730" alt="image" src="https://github.com/user-attachments/assets/e991abe4-f3a0-448d-975b-408bf11d1e30" />


Issue: https://github.com/hashtopolis/server/issues/2415