### PR TITLE
Invert boolean to mimick behaviour of old UI

### DIFF
--- a/src/app/hashlists/new-hashlist/new-hashlist.form.ts
+++ b/src/app/hashlists/new-hashlist/new-hashlist.form.ts
@@ -46,6 +46,6 @@ export const getNewHashlistForm = () => {
     sourceData: new FormControl<string>('', { nonNullable: true }),
     hashCount: new FormControl<number>(0, { nonNullable: true }),
     isArchived: new FormControl<boolean>(false, { nonNullable: true }),
-    isSecret: new FormControl<boolean>(true, { nonNullable: true })
+    isSecret: new FormControl<boolean>(false, { nonNullable: true })
   });
 };


### PR DESCRIPTION
In the old UI there was no checkbox to mark a hashlist secret. In the new UI there is a checkbox but it's on by default. This results in hashlist being secret by default if you don't notice the checkbox.. This PR turns it off by default so the form has the same behavior as the old UI.