### PR TITLE
2419 enhancement make supertask name editable

### DIFF
--- a/src/app/core/_components/tables/ht-table/ht-table.models.ts
+++ b/src/app/core/_components/tables/ht-table/ht-table.models.ts
@@ -75,6 +75,10 @@ export interface HTTableEditable<T> {
   tooltip?: string;
   // indeterminate if checkbox is half filled (instead of full check) so we know that only some and not all entries are checked
   indeterminate?: boolean;
+  // Optional display string - useful if text for displaying and value for editing differ, e.g. to show values with units
+  display?: string;
+  // Optional flag to hide value when not in editing mode - useful for only showing the edit icon
+  hidden?: boolean;
 }
 
 /** Column type for checkbox toggle events in attack file tables. */

--- a/src/app/core/_components/tables/ht-table/type/editable/editable-text/ht-table-type-editable.component.html
+++ b/src/app/core/_components/tables/ht-table/type/editable/editable-text/ht-table-type-editable.component.html
@@ -35,9 +35,11 @@
         </button>
       </mat-form-field>
     } @else {
-      <div class="editable-text">
-        <span [innerHtml]="editable.value"></span>
-      </div>
+      @if (!(editable.hidden ?? false)) {
+        <div class="editable-text">
+          <span [innerHtml]="editable.display ?? editable.value"></span>
+        </div>
+      }
       <mat-icon class="editable-pencil" aria-hidden="true">edit</mat-icon>
     }
   </div>

--- a/src/app/core/_components/tables/tasks-table/tasks-table.component.ts
+++ b/src/app/core/_components/tables/tasks-table/tasks-table.component.ts
@@ -156,6 +156,14 @@ export class TasksTableComponent extends BaseTableComponent implements OnInit, O
         dataKey: 'displayName',
         cssClass: 'cell-task-name',
         routerLink: (wrapper: JTaskWrapperDisplayOverview) => this.renderTaskWrapperLink(wrapper),
+        editable: (wrapper: JTaskWrapperDisplayOverview) => {
+          return {
+            data: wrapper,
+            value: wrapper.displayName ?? '',
+            hidden: true,
+            action: TaskTableEditableAction.CHANGE_NAME
+          };
+        },
         isSortable: true,
         isSearchable: true,
         export: async (wrapper: JTaskWrapperDisplayOverview) => wrapper.displayName ?? ''
@@ -551,6 +559,9 @@ export class TasksTableComponent extends BaseTableComponent implements OnInit, O
       case TaskTableEditableAction.CHANGE_MAX_AGENTS:
         this.changeMaxAgents(editable.data, editable.value);
         break;
+      case TaskTableEditableAction.CHANGE_NAME:
+        this.changeName(editable.data, editable.value);
+        break;
     }
   }
 
@@ -808,6 +819,43 @@ export class TasksTableComponent extends BaseTableComponent implements OnInit, O
       )
       .subscribe(() => {
         this.alertService.showSuccessMessage(`Changed number of max agents to ${val} on Task #${task.id}!`);
+        this.reload();
+      });
+  }
+
+  private changeName(wrapper: JTaskWrapperDisplayOverview, name: string): void {
+    const val = name;
+
+    let task: { id: number; name: string; attributeName: keyof JTaskWrapperDisplayOverview };
+    let serv: ServiceConfig;
+
+    if (wrapper.taskType === TaskType.TASK) {
+      task = { id: wrapper.taskId!, name: wrapper.taskName!, attributeName: 'taskName' };
+      serv = SERV.TASKS;
+    } else {
+      task = { id: wrapper.taskWrapperId!, name: wrapper.taskWrapperName!, attributeName: 'taskWrapperName' };
+      serv = SERV.TASKS_WRAPPER;
+    }
+
+    if (task.name == val) {
+      this.alertService.showInfoMessage('Nothing changed');
+      return;
+    }
+
+    const request$ = this.gs.update(serv, task.id, {
+      [task.attributeName]: val
+    });
+    request$
+      .pipe(
+        catchError((error) => {
+          this.alertService.showErrorMessage(`Failed to update task name!`);
+          console.error('Failed to update task name:', error);
+          return [];
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => {
+        this.alertService.showSuccessMessage(`Changed name to '${val}' on Task #${task.id}!`);
         this.reload();
       });
   }

--- a/src/app/core/_components/tables/tasks-table/tasks-table.constants.ts
+++ b/src/app/core/_components/tables/tasks-table/tasks-table.constants.ts
@@ -38,5 +38,6 @@ export const TaskTableColumnLabel = {
 
 export const TaskTableEditableAction = {
   CHANGE_PRIORITY: 'change-priority',
-  CHANGE_MAX_AGENTS: 'change-max-agents'
+  CHANGE_MAX_AGENTS: 'change-max-agents',
+  CHANGE_NAME: 'change-name'
 };

--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -251,7 +251,7 @@ table.hashtopolis-table {
 
       ht-table-editable {
         display: block;
-        flex: 1 1 auto;
+        flex: 0 1 auto;
         min-width: 0;
 
         // A column without an `editable` callback renders nothing here. Don't let

--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -273,7 +273,6 @@ table.hashtopolis-table {
       width: 100%;
       gap: var(--space-xs);
       min-height: 32px;
-      min-width: 96px;
 
       .mat-mdc-form-field {
         margin: 0;

--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -273,7 +273,7 @@ table.hashtopolis-table {
       width: 100%;
       gap: var(--space-xs);
       min-height: 32px;
-      min-width: 96px;
+      min-width: 32px;
 
       .mat-mdc-form-field {
         margin: 0;


### PR DESCRIPTION
Closes hashtopolis/server#2419

As part of this enhancement, first made changes to the `HTTableTypeEditableComponent` by introducing new fields that allow for a more flexible behaviour:

https://github.com/hashtopolis/web-ui/blob/3318098724e60d0333335fa8a36ba35e07e6678e/src/app/core/_components/tables/ht-table/ht-table.models.ts#L78-L81


Also, consider this PR a proposal, it's up for discussion if this is the best way to make the task name editable.

