### PR TITLE
Fix broken agent assignment, now use helper instead of CRUD method

### DIFF
--- a/src/app/agents/edit-agent/edit-agent.component.spec.ts
+++ b/src/app/agents/edit-agent/edit-agent.component.spec.ts
@@ -168,7 +168,8 @@ describe('EditAgentComponent', () => {
       'update',
       'create',
       'delete',
-      'ghelper'
+      'ghelper',
+      'chelper'
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
     agentRoleServiceSpy = jasmine.createSpyObj('AgentRoleService', ['hasRole']);
@@ -185,6 +186,7 @@ describe('EditAgentComponent', () => {
     globalServiceSpy.get.and.returnValue(of(mockResponse({ data: mockAgent })));
     globalServiceSpy.getAll.and.returnValue(of(mockResponse({ data: [mockUser] })));
     globalServiceSpy.ghelper.and.returnValue(of(mockResponse({ data: [] })));
+    globalServiceSpy.chelper.and.returnValue(of(mockResponse()));
     globalServiceSpy.update.and.returnValue(of(mockResponse()));
     globalServiceSpy.create.and.returnValue(of(mockResponse()));
 

--- a/src/app/agents/edit-agent/edit-agent.component.spec.ts
+++ b/src/app/agents/edit-agent/edit-agent.component.spec.ts
@@ -411,7 +411,7 @@ describe('EditAgentComponent', () => {
     component.onUpdateAssign(5);
     tick();
 
-    expect(globalServiceSpy.create).toHaveBeenCalledWith(SERV.AGENT_ASSIGN, {
+    expect(globalServiceSpy.chelper).toHaveBeenCalledWith(SERV.HELPER, 'assignAgent', {
       taskId: 5,
       agentId: 1
     });

--- a/src/app/agents/edit-agent/edit-agent.component.ts
+++ b/src/app/agents/edit-agent/edit-agent.component.ts
@@ -326,7 +326,7 @@ export class EditAgentComponent implements OnInit {
         taskId,
         agentId: this.editedAgentIndex
       };
-      request$ = this.gs.create(SERV.AGENT_ASSIGN, payload);
+      request$ = this.gs.chelper(SERV.HELPER, 'assignAgent', payload);
     } else if (this.assignId) {
       request$ = this.gs.delete(SERV.AGENT_ASSIGN, this.assignId);
     }

--- a/src/app/core/_services/main.config.ts
+++ b/src/app/core/_services/main.config.ts
@@ -23,6 +23,9 @@ export const HELPER_ENDPOINTS = [
   'getAccessGroups',
   'getGlobalConfig',
   // POST helpers (chelper)
+  'assignAgent',
+  'unassignAgent',
+  'searchHashes',
   'changeOwnPassword',
   'importFile',
   'importCrackedHashes',

--- a/src/app/tasks/edit-tasks/edit-tasks.component.ts
+++ b/src/app/tasks/edit-tasks/edit-tasks.component.ts
@@ -410,7 +410,7 @@ export class EditTasksComponent implements OnInit, OnDestroy {
         agentId: this.createForm.value['agentId']
       };
       this.gs
-        .create(SERV.AGENT_ASSIGN, payload)
+        .chelper(SERV.HELPER, 'assignAgent', payload)
         .pipe(
           finalize(() => {
             this.reloadAgentAssignment();


### PR DESCRIPTION
Fixes hashtopolis/server#2459

Changes to the backend made `benchmark` a required field, this is what broke this and caused the bug.

I made it so that assigning the agent now uses the helper instead of a plain CRUD method, which is better anyway because helpers can be stuffed with business/application logic which might apply when assigning agents.